### PR TITLE
[KED-3071] Bump minimum Pillow version

### DIFF
--- a/demo-project/src/demo_project/requirements.in
+++ b/demo-project/src/demo_project/requirements.in
@@ -14,6 +14,6 @@ pytest~=6.2
 scikit-learn~=0.24
 wheel>=0.35, <0.37
 openpyxl==3.0.9
-pillow==8.3.2
+pillow~=9.0
 matplotlib==3.5.0
 pre-commit~=1.17

--- a/demo-project/src/docker_requirements.txt
+++ b/demo-project/src/docker_requirements.txt
@@ -1,5 +1,5 @@
 kedro[pandas.CSVDataSet,pandas.ExcelDataSet, pandas.ParquetDataSet, plotly.PlotlyDataSet]==0.17.6
 scikit-learn~=0.24
 openpyxl==3.0.9
-pillow==8.3.2
+pillow~=9.0
 matplotlib==3.5.0


### PR DESCRIPTION
## Description

As per https://github.com/kedro-org/kedro/pull/1200: following [CVE-2022-22817](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-22817), I've bumped the Pillow version. 

No need for a Python-version dependent specification here since the demo uses Python 3.8.

## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes
