### PR TITLE
Document how to use demo project in `make run`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,7 +107,7 @@ Alternatively, if you know the JIRA ticket number of the issue that you are fixi
 
 ### JavaScript development
 
-_*Note*: We use the [latest release of v14 Node.js](https://nodejs.org/download/release/latest-v14.x/) in our development environment._
+_*Note*: We suggest using the [latest release of Node.js v14](https://nodejs.org/download/release/latest-v14.x/) in your development environment._
 
 First clone this repo, then download and install dependencies:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -186,13 +186,13 @@ make run PROJECT_PATH=<path-to-your-test-project>/new-kedro-project
 
 #### Launch the development server with the `SQLiteSessionStore`
 
-Kedro-Viz provides a `SQLiteSessionStore` that users can use in their project to enable experiment tracking functionality. If you want to use this session store with the development server, make sure you don't use a relative path when specifying the store's location. For example, to specify the local `data` directory within a project as the session store's location, configure the project's `settings.py` as follows:
+Kedro-Viz provides a `SQLiteSessionStore` that users can use in their project to enable experiment tracking functionality. If you want to use this session store with the development server, make sure you don't use a relative path when specifying the store's location in `settings.py`. For example, `demo-project` specifies the local `data` directory within a project as the session store's location as follows: 
 ```python
 from kedro_viz.integrations.kedro.sqlite_store import SQLiteStore
 SESSION_STORE_ARGS = {"path": str(Path(__file__).parents[2] / "data")}
 ```
 
-`demo-project` includes a `settings.py` file that includes this option. Owing to this coupling between the project settings and Kedro-Viz, if you wish to execute any Kedro commands on `demo-project` (including `kedro run`), you will need to install the Kedro-Viz Python package. To make sure that you are installing the one that you are developing against, run:
+Owing to this coupling between the project settings and Kedro-Viz, if you wish to execute any Kedro commands on `demo-project` (including `kedro run`), you will need to install the Kedro-Viz Python package. To install your local development version of the package, run:
 
 ```bash
 pip3 install -e package

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -189,15 +189,15 @@ As far as the development server for the backend is concerned, you only need to 
 make run
 ```
 
-This command will launch a Kedro-Viz server at [localhost:4142](http://localhost:4142) and serve data from `demo-project`. From then on, launching the app locally at [localhost:4141](http://localhost:4141) will pull data from the Kedro-Viz server that is running on port 4142.
+This command will launch a Kedro-Viz backend server at [localhost:4142](http://localhost:4142) and serve data from `demo-project`. If you wish to also launch the frontend app then execute `npm start` in a separate terminal window. [localhost:4141](http://localhost:4141) will then pull data from the backend Kedro-Viz server that is running on port 4142.
 
-If you wish to point the server to a different Kedro project then you can do so by altering the `PROJECT_PATH` variable:
+If you wish to point the backend server to a different Kedro project then you can do so by altering the `PROJECT_PATH` variable:
 
 ```bash
 make run PROJECT_PATH=<path-to-your-test-project>/new-kedro-project
 ```
 
-> **Note**: Once the development server is launched at port 4142, the local app will always pull data from that server. To prevent this, you can comment out the proxy setting in `package.json` and restart the dev server at port 4141.
+> **Note**: Once the backend development server is launched at port 4142, the local app will always pull data from that server. To prevent this, you can comment out the proxy setting in `package.json` and restart the dev server at port 4141.
 
 #### Launch the development server with the `SQLiteSessionStore`
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,7 +107,7 @@ Alternatively, if you know the JIRA ticket number of the issue that you are fixi
 
 ### JavaScript development
 
-_*Note*: We use `node==14` in our development environment._
+_*Note*: We use the [latest release of v14 Node.js](https://nodejs.org/download/release/latest-v14.x/) in our development environment._
 
 First clone this repo, then download and install dependencies:
 
@@ -127,13 +127,36 @@ This will serve the app at [localhost:4141](http://localhost:4141/), and watch f
 npm run lib
 ```
 
+### Data sources
+
+Kedro-Viz uses a unique identifier to determine the data source from one of several available sources. You can configure this by appending a query string to the URL, e.g. `http://localhost:4141/?data=random`. Alternatively, you can set it with an environment variable when starting up the dev server:
+
+```bash
+DATA=random npm start
+```
+
+These are the supported dataset identifiers:
+
+| Identifier | Data source |
+|------------|-------------|
+| `json` (default) | `/public/api/main` |
+| `random` | Randomly-generated data |
+| `demo` | `/src/utils/data/demo.mock.js` |
+| `spaceflights` | `/src/utils/data/spaceflights.mock.json` |
+
+By default in production, the app asynchronously loads JSON from the `/api/main` endpoint. You can replicate this in development by placing a JSON dataset in `/public/api/main`, using `main` as the name of the file, [without an extension](https://www.computerhope.com/issues/ch002089.htm). Note that operating systems often add hidden file extensions, so you might need to use a CLI to confirm the filename.
+
+Alternatively, you can synchronously load one of the mock datasets in `/src/utils/data`. The 'spaceflights' dataset is mainly used as mock data for unit testing.
+
+Finally, you can use pseudo-random data, which is procedurally-generated on page load, and is often useful for local development. Random data can be seeded with a hash string, which will allow you to replicate a generated layout. You can supply a seed with a `seed` query string in the URL, e.g. `http://localhost:4141/?data=random&seed=oM4xauN4Whyse`. If you do not supply a seed, the app will generate a new pseudo-random one every time, and will output it to the browser console in case you wish to reuse it.
+
 ### Launch a development server with a real Kedro project
 
 > **Note**: Kedro-Viz>=3.8.0 will not work with projects created with Kedro<=0.16.6. Please consider migrating your project to Kedro>=0.17.0 before you develop against the latest version of Kedro-Viz. 
 
 Before launching a development server with a real Kedro project, you'd need to have [Python](https://www.python.org/)(>=3.7, <3.9) installed. We strongly recommend setting up [conda](https://docs.conda.io/en/latest/) to manage your Python versions and virtual environments. You can visit Kedro's [guide to installing conda](https://kedro.readthedocs.io/en/latest/02_get_started/01_prerequisites.html#conda) for more information.
 
-The Kedro-Viz repository comes with an example project in the `demo-project` folder. To use this you need to install both the Kedro-Viz dependencies and a minimal set of dependencies  for the demo project:
+The Kedro-Viz repository comes with an example project in the `demo-project` folder. This is used on the [public demo](https://demo.kedro.org/). To use it in your development environment, you need to install both the Kedro-Viz dependencies and a minimal set of dependencies  for the demo project:
 ```bash
 pip3 install -r package/test_requirements.txt
 pip3 install -r demo-project/src/docker_requirements.txt
@@ -174,29 +197,6 @@ SESSION_STORE_ARGS = {"path": str(Path(__file__).parents[2] / "data")}
 ```bash
 pip3 install -e package
 ```
-
-### Data sources
-
-Kedro-Viz uses a unique identifier to determine the data source from one of several available sources. You can configure this by appending a query string to the URL, e.g. `http://localhost:4141/?data=random`. Alternatively, you can set it with an environment variable when starting up the dev server:
-
-```bash
-DATA=random npm start
-```
-
-These are the supported dataset identifiers:
-
-| Identifier | Data source |
-|------------|-------------|
-| `json` (default) | `/public/api/main` |
-| `random` | Randomly-generated data |
-| `demo` | `/src/utils/data/demo.mock.js` |
-| `spaceflights` | `/src/utils/data/spaceflights.mock.json` |
-
-By default in production, the app asynchronously loads JSON from the `/api/main` endpoint. You can replicate this in development by placing a JSON dataset in `/public/api/main`, using `main` as the name of the file, [without an extension](https://www.computerhope.com/issues/ch002089.htm). Note that operating systems often add hidden file extensions, so you might need to use a CLI to confirm the filename.
-
-Alternatively, you can synchronously load one of the mock datasets in `/src/utils/data`. The 'spaceflights' dataset is mainly used as mock data for unit testing, while the 'demo' dataset is used on the [public demo](https://demo.kedro.org/).
-
-Finally, you can use pseudo-random data, which is procedurally-generated on page load, and is often useful for local development. Random data can be seeded with a hash string, which will allow you to replicate a generated layout. You can supply a seed with a `seed` query string in the URL, e.g. `http://localhost:4141/?data=random&seed=oM4xauN4Whyse`. If you do not supply a seed, the app will generate a new pseudo-random one every time, and will output it to the browser console in case you wish to reuse it.
 
 ## Testing guidelines
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,7 +148,7 @@ By default in production, the app asynchronously loads JSON from the `/api/main`
 
 Alternatively, you can synchronously load one of the mock datasets in `/src/utils/data`. The 'spaceflights' dataset is mainly used as mock data for unit testing.
 
-Finally, you can use pseudo-random data, which is procedurally-generated on page load, and is often useful for local development. Random data can be seeded with a hash string, which will allow you to replicate a generated layout. You can supply a seed with a `seed` query string in the URL, e.g. `http://localhost:4141/?data=random&seed=oM4xauN4Whyse`. If you do not supply a seed, the app will generate a new pseudo-random one every time, and will output it to the browser console in case you wish to reuse it.
+Finally, you can use pseudo-random data, which is procedurally-generated on page load, and is often useful for local development. Random data can be seeded with a hash string, which will allow you to replicate a generated layout. You can supply a seed with a `seed` query string in the URL, e.g. `http://localhost:4141/?data=random&seed=oM4xauN4Whyse`. If you do not supply a seed query to the URL, the app will generate a new pseudo-random seed on every browser refresh, and will output it to the browser console in case you wish to reuse it.
 
 ### Launch a development server with a real Kedro project
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -131,70 +131,48 @@ npm run lib
 
 > **Note**: Kedro-Viz>=3.8.0 will not work with projects created with Kedro<=0.16.6. Please consider migrating your project to Kedro>=0.17.0 before you develop against the latest version of Kedro-Viz. 
 
-Before launching a development server with a real Kedro project, you'd need to have [Python](https://www.python.org/)(>=3.7, <3.9) and Kedro installed. We strongly recommend setting up [conda](https://docs.conda.io/en/latest/) to manage your Python versions and virtual environments. You can visit Kedro's guide for installing [conda](https://kedro.readthedocs.io/en/latest/02_get_started/01_prerequisites.html#conda) and [how to get started with Kedro](https://kedro.readthedocs.io/en/latest/02_get_started/02_install.html) for more information.
+Before launching a development server with a real Kedro project, you'd need to have [Python](https://www.python.org/)(>=3.7, <3.9) installed. We strongly recommend setting up [conda](https://docs.conda.io/en/latest/) to manage your Python versions and virtual environments. You can visit Kedro's [guide to installing conda](https://kedro.readthedocs.io/en/latest/02_get_started/01_prerequisites.html#conda) for more information.
 
-After setting up Python and Kedro, you will need to have a Kedro project setup. If you don't have any existing Kedro project, you can create a new one with the `spaceflights` example:
-
-> **Note**: You can use any other [starters](https://github.com/kedro-org/kedro-starters), except `mini-kedro`, for the purpose of this development server, not just `spaceflights`.
-
-```bash
-cd $HOME # or wherever you prefer to keep your test project
-kedro new --starter=spaceflights
-```
-
-You can use default values when creating the project, which will create a new project called `new-kedro-project`. Changing your directory into that project and install the project's dependencies:
-
-```bash
-cd new-kedro-project
-kedro install
-```
-
-After installing the project's dependencies, make sure you can run it with:
-
-```bash
-kedro run
-```
-
-Now you are ready to launch a new viz's development server with a real Kedro project. First, changing your directory back to kedro-viz:
-
-```bash
-cd /path/to/kedro-viz
-```
-
-Install kedro-viz's development dependencies with:
-
+The Kedro-Viz repository comes with an example project in the `demo-project` folder. To use this you need to install both the Kedro-Viz dependencies and a minimal set of dependencies  for the demo project:
 ```bash
 pip3 install -r package/test_requirements.txt
+pip3 install -r demo-project/src/docker_requirements.txt
 ```
 
-Build the application with:
+Now build the application with:
 
 ```bash
 make build
 ```
 
-As far as the development server for the backend is concerned, you only need to run `make build` once when you first setup the project.
+As far as the development server for the backend is concerned, you only need to run `make build` once when you first setup the project. You can then launch the server with:
 
-Then launch the server with:
+```bash
+make run
+```
+
+This command will launch a Kedro-Viz server at [localhost:4142](http://localhost:4142) and serve data from `demo-project`. From then on, launching the app locally at [localhost:4141](http://localhost:4141) will pull data from the Kedro-Viz server that is running on port 4142.
+
+If you wish to point the server to a different Kedro project then you can do so by altering the `PROJECT_PATH` variable:
 
 ```bash
 make run PROJECT_PATH=<path-to-your-test-project>/new-kedro-project
-```
-This command will launch a Kedro-Viz server at [localhost:4142](http://localhost:4142) and serve data from a real Kedro pipeline located at the project path supplied to the command. From then on, launching the app locally at [localhost:4141](http://localhost:4141) will pull data from the Kedro-Viz server that is running on port 4142. To avoid needing to supply `PROJECT_PATH` every time you call `make run`, you can set it as an environment variable:
-
-```bash
-export PROJECT_PATH=<path-to-your-test-project>/new-kedro-project 
-make run
 ```
 
 > **Note**: Once the development server is launched at port 4142, the local app will always pull data from that server. To prevent this, you can comment out the proxy setting in `package.json` and restart the dev server at port 4141.
 
 #### Launch the development server with the `SQLiteSessionStore`
 
-Kedro-Viz provides a `SQLiteSessionStore` that users can use in their project to enable experiment tracking functionality. If you want to use this session store with the development server, make sure you don't use a relative path when specifying the store's location. For example, to specify the local `data` directory within a project as the session store's location, configure the project's `settings.py` as follow:
+Kedro-Viz provides a `SQLiteSessionStore` that users can use in their project to enable experiment tracking functionality. If you want to use this session store with the development server, make sure you don't use a relative path when specifying the store's location. For example, to specify the local `data` directory within a project as the session store's location, configure the project's `settings.py` as follows:
 ```python
 from kedro_viz.integrations.kedro.sqlite_store import SQLiteStore
 SESSION_STORE_ARGS = {"path": str(Path(__file__).parents[2] / "data")}
+```
+
+`demo-project` includes a `settings.py` file that includes this option. Owing to this coupling between the project settings and Kedro-Viz, if you wish to execute any Kedro commands on `demo-project` (including `kedro run`), you will need to install the Kedro-Viz Python package. To make sure that you are installing the one that you are developing against, run:
+
+```bash
+pip3 install -e package
 ```
 
 ### Data sources

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,8 @@ clean:
 	find . -regex ".*/__pycache__" -exec rm -rf {} +
 	find . -regex ".*\.egg-info" -exec rm -rf {} +
 
+PROJECT_PATH ?= demo-project
+
 run:
 	PYTHONPATH=$(shell pwd)/package python3 package/kedro_viz/server.py $(PROJECT_PATH)
 

--- a/demo-project/.telemetry
+++ b/demo-project/.telemetry
@@ -1,1 +1,1 @@
-consent: true
+consent: false

--- a/package/kedro_viz/server.py
+++ b/package/kedro_viz/server.py
@@ -52,7 +52,7 @@ def run_server(
     env: str = None,
     project_path: str = None,
     autoreload: bool = False,
-):
+):  # pylint: disable=redefined-outer-name
     """Run a uvicorn server with a FastAPI app that either launches API response data from a file
     or from reading data from a real Kedro project.
 

--- a/package/kedro_viz/server.py
+++ b/package/kedro_viz/server.py
@@ -116,6 +116,6 @@ if __name__ == "__main__":  # pragma: no cover
         kwargs={
             "host": args.host,
             "port": args.port,
-            "project_path": project_path,
+            "project_path": str(project_path),
         },
     )

--- a/package/kedro_viz/server.py
+++ b/package/kedro_viz/server.py
@@ -108,13 +108,14 @@ if __name__ == "__main__":  # pragma: no cover
     )
     args = parser.parse_args()
 
-    source_dir = bootstrap_project(args.project_path)
+    project_path = (Path.cwd() / args.project_path).absolute()
+    bootstrap_project(project_path)
     run_process(
-        args.project_path,
+        project_path,
         run_server,
         kwargs={
             "host": args.host,
             "port": args.port,
-            "project_path": args.project_path,
+            "project_path": project_path,
         },
     )


### PR DESCRIPTION
## Description

Following https://github.com/kedro-org/kedro-viz/pull/688, which created the `make run` command to make it easier to start the dev server, and https://github.com/kedro-org/kedro-viz/pull/696, which added demo-project to the repo, I've now linked the two together so that `make run` points to demo-project with no other fiddling needed 🎉 

Now the process of developing something on the backend just goes as follows:
```
npm start
make build
make run
```

This will start a dev server pointing to demo-project with full access to the project pipeline, experiment tracking data, etc. No need to faff around setting a `PROJECT_PATH` any more.

I've updated CONRIBUTING with instructions on the above and also to explain the use of demo project better.

## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes
