### PR TITLE
Restore Menu-Option CSS in Dropdown

### DIFF
--- a/src/components/tag-list/index.js
+++ b/src/components/tag-list/index.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import Checkbox from '@quantumblack/kedro-ui/lib/components/checkbox';
 import Dropdown from '@quantumblack/kedro-ui/lib/components/dropdown';
+import '@quantumblack/kedro-ui/lib/components/menu-option/menu-option.css';
 import { toggleTagActive, toggleTagFilter } from '../../actions';
 import { getTags, getTagCount } from '../../selectors/tags';
 import './tag-list.css';


### PR DESCRIPTION


## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.

## Motivation and Context

The corresponding HTML was manually added, without using the component itself, which was fine when we were including all of the Kedro-UI CSS. But now that we're only including the bits we need, this implied bit of CSS needs to be manually included.

## How has this been tested?
Manual

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [x] Added new entries to the `RELEASE.md` file
- [x] Added tests to cover my changes
- [x] Assigned myself to the PR
- [x] Added `Type` label to the PR
