### PR TITLE
[KED-2841] Change syntax for session creation

### DIFF
--- a/package/kedro_viz/integrations/kedro/data_loader.py
+++ b/package/kedro_viz/integrations/kedro/data_loader.py
@@ -82,8 +82,8 @@ def load_data(
             project_path=project_path, env=env, save_on_close=False
         ) as session:
             context = session.load_context()
-            catalog, pipelines = context.catalog, dict(pipelines)
-        return catalog, pipelines
+            catalog, pipelines_dict = context.catalog, dict(pipelines)
+        return catalog, pipelines_dict
 
     if KEDRO_VERSION.match(">=0.17.1"):
         from kedro.framework.session import KedroSession


### PR DESCRIPTION
## Description

This PR makes changes to data_loader.py to update syntax and resolve the bug documented in KED-2841. 

## Development notes

- KedroSession is now created using `with` syntax in order to automatically activate the session
- Pipelines forced to fully load within active session

## QA notes

<!-- How has the expected behaviour changed? What testing strategies have you used? -->

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
