### PR TITLE
[KED-3060] Create viz version graphql endpoint

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -10,6 +10,7 @@ Please follow the established format:
 ## Bug fixes and other changes
 - Migrate Kedro-UI buttons to Kedro-viz as Kedro-UI is now deprecated. (#716)
 - Add a Husky pre-push hook. (#723)
+- Create a `version` GraphQL query to get versions of Kedro-Viz. (#727)
 
 # Release 4.3.1
 

--- a/package/kedro_viz/api/graphql.py
+++ b/package/kedro_viz/api/graphql.py
@@ -19,7 +19,6 @@ from typing import (
     cast,
 )
 
-import requests
 import strawberry
 from fastapi import APIRouter
 from strawberry import ID
@@ -27,6 +26,7 @@ from strawberry.asgi import GraphQL
 
 from kedro_viz import __version__
 from kedro_viz.data_access import data_access_manager
+from kedro_viz.integrations.pypi import get_latest_version
 from kedro_viz.models.experiments_tracking import RunModel, UserRunDetailsModel
 
 logger = logging.getLogger(__name__)
@@ -126,10 +126,7 @@ def get_version() -> Version:
     Returns:
         the currently installed and most-recent released version of Viz.
     """
-    package = "kedro-viz"
-    response = requests.get(f"https://pypi.org/pypi/{package}/json")
-    latest_version = response.json()["info"]["version"]
-
+    latest_version = get_latest_version()
     version = Version(current=__version__, latest=latest_version)
     return version
 
@@ -328,10 +325,7 @@ class Query:
         """Query to get data for specific runs from the session store"""
         return get_run_tracking_data(run_ids, show_diff)
 
-    @strawberry.field
-    def version(self) -> Version:
-        """Query to get current and latest Kedro Viz versions"""
-        return get_version()
+    version: Version = strawberry.field(resolver=get_version)
 
     runs_list: List[Run] = strawberry.field(resolver=get_all_runs)
 

--- a/package/kedro_viz/api/graphql.py
+++ b/package/kedro_viz/api/graphql.py
@@ -21,12 +21,13 @@ from typing import (
 
 import strawberry
 from fastapi import APIRouter
+from semver import VersionInfo
 from strawberry import ID
 from strawberry.asgi import GraphQL
 
 from kedro_viz import __version__
 from kedro_viz.data_access import data_access_manager
-from kedro_viz.integrations.pypi import get_latest_version
+from kedro_viz.integrations.pypi import get_latest_version, is_running_outdated_version
 from kedro_viz.models.experiments_tracking import RunModel, UserRunDetailsModel
 
 logger = logging.getLogger(__name__)
@@ -126,9 +127,13 @@ def get_version() -> Version:
     Returns:
         the currently installed and most-recent released version of Viz.
     """
+    installed_version = VersionInfo.parse(__version__)
     latest_version = get_latest_version()
-    version = Version(installed=__version__, latest=latest_version)
-    return version
+    return Version(
+        installed=installed_version,
+        isOutdated=is_running_outdated_version(installed_version, latest_version),
+        latest=latest_version or "",
+    )
 
 
 def get_all_runs() -> List[Run]:
@@ -284,6 +289,7 @@ class Version:
     """The installed and latest Kedro Viz versions."""
 
     installed: str
+    isOutdated: bool
     latest: str
 
 

--- a/package/kedro_viz/api/graphql.py
+++ b/package/kedro_viz/api/graphql.py
@@ -18,8 +18,8 @@ from typing import (
     Optional,
     cast,
 )
-import requests
 
+import requests
 import strawberry
 from fastapi import APIRouter
 from strawberry import ID
@@ -121,19 +121,16 @@ def get_runs(run_ids: List[ID]) -> List[Run]:
     )
 
 
-def get_version():
+def get_version() -> Version:
     """Get the user's installed Viz version and the latest version on PyPI.
     Returns:
         the currently installed and most-recent released version of Viz.
     """
-    package = 'kedro-viz'
-    response = requests.get(f'https://pypi.org/pypi/{package}/json')
-    latest_version = response.json()['info']['version']
+    package = "kedro-viz"
+    response = requests.get(f"https://pypi.org/pypi/{package}/json")
+    latest_version = response.json()["info"]["version"]
 
-    version = Version(
-        current=__version__,
-        latest=latest_version
-    )
+    version = Version(current=__version__, latest=latest_version)
     return version
 
 

--- a/package/kedro_viz/api/graphql.py
+++ b/package/kedro_viz/api/graphql.py
@@ -127,7 +127,7 @@ def get_version() -> Version:
         the currently installed and most-recent released version of Viz.
     """
     latest_version = get_latest_version()
-    version = Version(current=__version__, latest=latest_version)
+    version = Version(installed=__version__, latest=latest_version)
     return version
 
 
@@ -281,9 +281,9 @@ class TrackingDataset:
 
 @strawberry.type
 class Version:
-    """The latest and current Kedro Viz versions."""
+    """The installed and latest Kedro Viz versions."""
 
-    current: str
+    installed: str
     latest: str
 
 

--- a/package/kedro_viz/integrations/pypi/__init__.py
+++ b/package/kedro_viz/integrations/pypi/__init__.py
@@ -6,6 +6,8 @@ import click
 import requests
 from semver import VersionInfo
 
+from kedro_viz import __version__
+
 # PyPI endpoint to query latest Kedro-Viz version available
 _PYPI_ENDPOINT = "https://pypi.python.org/pypi/kedro-viz/json"
 logger = logging.getLogger(__name__)
@@ -19,3 +21,11 @@ def get_latest_version() -> VersionInfo:
     except requests.exceptions.RequestException:
         return None
     return VersionInfo.parse(pypi_response["info"]["version"])
+
+
+def is_running_outdated_version(
+    installed_version: VersionInfo, latest_version: Optional[VersionInfo]
+) -> bool:
+    """Check if the user is running the latest version of Viz."""
+
+    return latest_version is not None and installed_version < latest_version

--- a/package/kedro_viz/launchers/cli.py
+++ b/package/kedro_viz/launchers/cli.py
@@ -74,14 +74,14 @@ def commands():
 )
 def viz(host, port, browser, load_file, save_file, pipeline, env, autoreload):
     """Visualise a Kedro pipeline using Kedro viz."""
-    current_version = VersionInfo.parse(__version__)
+    installed_version = VersionInfo.parse(__version__)
     latest_version = get_latest_version()
 
-    if latest_version is not None and current_version < latest_version:
+    if latest_version is not None and installed_version < latest_version:
         click.echo(
             click.style(
                 "WARNING: You are using an old version of Kedro Viz. "
-                f"You are using version {current_version}; "
+                f"You are using version {installed_version}; "
                 f"however, version {latest_version} is now available.\n"
                 "You should consider upgrading via the `pip install -U kedro-viz` command.\n"
                 "You can view the complete changelog at "

--- a/package/kedro_viz/launchers/cli.py
+++ b/package/kedro_viz/launchers/cli.py
@@ -10,7 +10,7 @@ from semver import VersionInfo
 from watchgod import RegExpWatcher, run_process
 
 from kedro_viz import __version__
-from kedro_viz.integrations.pypi import get_latest_version
+from kedro_viz.integrations.pypi import get_latest_version, is_running_outdated_version
 from kedro_viz.server import DEFAULT_HOST, DEFAULT_PORT, is_localhost, run_server
 
 
@@ -77,7 +77,7 @@ def viz(host, port, browser, load_file, save_file, pipeline, env, autoreload):
     installed_version = VersionInfo.parse(__version__)
     latest_version = get_latest_version()
 
-    if latest_version is not None and installed_version < latest_version:
+    if is_running_outdated_version(installed_version, latest_version):
         click.echo(
             click.style(
                 "WARNING: You are using an old version of Kedro Viz. "

--- a/package/tests/test_api/test_graphql/test_queries.py
+++ b/package/tests/test_api/test_graphql/test_queries.py
@@ -1,5 +1,8 @@
 import pytest
 
+from kedro_viz import __version__
+from kedro_viz.integrations.pypi import get_latest_version
+
 
 class TestQueryNoSessionStore:
     def test_graphql_run_list_endpoint(self, client):
@@ -53,6 +56,17 @@ class TestQueryWithRuns:
         )
         assert response.json() == {
             "data": {"runMetadata": [{"id": example_run_ids[0], "bookmark": True}]}
+        }
+
+    def test_graphql_version_endpoint(self, client):
+        response = client.post(
+            "/graphql",
+            json={"query": "{{version {{installed latest}}}}"},
+        )
+        assert response.json() == {
+            "data": {
+                "version": {"installed": __version__, "latest": get_latest_version()}
+            }
         }
 
     def test_run_tracking_data_query(

--- a/package/tests/test_api/test_graphql/test_queries.py
+++ b/package/tests/test_api/test_graphql/test_queries.py
@@ -59,17 +59,6 @@ class TestQueryWithRuns:
             "data": {"runMetadata": [{"id": example_run_ids[0], "bookmark": True}]}
         }
 
-    def test_graphql_version_endpoint(self, client):
-        response = client.post(
-            "/graphql",
-            json={"query": "{version {installed latest}}"},
-        )
-        assert response.json() == {
-            "data": {
-                "version": {"installed": __version__, "latest": get_latest_version()}
-            }
-        }
-
     def test_run_tracking_data_query(
         self,
         example_run_ids,

--- a/package/tests/test_api/test_graphql/test_queries.py
+++ b/package/tests/test_api/test_graphql/test_queries.py
@@ -132,10 +132,12 @@ class TestQueryWithRuns:
         assert response.json() == expected_response
 
 
-class TestVersionQuery:
+class TestQueryVersion:
     def test_graphql_version_endpoint(self, client, mocker):
-        mocker.patch("kedro_viz.integrations.pypi.get_latest_version",
-                     return_value=VersionInfo.parse("1.0.0"))
+        mocker.patch(
+            "kedro_viz.api.graphql.get_latest_version",
+            return_value=VersionInfo.parse("1.0.0"),
+        )
         response = client.post(
             "/graphql",
             json={"query": "{version {installed isOutdated latest}}"},
@@ -144,7 +146,7 @@ class TestVersionQuery:
             "data": {
                 "version": {
                     "installed": __version__,
-                    "isOutdated": True,
+                    "isOutdated": False,
                     "latest": "1.0.0",
                 }
             }

--- a/package/tests/test_api/test_graphql/test_queries.py
+++ b/package/tests/test_api/test_graphql/test_queries.py
@@ -2,7 +2,6 @@ import pytest
 from semver import VersionInfo
 
 from kedro_viz import __version__
-from kedro_viz.integrations.pypi import get_latest_version
 
 
 class TestQueryNoSessionStore:

--- a/package/tests/test_api/test_graphql/test_queries.py
+++ b/package/tests/test_api/test_graphql/test_queries.py
@@ -61,7 +61,7 @@ class TestQueryWithRuns:
     def test_graphql_version_endpoint(self, client):
         response = client.post(
             "/graphql",
-            json={"query": "{{version {{installed latest}}}}"},
+            json={"query": "{version {installed latest}}"},
         )
         assert response.json() == {
             "data": {

--- a/package/tests/test_api/test_graphql/test_queries.py
+++ b/package/tests/test_api/test_graphql/test_queries.py
@@ -1,4 +1,5 @@
 import pytest
+from semver import VersionInfo
 
 from kedro_viz import __version__
 from kedro_viz.integrations.pypi import get_latest_version
@@ -129,3 +130,22 @@ class TestQueryWithRuns:
             }
         }
         assert response.json() == expected_response
+
+
+class TestVersionQuery:
+    def test_graphql_version_endpoint(self, client, mocker):
+        mocker.patch("kedro_viz.integrations.pypi.get_latest_version",
+                     return_value=VersionInfo.parse("1.0.0"))
+        response = client.post(
+            "/graphql",
+            json={"query": "{version {installed isOutdated latest}}"},
+        )
+        assert response.json() == {
+            "data": {
+                "version": {
+                    "installed": __version__,
+                    "isOutdated": True,
+                    "latest": "1.0.0",
+                }
+            }
+        }

--- a/package/tests/test_integrations/test_pypi.py
+++ b/package/tests/test_integrations/test_pypi.py
@@ -1,6 +1,7 @@
+import pytest
 from semver import VersionInfo
 
-from kedro_viz.integrations.pypi import get_latest_version
+from kedro_viz.integrations.pypi import get_latest_version, is_running_outdated_version
 
 
 def test_get_latest_version(mocker, mock_http_response):
@@ -10,3 +11,11 @@ def test_get_latest_version(mocker, mock_http_response):
         data={"info": {"version": mock_version}}
     )
     assert get_latest_version() == VersionInfo.parse(mock_version)
+
+
+@pytest.mark.parametrize(
+    "installed_version, latest_version, is_outdated",
+    [("1.0.0", "1.2.3", True), ("1.2.3", "1.0.0", False), ("1.0.0", None, False)],
+)
+def test_is_running_outdated_version(installed_version, latest_version, is_outdated):
+    assert is_running_outdated_version(installed_version, latest_version) == is_outdated

--- a/package/tests/test_integrations/test_pypi.py
+++ b/package/tests/test_integrations/test_pypi.py
@@ -18,4 +18,7 @@ def test_get_latest_version(mocker, mock_http_response):
     [("1.0.0", "1.2.3", True), ("1.2.3", "1.0.0", False), ("1.0.0", None, False)],
 )
 def test_is_running_outdated_version(installed_version, latest_version, is_outdated):
+    installed_version = VersionInfo.parse(installed_version)
+    if latest_version is not None:
+        latest_version = VersionInfo.parse(latest_version)
     assert is_running_outdated_version(installed_version, latest_version) == is_outdated

--- a/package/tests/test_launchers/test_cli.py
+++ b/package/tests/test_launchers/test_cli.py
@@ -62,8 +62,8 @@ def test_kedro_viz_command_run_server(command_options, run_server_args, mocker):
 
 
 def test_kedro_viz_command_should_log_outdated_version(mocker, mock_http_response):
-    current_version = VersionInfo.parse(__version__)
-    mock_version = f"{current_version.major + 1}.0.0"
+    installed_version = VersionInfo.parse(__version__)
+    mock_version = f"{installed_version.major + 1}.0.0"
     requests_get = mocker.patch("requests.get")
     requests_get.return_value = mock_http_response(
         data={"info": {"version": mock_version}}
@@ -77,7 +77,7 @@ def test_kedro_viz_command_should_log_outdated_version(mocker, mock_http_respons
 
     mock_click_echo.assert_called_once_with(
         "\x1b[33mWARNING: You are using an old version of Kedro Viz. "
-        f"You are using version {current_version}; "
+        f"You are using version {installed_version}; "
         f"however, version {mock_version} is now available.\n"
         "You should consider upgrading via the `pip install -U kedro-viz` command.\n"
         "You can view the complete changelog at "

--- a/src/apollo/schema.graphql
+++ b/src/apollo/schema.graphql
@@ -6,28 +6,28 @@ type Mutation {
 }
 
 type Query {
-  version: Version!
-  runsList: [Run!]!
   runMetadata(runIds: [ID!]!): [Run!]!
+  runsList: [Run!]!
   runTrackingData(runIds: [ID!]!, showDiff: Boolean = false): [TrackingDataset!]!
+  version: Version!
 }
 
 type Run {
-  id: ID!
-  title: String!
-  timestamp: String!
   author: String
+  bookmark: Boolean
   gitBranch: String
   gitSha: String
-  bookmark: Boolean
+  id: ID!
   notes: String
   runCommand: String
+  timestamp: String!
+  title: String!
 }
 
 input RunInput {
   bookmark: Boolean = null
-  title: String = null
   notes: String = null
+  title: String = null
 }
 
 type Subscription {
@@ -35,9 +35,9 @@ type Subscription {
 }
 
 type TrackingDataset {
+  data: JSONObject
   datasetName: String
   datasetType: String
-  data: JSONObject
 }
 
 type UpdateRunDetailsFailure {

--- a/src/apollo/schema.graphql
+++ b/src/apollo/schema.graphql
@@ -53,5 +53,6 @@ type UpdateRunDetailsSuccess {
 
 type Version {
   installed: String!
+  isOutdated: Boolean!
   latest: String!
 }

--- a/src/apollo/schema.graphql
+++ b/src/apollo/schema.graphql
@@ -9,6 +9,7 @@ type Query {
   runsList: [Run!]!
   runMetadata(runIds: [ID!]!): [Run!]!
   runTrackingData(runIds: [ID!]!, showDiff: Boolean = false): [TrackingDataset!]!
+  version: Version!
 }
 
 type Run {
@@ -51,6 +52,6 @@ type UpdateRunDetailsSuccess {
 }
 
 type Version {
-  current: String!
+  installed: String!
   latest: String!
 }

--- a/src/apollo/schema.graphql
+++ b/src/apollo/schema.graphql
@@ -6,10 +6,10 @@ type Mutation {
 }
 
 type Query {
+  version: Version!
   runsList: [Run!]!
   runMetadata(runIds: [ID!]!): [Run!]!
   runTrackingData(runIds: [ID!]!, showDiff: Boolean = false): [TrackingDataset!]!
-  version: Version!
 }
 
 type Run {

--- a/src/apollo/schema.graphql
+++ b/src/apollo/schema.graphql
@@ -49,3 +49,8 @@ union UpdateRunDetailsResponse = UpdateRunDetailsSuccess | UpdateRunDetailsFailu
 type UpdateRunDetailsSuccess {
   run: Run!
 }
+
+type Version {
+  current: String!
+  latest: String!
+}


### PR DESCRIPTION
## Description

For an upcoming frontend feature, we need a way to programmatically check the user's installed Viz version and the latest one released on PyPI.

## Development notes

I've created a GraphQL query (`version`) that returns the current and latest versions.

## QA notes

To test:

1. Check out the branch
2. Run `make run`
3. Open http://127.0.0.1:4142/graphql
4. Run this query: 

```graphql
query MyQuery {
  version {
    installed
    latest
  }
}
```

The output should look akin to this: 

```json
{
  "data": {
    "version": {
      "installed": "4.3.1",
      "latest": "4.3.1"
    }
  }
}
```

P.S. this is my first Python PR. Please be critical of my code and help me learn :)

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes
