### PR TITLE
Fix: add active state to page route links

### DIFF
--- a/src/components/global-toolbar/global-toolbar.js
+++ b/src/components/global-toolbar/global-toolbar.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import { Link } from 'react-router-dom';
+import { NavLink } from 'react-router-dom';
 import { toggleSettingsModal, toggleTheme } from '../../actions';
 import ExperimentsIcon from '../icons/experiments';
 import IconButton from '../icon-button';
@@ -32,7 +32,7 @@ export const GlobalToolbar = ({
             disabled={false}
             icon={LogoIcon}
           />
-          <Link to={{ pathname: '/' }}>
+          <NavLink exact to={{ pathname: '/' }}>
             <IconButton
               ariaLabel={'View your pipeline'}
               className={
@@ -41,8 +41,8 @@ export const GlobalToolbar = ({
               disabled={false}
               icon={TreeIcon}
             />
-          </Link>
-          <Link to={{ pathname: '/runsList' }}>
+          </NavLink>
+          <NavLink exact to={{ pathname: '/runsList' }}>
             <IconButton
               ariaLabel={'View your experiments'}
               className={
@@ -51,7 +51,7 @@ export const GlobalToolbar = ({
               disabled={false}
               icon={ExperimentsIcon}
             />
-          </Link>
+          </NavLink>
         </ul>
         <ul className="pipeline-global-control-toolbar kedro">
           <IconButton

--- a/src/components/global-toolbar/global-toolbar.scss
+++ b/src/components/global-toolbar/global-toolbar.scss
@@ -43,3 +43,11 @@
     width: 2.9em;
   }
 }
+
+.pipeline-global-routes-toolbar a.active .pipeline-menu-button--link {
+  background-color: var(--color-bg-2);
+}
+
+.pipeline-global-routes-toolbar a.active .pipeline-menu-button--link svg {
+  opacity: 1;
+}


### PR DESCRIPTION
## Description

Our global toolbar page links should have an active state. Currently, they don't. This fixes that.

## QA notes

Checkout the branch to see the change or look at the screenshots below.

Before: 
<img width="654" alt="Screen Shot 2022-01-24 at 13 35 14" src="https://user-images.githubusercontent.com/16869061/150792578-9c47adab-94f1-4102-83ff-573b73f5338b.png">

After:
<img width="652" alt="Screen Shot 2022-01-24 at 13 34 55" src="https://user-images.githubusercontent.com/16869061/150792597-0fffa05e-66a4-4cc7-b1c6-dc6c7283bcd5.png">


## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes
