### PR TITLE
[KED-3052] Add globalToolbarWidth to constants

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -10,11 +10,10 @@ Please follow the established format:
 
 ## Bug fixes and other changes
 
-
 - Bug fix to display the original function names when pretty name is turned off. (#686)
 - Fix the order of the runs list in experiment tracking. (#691)
-- Bug fix for plotly JSONDataSet icon (#684)
-
+- Bug fix for Plotly JSONDataSet icon. (#684)
+- Bug fix for when some flowchart nodes were being cut off by the sidebar. (#701)
 
 # Release 4.2.0
 
@@ -26,16 +25,17 @@ Please follow the established format:
 
 ## Bug fixes and other changes
 
-- Bug fix for plotly modal when escape button is pressed. (#654)
+- Bug fix for Plotly modal when escape button is pressed. (#654)
 - Display Plotly JSONDataSet plot in metadata side-panel. (#660)
 - Refactor Primary Toolbar setup. (#664)
-- Upgrade @apollo/client from 3.4.16 to 3.5.3. (#661, #668) 
+- Upgrade @apollo/client from 3.4.16 to 3.5.3. (#661, #668)
 
 # Release 4.1.1
+
 ## Bug fixes and other changes
 
 - Fix display of boolean values on tracking dataset (#652)
-- Fix node IDs in test data after Kedro updates its _str_logic for node (#653)
+- Fix node IDs in test data after Kedro updates its \_str_logic for node (#653)
 
 # Release 4.1.0
 
@@ -83,7 +83,7 @@ Please follow the established format:
 
 ## Bug fixes and other changes
 
-- Relax pandas and plotly versions.
+- Relax pandas and Plotly versions.
 
 # Release 3.17.0
 
@@ -184,7 +184,7 @@ Please follow the established format:
 - Complete backend rewrite to be more modular and maintainable using FastAPI. (#432)
 - Add layout engine documentation. (#436)
 - Add split panel components and implement into the sidebar. (#448)
-- Visualise plotly charts if user defines them with `kedro.extra.datasets.plotly.PlotlyDataSet` in their Kedro project _(Note: This feature is only available in `kedro>=0.17.4`)._ (#455)
+- Visualise Plotly charts if user defines them with `kedro.extra.datasets.plotly.PlotlyDataSet` in their Kedro project _(Note: This feature is only available in `kedro>=0.17.4`)._ (#455)
 
 ## Bug fixes and other changes
 

--- a/src/components/flowchart/draw.js
+++ b/src/components/flowchart/draw.js
@@ -59,7 +59,6 @@ export const drawLayerNames = function () {
     layers,
   } = this.props;
 
-  console.log('sidebarWidth: ', sidebarWidth);
   this.el.layerNameGroup
     .transition('layer-names-sidebar-width')
     .duration(this.DURATION)

--- a/src/components/flowchart/draw.js
+++ b/src/components/flowchart/draw.js
@@ -3,7 +3,6 @@ import { interpolatePath } from 'd3-interpolate-path';
 import { select } from 'd3-selection';
 import { curveBasis, line } from 'd3-shape';
 import { paths as nodeIcons } from '../icons/node-icon';
-import { globalToolbarWidth } from '../../config';
 
 const lineShape = line()
   .x((d) => d.x)
@@ -60,10 +59,11 @@ export const drawLayerNames = function () {
     layers,
   } = this.props;
 
+  console.log('sidebarWidth: ', sidebarWidth);
   this.el.layerNameGroup
     .transition('layer-names-sidebar-width')
     .duration(this.DURATION)
-    .style('transform', `translateX(${sidebarWidth + globalToolbarWidth}px)`);
+    .style('transform', `translateX(${sidebarWidth}px)`);
 
   this.el.layerNames = this.el.layerNameGroup
     .selectAll('.pipeline-layer-name')

--- a/src/components/tooltip/tooltip.test.js
+++ b/src/components/tooltip/tooltip.test.js
@@ -1,6 +1,6 @@
 import Tooltip, { insertZeroWidthSpace } from './tooltip';
 import { setup } from '../../utils/state.mock';
-import { sidebarWidth } from '../../config';
+import { globalToolbarWidth, sidebarWidth } from '../../config';
 
 const mockProps = {
   chartSize: {
@@ -66,7 +66,7 @@ describe('Tooltip', () => {
   it("should add the 'right' class when the tooltip is towards the right", () => {
     const targetRect = {
       ...mockProps.targetRect,
-      left: mockProps.chartSize.width - 10,
+      left: mockProps.chartSize.width - 10 + globalToolbarWidth,
     };
     const wrapper = setup.shallow(Tooltip, { ...mockProps, targetRect });
     const container = wrapper.find('.pipeline-tooltip--right');

--- a/src/config.js
+++ b/src/config.js
@@ -5,21 +5,23 @@ export const localStorageName = 'KedroViz';
 // These values are used in both SCSS and JS, and we don't have variable-sharing
 // across Sass and JavaScript, so they're defined in two places. If you update their
 // value here, please also update their corresponding value in src/styles/_variables.scss
+export const globalToolbarWidth = 80;
+
 export const metaSidebarWidth = {
   open: 400,
   closed: 0,
 };
+
 export const sidebarWidth = {
-  open: 400,
-  closed: 56,
+  open: 400 + globalToolbarWidth,
+  closed: 56 + globalToolbarWidth,
   breakpoint: 700,
 };
+
 export const codeSidebarWidth = {
   open: 480,
   closed: 0,
 };
-
-export const globalToolbarWidth = 80;
 
 export const chartMinWidthScale = 0.25;
 


### PR DESCRIPTION
## Description

Fixes [KED-3052](https://jira.quantumblack.com/browse/KED-3052).

## Development notes

I've added on the `globalToolbarWidth` const to the necessary widths and removed it from a place where it wasn't needed.

I also capitalize the use of `Plotly` in the release-notes file and formatted it.

## QA notes

Look at our default data set and expand the `Reporting` pipeline. Before this changed one part of the flowchart looked like this:

![image](https://user-images.githubusercontent.com/16869061/149807617-5da1eeef-56e7-4227-b173-0b91ac5e638a.png)

And now we have:

![image](https://user-images.githubusercontent.com/16869061/149807675-1f3ab691-3a47-4d33-89b7-8e3bfa4d23fb.png)


## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [x] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes
