### PR TITLE
[KED-2984] Remove Kedro-UI webfont usage

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -10,12 +10,16 @@
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
     <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico" />
     <title>Kedro-Viz</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Titillium+Web:wght@400;600&display=swap"
+      rel="stylesheet"
+    />
   </head>
 
   <body>
-    <noscript>
-      You need to enable JavaScript to run this app.
-    </noscript>
+    <noscript> You need to enable JavaScript to run this app. </noscript>
     <div id="root"></div>
   </body>
 </html>

--- a/src/actions/actions.test.js
+++ b/src/actions/actions.test.js
@@ -13,7 +13,6 @@ import {
   TOGGLE_TEXT_LABELS,
   TOGGLE_THEME,
   UPDATE_CHART_SIZE,
-  UPDATE_FONT_LOADED,
   TOGGLE_CODE,
   TOGGLE_MODULAR_PIPELINE_FOCUS_MODE,
   changeFlag,
@@ -30,7 +29,6 @@ import {
   toggleTextLabels,
   toggleTheme,
   updateChartSize,
-  updateFontLoaded,
   toggleFocusMode,
 } from '../actions';
 import {
@@ -272,15 +270,6 @@ describe('actions', () => {
       chartSize,
     };
     expect(updateChartSize(chartSize)).toEqual(expectedAction);
-  });
-
-  it('should create an action to update the state when the webfont has loaded', () => {
-    const fontLoaded = true;
-    const expectedAction = {
-      type: UPDATE_FONT_LOADED,
-      fontLoaded,
-    };
-    expect(updateFontLoaded(fontLoaded)).toEqual(expectedAction);
   });
 
   it('should create an action to change a flag', () => {

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -154,19 +154,6 @@ export function updateZoom(zoom) {
   };
 }
 
-export const UPDATE_FONT_LOADED = 'UPDATE_FONT_LOADED';
-
-/**
- * Update whether the webfont has loaded, which should block the chart render
- * @param {Boolean} fontLoaded Whether the font has loaded
- */
-export function updateFontLoaded(fontLoaded) {
-  return {
-    type: UPDATE_FONT_LOADED,
-    fontLoaded,
-  };
-}
-
 export const TOGGLE_MINIMAP = 'TOGGLE_MINIMAP';
 
 /**

--- a/src/components/app/app.js
+++ b/src/components/app/app.js
@@ -2,10 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Provider } from 'react-redux';
 import 'what-input';
-import '@quantumblack/kedro-ui/lib/styles/app-no-webfont.css';
-import LoadWebFont from '@quantumblack/kedro-ui/lib/utils/webfont.js';
 import configureStore from '../../store';
-import { resetData, updateFontLoaded } from '../../actions';
+import { resetData } from '../../actions';
 import { loadInitialPipelineData } from '../../actions/pipelines';
 import Wrapper from '../wrapper';
 import getInitialState, {
@@ -33,7 +31,6 @@ class App extends React.Component {
     if (this.props.data === 'json') {
       this.store.dispatch(loadInitialPipelineData());
     }
-    this.loadWebFonts();
     this.announceFlags(this.store.getState().flags);
   }
 
@@ -52,20 +49,6 @@ class App extends React.Component {
     if (message && typeof jest === 'undefined') {
       console.info(message);
     }
-  }
-
-  /**
-   * Dispatch an action once the webfont has loaded.
-   * Uses https://github.com/typekit/webfontloader
-   */
-  loadWebFonts() {
-    const setFontLoaded = () => {
-      this.store.dispatch(updateFontLoaded(true));
-    };
-    LoadWebFont({
-      active: setFontLoaded,
-      inactive: setFontLoaded,
-    });
   }
 
   /**

--- a/src/components/app/app.scss
+++ b/src/components/app/app.scss
@@ -41,3 +41,12 @@
   --color-base-20: rgba(255, 255, 255, 0.2);
   --color-black-10: rgba(0, 0, 0, 0.1);
 }
+
+.kedro {
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Titillium Web', sans-serif;
+  font-size: 10px;
+  font-weight: 400;
+  letter-spacing: 0.1px;
+  line-height: 1.4;
+}

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -15,7 +15,6 @@ import {
   TOGGLE_THEME,
   UPDATE_CHART_SIZE,
   UPDATE_ZOOM,
-  UPDATE_FONT_LOADED,
   TOGGLE_IGNORE_LARGE_WARNING,
   TOGGLE_PRETTY_NAME,
 } from '../actions';
@@ -68,7 +67,6 @@ const combinedReducer = combineReducers({
   // These props have very simple non-nested actions
   chartSize: createReducer({}, UPDATE_CHART_SIZE, 'chartSize'),
   zoom: createReducer({}, UPDATE_ZOOM, 'zoom'),
-  fontLoaded: createReducer(false, UPDATE_FONT_LOADED, 'fontLoaded'),
   textLabels: createReducer(true, TOGGLE_TEXT_LABELS, 'textLabels'),
   theme: createReducer('dark', TOGGLE_THEME, 'theme'),
   prettyName: createReducer(true, TOGGLE_PRETTY_NAME, 'prettyName'),

--- a/src/reducers/reducers.test.js
+++ b/src/reducers/reducers.test.js
@@ -17,7 +17,6 @@ import {
   TOGGLE_TEXT_LABELS,
   TOGGLE_THEME,
   UPDATE_CHART_SIZE,
-  UPDATE_FONT_LOADED,
 } from '../actions';
 import {
   TOGGLE_NODE_CLICKED,
@@ -340,16 +339,6 @@ describe('Reducer', () => {
         x: expect.any(Number),
         y: expect.any(Number),
       });
-    });
-  });
-
-  describe('UPDATE_FONT_LOADED', () => {
-    it('should update the state when the webfont is loaded', () => {
-      const newState = reducer(mockState.spaceflights, {
-        type: UPDATE_FONT_LOADED,
-        fontLoaded: true,
-      });
-      expect(newState.fontLoaded).toBe(true);
     });
   });
 

--- a/src/selectors/layout.js
+++ b/src/selectors/layout.js
@@ -14,7 +14,6 @@ import {
 const getSizeWarningFlag = (state) => state.flags.sizewarning;
 const getVisibleSidebar = (state) => state.visible.sidebar;
 const getVisibleCode = (state) => state.visible.code;
-const getFontLoaded = (state) => state.fontLoaded;
 const getIgnoreLargeWarning = (state) => state.ignoreLargeWarning;
 const getGraphHasNodes = (state) => Boolean(state.graph?.nodes?.length);
 const getChartSizeState = (state) => state.chartSize;
@@ -49,15 +48,14 @@ export const getGraphInput = createSelector(
     getVisibleNodes,
     getVisibleEdges,
     getVisibleLayerIDs,
-    getFontLoaded,
     getTriggerLargeGraphWarning,
   ],
-  (nodes, edges, layers, fontLoaded, triggerLargeGraphWarning) => {
-    if (!fontLoaded || triggerLargeGraphWarning) {
+  (nodes, edges, layers, triggerLargeGraphWarning) => {
+    if (triggerLargeGraphWarning) {
       return null;
     }
 
-    return { nodes, edges, layers, fontLoaded };
+    return { nodes, edges, layers };
   }
 );
 

--- a/src/selectors/layout.test.js
+++ b/src/selectors/layout.test.js
@@ -5,11 +5,7 @@ import {
   getGraphInput,
   getTriggerLargeGraphWarning,
 } from './layout';
-import {
-  changeFlag,
-  toggleIgnoreLargeWarning,
-  updateFontLoaded,
-} from '../actions';
+import { changeFlag, toggleIgnoreLargeWarning } from '../actions';
 import { updateGraph } from '../actions/graph';
 import { toggleTypeDisabled } from '../actions/node-type';
 import reducer from '../reducers';
@@ -113,14 +109,8 @@ describe('Selectors', () => {
           nodes: expect.any(Array),
           edges: expect.any(Array),
           layers: expect.any(Array),
-          fontLoaded: expect.any(Boolean),
         })
       );
-    });
-
-    it('returns null if fontLoaded is false', () => {
-      const newMockState = reducer(mockState, updateFontLoaded(false));
-      expect(getGraphInput(newMockState)).toEqual(null);
     });
   });
 

--- a/src/selectors/loading.js
+++ b/src/selectors/loading.js
@@ -2,7 +2,6 @@ import { createSelector } from 'reselect';
 
 const getGraphLoading = (state) => state.loading.graph;
 const getPipelineLoading = (state) => state.loading.pipeline;
-const getFontLoading = (state) => !state.fontLoaded;
 const getNodeLoading = (state) => state.loading.node;
 
 export const getDisplayLargeGraph = (state) => state.ignoreLargeWarning;
@@ -11,8 +10,8 @@ export const getDisplayLargeGraph = (state) => state.ignoreLargeWarning;
  * Determine whether to show the loading spinner
  */
 export const isLoading = createSelector(
-  [getGraphLoading, getPipelineLoading, getFontLoading, getNodeLoading],
-  (graphLoading, pipelineLoading, fontLoading, nodeLoading) => {
-    return graphLoading || pipelineLoading || fontLoading || nodeLoading;
+  [getGraphLoading, getPipelineLoading, getNodeLoading],
+  (graphLoading, pipelineLoading, nodeLoading) => {
+    return graphLoading || pipelineLoading || nodeLoading;
   }
 );

--- a/src/selectors/nodes.js
+++ b/src/selectors/nodes.js
@@ -23,7 +23,6 @@ const getPrettyName = (state) => state.prettyName;
 const getTagActive = (state) => state.tag.active;
 const getModularPipelineActive = (state) => state.modularPipeline.active;
 const getTextLabels = (state) => state.textLabels;
-const getFontLoaded = (state) => state.fontLoaded;
 const getNodeTypeDisabled = (state) => state.nodeType.disabled;
 const getClickedNode = (state) => state.node.clicked;
 const getEdgeIDs = (state) => state.edge.ids;
@@ -245,11 +244,8 @@ export const getGroupedNodes = createSelector([getNodeData], (nodes) =>
  * measure its width with getBBox, then delete the container and store the value
  */
 export const getNodeTextWidth = createSelector(
-  [getPipelineNodeIDs, getNodeLabel, getFontLoaded],
-  (nodeIDs, nodeLabel, fontLoaded) => {
-    if (!fontLoaded) {
-      return {};
-    }
+  [getPipelineNodeIDs, getNodeLabel],
+  (nodeIDs, nodeLabel) => {
     const nodeTextWidth = {};
     const svg = select(document.body)
       .append('svg')
@@ -299,17 +295,8 @@ export const getPadding = (showLabels, nodeType) => {
  * Calculate node width/height and icon/text positioning
  */
 export const getNodeSize = createSelector(
-  [
-    getPipelineNodeIDs,
-    getNodeTextWidth,
-    getTextLabels,
-    getNodeType,
-    getFontLoaded,
-  ],
-  (nodeIDs, nodeTextWidth, textLabels, nodeType, fontLoaded) => {
-    if (!fontLoaded) {
-      return {};
-    }
+  [getPipelineNodeIDs, getNodeTextWidth, getTextLabels, getNodeType],
+  (nodeIDs, nodeTextWidth, textLabels, nodeType) => {
     return arrayToObject(nodeIDs, (nodeID) => {
       const iconSize = textLabels ? 24 : 28;
       const padding = getPadding(textLabels, nodeType[nodeID]);
@@ -342,7 +329,6 @@ export const getVisibleNodes = createSelector(
     getNodeSize,
     getNodeLayer,
     getNodeRank,
-    getFontLoaded,
   ],
   (
     nodeIDs,
@@ -352,21 +338,18 @@ export const getVisibleNodes = createSelector(
     nodeFullName,
     nodeSize,
     nodeLayer,
-    nodeRank,
-    fontLoaded
+    nodeRank
   ) =>
-    fontLoaded
-      ? nodeIDs.map((id) => ({
-          id,
-          name: nodeLabel[id],
-          fullName: nodeFullName[id],
-          icon: getShortType([nodeDatasetType[id]], nodeType[id]),
-          type: nodeType[id],
-          layer: nodeLayer[id],
-          rank: nodeRank[id],
-          ...nodeSize[id],
-        }))
-      : []
+    nodeIDs.map((id) => ({
+      id,
+      name: nodeLabel[id],
+      fullName: nodeFullName[id],
+      icon: getShortType([nodeDatasetType[id]], nodeType[id]),
+      type: nodeType[id],
+      layer: nodeLayer[id],
+      rank: nodeRank[id],
+      ...nodeSize[id],
+    }))
 );
 
 /**

--- a/src/store/initial-state.js
+++ b/src/store/initial-state.js
@@ -17,7 +17,6 @@ export const createInitialState = () => ({
   prettyName: settings.prettyName.default,
   ignoreLargeWarning: false,
   loading: {
-    graph: false,
     pipeline: false,
     node: false,
   },

--- a/src/utils/state.mock.js
+++ b/src/utils/state.mock.js
@@ -6,7 +6,6 @@ import getInitialState from '../store/initial-state';
 import spaceflights from './data/spaceflights.mock.json';
 import demo from './data/demo.mock.json';
 import reducer from '../reducers';
-import { updateFontLoaded } from '../actions';
 import { getGraphInput } from '../selectors/layout';
 import { updateGraph } from '../actions/graph';
 import { graphNew } from './graph';
@@ -26,8 +25,6 @@ export const prepareState = ({
 }) => {
   const initialState = getInitialState(props);
   const actions = [
-    // Set fontLoaded = true:
-    () => updateFontLoaded(true),
     // Per-test provided actions before layout:
     ...beforeLayoutActions,
     // Precalculate graph layout:


### PR DESCRIPTION
## Description

We're migrating the components we use from [Kedro-UI](https://github.com/quantumblacklabs/kedro-ui/), and this is one of those migrations, though this time it's a deletion and simplification. Here's the [relevant ticket](https://jira.quantumblack.com/browse/KED-2984) (QB-only access).

## Development notes

The [WebFontLoader](https://github.com/typekit/webfontloader) library we were using from TypeKit/Google hasn't been updated since May 2017. We weren't really leveraging it's useful options either. We we using it to trigger a Redux action if the web font loaded and even if it didn't:

```js
LoadWebFont({
  active: setFontLoaded,
  inactive: setFontLoaded,
});
```

The result of that action would be one indicator to Viz if the flowchart should load or not. Since we made no distinction between a successful/unsuccessful font load, I decided to take it out completely. So I've removed the two instances of the Kedro-UI Webfont business that was present in `src/components/app/app.js`:

```jsx
import '@quantumblack/kedro-ui/lib/styles/app-no-webfont.css';
import LoadWebFont from '@quantumblack/kedro-ui/lib/utils/webfont.js';
```

In it's place, I'm loading the Google Font we use in the `index.html` file:

```html
<link rel="preconnect" href="https://fonts.googleapis.com" />
<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
<link
  href="https://fonts.googleapis.com/css2?family=Titillium+Web:wght@400;600&display=swap"
  rel="stylesheet"
/>
```

And bringing in the few lines of CSS we need for the font styles:

```css
.kedro {
  -webkit-font-smoothing: antialiased;
  font-family: 'Titillium Web', sans-serif;
  font-size: 10px;
  font-weight: 400;
  letter-spacing: 0.1px;
  line-height: 1.4;
}
```

I've also removed all references that dealt with testing the `fontLoaded` action/state/etc.

This part of the app is much simpler now, and in a way starts us along a lengthy path moving away from Redux.

## QA notes

Check out the branch and see if you notice anything different with the fonts.

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes
