### PR TITLE
Remove git add from lint-staged tasks

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,16 +110,13 @@
   },
   "lint-staged": {
     "src/**/*.scss": [
-      "stylelint --fix",
-      "git add"
+      "stylelint --fix"
     ],
     "src/**/*.{js,jsx,ts,tsx,json,css,scss,md}": [
-      "prettier --single-quote --write",
-      "git add"
+      "prettier --single-quote --write"
     ],
     "src/**/*.{js,jsx,ts,tsx}": [
-      "eslint src/ --fix",
-      "git add"
+      "eslint src/ --fix"
     ]
   },
   "browserslist": [


### PR DESCRIPTION
## Description

<img width="892" alt="Screen Shot 2021-10-11 at 14 10 05" src="https://user-images.githubusercontent.com/16869061/136800333-26262337-fc28-459e-abcb-da48c13a4740.png">

I kept getting this warning each time I was committing. This PR fixes that.

Since v10, the `git add` step is [no longer needed](https://github.com/okonet/lint-staged#v10).

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [x] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
