### PR TITLE
Fix `make sign-off` so it works with husky

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,6 @@ install-pip-setuptools:
 	python -m pip install -U "pip>=18.0, <19.0" "setuptools>=38.0, <39.0" wheel
 
 sign-off:
-	echo "git interpret-trailers --if-exists doNothing \c" >> .git/hooks/commit-msg
+	echo "git interpret-trailers --if-exists doNothing \c" > .git/hooks/commit-msg
 	echo '--trailer "Signed-off-by: $$(git config user.name) <$$(git config user.email)>" \c' >> .git/hooks/commit-msg
 	echo '--in-place "$$1"' >> .git/hooks/commit-msg


### PR DESCRIPTION
## Description

A one character diff PR 🎉 

Tynan found that `make sign-off` wasn't working. It turns out this is due to a conflict with husky, which also creates a `commit-msg` hook. After spending a while figuring out whether these could coexist happily, I decided they couldn't. So `make sign-off` will now overwrite the `commit-msg` hook rather than append to it.

This isn't a problem because we don't actually have any husky `commit-msg` hooks, just the boilerplate code to run them. It also doesn't affect `pre-commit/push` hooks at all. If in future we do want husky commit-msg hooks then we should first consider upgrading husky since it looks like in newer versions it might be easier to make husky hooks compatible with others.

N.B. if you `npm install husky` after `make sign-off`, husky won't overwrite the sign off commit message hook. So no need to worry about that. The sign-off hook always wins out.

## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes
