### PR TITLE
Update demo link throughout documentation

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -105,7 +105,7 @@ Redux reducers are placed in `/src/reducers/`. We use a [combineReducers](https:
 
 Selectors can be found in `/src/selectors/`. We use [Reselect](https://github.com/reduxjs/reselect) to derive data from the state and translate it into useful data structures while keeping it memoised in order to prevent repeated calculations when the original values have not changed. In order to avoid circular imports, we've occasionally needed to get creative with file naming, hence the low-level 'disabled' selectors are separated into different files from the rest of the node/edge/tag selectors.
 
-We have used Kedro-Viz to visualize the selector dependency graph - [visit the demo to see it in action](https://quantumblacklabs.github.io/kedro-viz/?data=selectors).
+We have used Kedro-Viz to visualize the selector dependency graph - [visit the demo to see it in action](https://demo.kedro.org/?data=selectors).
 
 ## Apollo
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -216,7 +216,7 @@ These are the supported dataset identifiers:
 
 By default in production, the app asynchronously loads JSON from the `/api/main` endpoint. You can replicate this in development by placing a JSON dataset in `/public/api/main`, using `main` as the name of the file, [without an extension](https://www.computerhope.com/issues/ch002089.htm). Note that operating systems often add hidden file extensions, so you might need to use a CLI to confirm the filename.
 
-Alternatively, you can synchronously load one of the mock datasets in `/src/utils/data`. The 'spaceflights' dataset is mainly used as mock data for unit testing, while the 'demo' dataset is used on the [public demo](https://quantumblacklabs.github.io/kedro-viz/).
+Alternatively, you can synchronously load one of the mock datasets in `/src/utils/data`. The 'spaceflights' dataset is mainly used as mock data for unit testing, while the 'demo' dataset is used on the [public demo](https://demo.kedro.org/).
 
 Finally, you can use pseudo-random data, which is procedurally-generated on page load, and is often useful for local development. Random data can be seeded with a hash string, which will allow you to replicate a generated layout. You can supply a seed with a `seed` query string in the URL, e.g. `http://localhost:4141/?data=random&seed=oM4xauN4Whyse`. If you do not supply a seed, the app will generate a new pseudo-random one every time, and will output it to the browser console in case you wish to reuse it.
 

--- a/LAYOUT_ENGINE.md
+++ b/LAYOUT_ENGINE.md
@@ -2,7 +2,7 @@
 
 On this page you'll find high-level details of how we have implemented the engine we use in [Kedro-Viz](https://github.com/quantumblacklabs/kedro-viz). We intend this to be useful as a reference for our project maintainers.  
 
-You can see and interact with the engine's graph drawings on the [Kedro-Viz demo](https://quantumblacklabs.github.io/kedro-viz/) or explore our [code](https://github.com/quantumblacklabs/kedro-viz/tree/main/src/utils/graph) to see how it works in practice, which we describe below in more detail.
+You can see and interact with the engine's graph drawings on the [Kedro-Viz demo](https://demo.kedro.org/) or explore our [code](https://github.com/quantumblacklabs/kedro-viz/tree/main/src/utils/graph) to see how it works in practice, which we describe below in more detail.
 
 <p align="center">
   <img width="450" alt="kedro-viz-drawing" src="https://user-images.githubusercontent.com/45365769/117349544-67d75680-aea3-11eb-8c72-d1b88f4b930c.png">

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 <p align="center">
 ✨ <em> Data Science Pipelines. Beautifully Designed</em> ✨
 <br />
-Live Demo: <a href="https://quantumblacklabs.github.io/kedro-viz/" target="_blank">https://quantumblacklabs.github.io/kedro-viz/</a>
+Live Demo: <a href="https://demo.kedro.org/" target="_blank">https://demo.kedro.org/</a>
 </p>
 
 <br />

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -225,7 +225,7 @@ We use [Jest](https://jestjs.io/), [Enzyme](https://enzymejs.github.io/enzyme/),
 
 Before you request a review on a PR, be sure to review it yourself [by comparing changes](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-comparing-branches-in-pull-requests) line by line. Make your amends with this style guide in mind.
 
-You should manually test your PR branch [across different browsers](#browser-and-device-support) and for [regressions](https://en.wikipedia.org/wiki/Regression_testing) against the behaviour of the [previous release](https://quantumblacklabs.github.io/kedro-viz/). Resolve problems where practical or otherwise note them in the PR text before you request a review.
+You should manually test your PR branch [across different browsers](#browser-and-device-support) and for [regressions](https://en.wikipedia.org/wiki/Regression_testing) against the behaviour of the [previous release](https://demo.kedro.org/). Resolve problems where practical or otherwise note them in the PR text before you request a review.
 
 As well as manual testing, we aim to include automated high-level [integration tests](https://en.wikipedia.org/wiki/Integration_testing) on a [user story](https://en.wikipedia.org/wiki/User_story) or feature and interface basis, such as [simulating UI interaction](https://testing-library.com/docs/ecosystem-user-event) and observing expected [UI outputs](https://github.com/testing-library/jest-dom#readme).
 


### PR DESCRIPTION
## Description

We still had a few https://quantumblacklabs.github.io/kedro-viz/ links hanging around, namely in the readme. This changes those to our new demo page: https://demo.kedro.org/.

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes
