### PR TITLE
Make CircleCI fail on bad formatting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,11 +72,11 @@ commands:
           name: Run JavaScript tests
           command: npm run build:css && npm run test:ci
 
-  run_pylint_and_flake8:
+  run_python_format_and_lint:
     steps:
       - run:
-          name: Run pylint and flake8
-          command: make pylint
+          name: Run Python formatters and linters
+          command: make format-check lint-check
 
   run_secret_scan:
     steps:
@@ -188,7 +188,7 @@ commands:
       - test_lib_import
       - run_eslint
       - run_javascript_tests
-      - run_pylint_and_flake8
+      - run_python_format_and_lint
       - run_secret_scan
       - run_security_scan
       - run_python_tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -284,7 +284,7 @@ make pytest
 ```bash
 make e2e-tests
 ```
-#### Linting tests (`isort`, `pylint` and `flake8`)
+#### Linting tests (`isort`, `black`, `pylint`, `flake8` and `mypy`)
 
 ```bash
 make lint

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ pytest: build
 e2e-tests: build
 	cd package && behave
 
-lint: format-fix pylint-check
+lint: format-fix lint-check
 
 format-fix:
 	isort package/kedro_viz package/tests package/features

--- a/Makefile
+++ b/Makefile
@@ -23,9 +23,17 @@ pytest: build
 e2e-tests: build
 	cd package && behave
 
-pylint:
-	cd package && isort .
+lint: format-fix pylint-check
+
+format-fix:
+	isort package/kedro_viz package/tests package/features
 	black package/kedro_viz package/tests package/features
+
+format-check:
+	isort --check package/kedro_viz package/tests package/features
+	black --check package/kedro_viz package/tests package/features
+
+lint-check:
 	pylint --rcfile=package/.pylintrc -j 0 package/kedro_viz
 	pylint --rcfile=package/.pylintrc -j 0 --disable=protected-access,missing-docstring,redefined-outer-name,no-self-use,invalid-name,too-few-public-methods,no-member,unused-argument,duplicate-code package/tests
 	pylint --rcfile=package/.pylintrc -j 0 --disable=missing-docstring,no-name-in-module,unused-argument package/features

--- a/package/kedro_viz/data_access/managers.py
+++ b/package/kedro_viz/data_access/managers.py
@@ -1,5 +1,6 @@
 """`kedro_viz.data_access.managers` defines data access managers."""
 import logging
+
 # pylint: disable=too-many-instance-attributes
 from collections import defaultdict
 from typing import Dict, List, Set, Union

--- a/package/kedro_viz/data_access/managers.py
+++ b/package/kedro_viz/data_access/managers.py
@@ -1,7 +1,6 @@
 """`kedro_viz.data_access.managers` defines data access managers."""
-import logging
-
 # pylint: disable=too-many-instance-attributes
+import logging
 from collections import defaultdict
 from typing import Dict, List, Set, Union
 

--- a/package/tests/test_models/test_graph/test_graph_nodes.py
+++ b/package/tests/test_models/test_graph/test_graph_nodes.py
@@ -95,7 +95,6 @@ class TestGraphNodeCreation:
         assert task_node.pipelines == set()
         assert task_node.modular_pipelines == expected_modular_pipelines
 
-    
     def test_task_node_full_name_when_no_given_name(self):
         kedro_node = node(
             identity,
@@ -105,7 +104,6 @@ class TestGraphNodeCreation:
         )
         task_node = GraphNode.create_task_node(kedro_node)
         assert task_node.full_name == "identity"
-
 
     @pytest.mark.parametrize(
         "dataset_name,pretty_name,expected_modular_pipelines",


### PR DESCRIPTION
## Description

Currently the CI runs `black` and `isort` but won't actually fail if there's formatting errors. I've added the `--check` flag to both so that it will give non-zero exit code if the files aren't formatted correctly.

Locally you should still run `make lint` to fix and check files. I've done this, hence the small changes to whitespace.

## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes
