### PR TITLE
[KED-2870] Fix - Add sleep between two save datasets

### DIFF
--- a/package/tests/test_models/test_graph/test_graph_nodes.py
+++ b/package/tests/test_models/test_graph/test_graph_nodes.py
@@ -573,14 +573,15 @@ class TestGraphNodeMetadata:
             filepath.write_text(json.dumps(json_content[index]))
         return source_dir
 
-    def test_load_latest_metrics(self, tmp_path):
+    def test_load_latest_metrics(self):
         # Note - filepath is assigned temp.json as temp solution instead of metrics_filepath
         # as it fails on windows build. This will be cleaned up in the future.
-        filename = tmp_path / "temp.json"
-        dataset = MetricsDataSet(filepath=f"{filename}")
+        filename = "temp.json"
+        dataset = MetricsDataSet(filepath=filename)
         data = {"col1": 1, "col2": 0.23, "col3": 0.002}
         dataset.save(data)
         assert DataNodeMetadata.load_latest_metrics_data(dataset) == data
+        #to avoid datasets being saved concurrently 
         time.sleep(1)
         new_data = {"col1": 3, "col2": 3.23, "col3": 3.002}
         dataset.save(new_data)


### PR DESCRIPTION
## Description

PR sometimes fail due to a flaky test where two datasets are saved concurrently instead of in a sequence. To avoid it from failing we add a sleep(1) for 1 second so that it waits in between both saves

## Development notes

<!-- What have you changed? Consider adding a screenshot or GIF. -->

## QA notes

<!-- How has the expected behaviour changed? What testing strategies have you used? -->

## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [ ] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
