### PR TITLE
Fix - Refactor Export CSV setup

### DIFF
--- a/src/components/experiment-tracking/experiment-primary-toolbar/experiment-primary-toolbar.js
+++ b/src/components/experiment-tracking/experiment-primary-toolbar/experiment-primary-toolbar.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import { CSVLink } from 'react-csv';
 import { useUpdateRunDetails } from '../../../apollo/mutations';
 import IconButton from '../../ui/icon-button';
@@ -32,9 +32,9 @@ export const ExperimentPrimaryToolbar = ({
     });
   };
 
-  const updateExportData = () => {
+  const updateExportData = useCallback(() => {
     setExportData(constructExportData(runMetadata, runTrackingData));
-  };
+  }, [runMetadata, runTrackingData]);
 
   return (
     <PrimaryToolbar

--- a/src/components/experiment-tracking/experiment-primary-toolbar/experiment-primary-toolbar.js
+++ b/src/components/experiment-tracking/experiment-primary-toolbar/experiment-primary-toolbar.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { CSVLink } from 'react-csv';
 import { useUpdateRunDetails } from '../../../apollo/mutations';
 import IconButton from '../../ui/icon-button';
@@ -23,6 +23,7 @@ export const ExperimentPrimaryToolbar = ({
   sidebarVisible,
 }) => {
   const { updateRunDetails } = useUpdateRunDetails();
+  const [exportData, setExportData] = useState([]);
 
   const toggleBookmark = () => {
     updateRunDetails({
@@ -31,7 +32,9 @@ export const ExperimentPrimaryToolbar = ({
     });
   };
 
-  const exportData = constructExportData(runMetadata, runTrackingData);
+  const updateExportData = () => {
+    setExportData(constructExportData(runMetadata, runTrackingData));
+  };
 
   return (
     <PrimaryToolbar
@@ -67,7 +70,12 @@ export const ExperimentPrimaryToolbar = ({
         visible={enableComparisonView}
         disabled={showChangesIconDisabled}
       />
-      <CSVLink data={exportData} filename="run-data.csv">
+      <CSVLink
+        data={exportData}
+        asyncOnClick={true}
+        onClick={updateExportData}
+        filename="run-data.csv"
+      >
         <IconButton
           ariaLabel="Export graph as SVG or PNG"
           className={'pipeline-menu-button--export'}


### PR DESCRIPTION
## Description

This is a quick PR to improve the existing CSV export setup to only construct the export data on click. 

## Development notes

Instead of assigning the export data to a variable, I have assigned it to a state that will be updated in the `onClick` callback that is passed to the `CSVLink` component. This async setup is made possible by assigning a `true` value for the `asyncOnClick` prop to the `CSVLink` component. 

## QA notes

When you click on the export csv link, it should work in exporting the selected runs. 

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro-viz/pull/761"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

