### PR TITLE
Temporarily upper pin pip version in e2e tests

### DIFF
--- a/package/features/environment.py
+++ b/package/features/environment.py
@@ -96,7 +96,7 @@ def _setup_context_with_venv(context, venv_dir):
     context.env["PATH"] = path_sep.join(path)
     # Windows thinks the pip version check warning is a failure
     # so disable it here.
-    context.env["PIP_DISABLE_PIP_VERSION_CHECK"] = 1
+    context.env["PIP_DISABLE_PIP_VERSION_CHECK"] = "1"
 
     call(
         [


### PR DESCRIPTION
## Description

`pip` releases a version yesterday and looks like it's not compatible with the piptools version we have. Only affect e2e tests.

## Development notes

<!-- What have you changed? Consider adding a screenshot or GIF. -->

## QA notes

<!-- How has the expected behaviour changed? What testing strategies have you used? -->

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
