### PR TITLE
Make commit-msg hook executable in `make sign-off`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,4 +59,3 @@ sign-off:
 	echo '--trailer "Signed-off-by: $$(git config user.name) <$$(git config user.email)>" \c' >> .git/hooks/commit-msg
 	echo '--in-place "$$1"' >> .git/hooks/commit-msg
 	chmod +x .git/hooks/commit-msg
-

--- a/Makefile
+++ b/Makefile
@@ -58,3 +58,5 @@ sign-off:
 	echo "git interpret-trailers --if-exists doNothing \c" > .git/hooks/commit-msg
 	echo '--trailer "Signed-off-by: $$(git config user.name) <$$(git config user.email)>" \c' >> .git/hooks/commit-msg
 	echo '--in-place "$$1"' >> .git/hooks/commit-msg
+	chmod +x .git/hooks/commit-msg
+


### PR DESCRIPTION
## Description

Sorry, this will be the last commit on `make sign-off` I promise 🤦 I somehow missed the `chmod` line that's in the kedro Makefile and is important - otherwise you can end up with this annoying warning:
```
hint: The '.git/hooks/commit-msg' hook was ignored because it's not set as executable.
``` 

## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes
