### PR TITLE
Add display props to standalone React component + expandAllPipelines flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ Kedro-Viz uses features flags to roll out some experimental features. The follow
 | Flag | Description |
 |------| ------------|
 | sizewarning | From release v3.9.1. Show a warning before rendering very large graphs (default `true`) |
+| expandAllPipelines | From release v4.3.2. Expand all modular pipelines on first load (default `false`) |
 
 To enable or disable a flag, click on the settings icon in the toolbar and toggle the flag on/off.
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -11,6 +11,8 @@ Please follow the established format:
 ## Major features and improvements
 - Set up of a pop-up reminder to nudge users to upgrade Kedro-Viz when a new version is released. (#746)
 - Set up the 'export run' button to allow exporting of selected run data into a csv file for download. (#757)
+- Set up new display props to standalone React component. (#786)
+- Set up 'expandAllPipelines' flag to allow the expanded display of all modular pipelines on initial load. (#786)
 
 ## Bug fixes and other changes
 

--- a/src/actions/pipelines.js
+++ b/src/actions/pipelines.js
@@ -94,8 +94,11 @@ export function loadInitialPipelineData() {
     // in order to obtain the list of pipelines, which is required for determining
     // whether the active pipeline (from localStorage) exists in the data.
     const url = getUrl('main');
+    // obtain the status of expandAllPipelines to decide whether it needs to overwrite the
+    // list of visible nodes
+    const expandAllPipelines = state.display.expandAllPipelines;
     let newState = await loadJsonData(url).then((data) =>
-      preparePipelineState(data, true)
+      preparePipelineState(data, true, expandAllPipelines)
     );
     // If the active pipeline isn't 'main' then request data from new URL
     if (requiresSecondRequest(newState.pipeline)) {

--- a/src/actions/pipelines.js
+++ b/src/actions/pipelines.js
@@ -104,7 +104,9 @@ export function loadInitialPipelineData() {
     // If the active pipeline isn't 'main' then request data from new URL
     if (requiresSecondRequest(newState.pipeline)) {
       const url = getPipelineUrl(newState.pipeline);
-      newState = await loadJsonData(url).then(preparePipelineState);
+      newState = await loadJsonData(url).then((data) =>
+        preparePipelineState(data, true, expandAllPipelines)
+      );
     }
     dispatch(resetData(newState));
     dispatch(toggleLoading(false));
@@ -118,7 +120,7 @@ export function loadInitialPipelineData() {
  */
 export function loadPipelineData(pipelineID) {
   return async function (dispatch, getState) {
-    const { dataSource, pipeline } = getState();
+    const { dataSource, pipeline, display, flags } = getState();
     if (pipelineID && pipelineID === pipeline.active) {
       return;
     }
@@ -130,7 +132,11 @@ export function loadPipelineData(pipelineID) {
         main: pipeline.main,
         active: pipelineID,
       });
-      const newState = await loadJsonData(url).then(preparePipelineState);
+      const expandAllPipelines =
+        display.expandAllPipelines || flags.expandAllPipelines;
+      const newState = await loadJsonData(url).then((data) =>
+        preparePipelineState(data, true, expandAllPipelines)
+      );
       // Set active pipeline here rather than dispatching two separate actions,
       // to improve performance by only requiring one state recalculation
       newState.pipeline.active = pipelineID;

--- a/src/actions/pipelines.js
+++ b/src/actions/pipelines.js
@@ -73,6 +73,7 @@ export const requiresSecondRequest = (pipeline) => {
   if (!pipeline.active) {
     return false;
   }
+
   // The active pipeline is not 'main'
   return pipeline.active !== pipeline.main;
 };
@@ -105,7 +106,7 @@ export function loadInitialPipelineData() {
     if (requiresSecondRequest(newState.pipeline)) {
       const url = getPipelineUrl(newState.pipeline);
       newState = await loadJsonData(url).then((data) =>
-        preparePipelineState(data, true, expandAllPipelines)
+        preparePipelineState(data, false, expandAllPipelines)
       );
     }
     dispatch(resetData(newState));
@@ -135,7 +136,7 @@ export function loadPipelineData(pipelineID) {
       const expandAllPipelines =
         display.expandAllPipelines || flags.expandAllPipelines;
       const newState = await loadJsonData(url).then((data) =>
-        preparePipelineState(data, true, expandAllPipelines)
+        preparePipelineState(data, false, expandAllPipelines)
       );
       // Set active pipeline here rather than dispatching two separate actions,
       // to improve performance by only requiring one state recalculation

--- a/src/actions/pipelines.js
+++ b/src/actions/pipelines.js
@@ -96,7 +96,8 @@ export function loadInitialPipelineData() {
     const url = getUrl('main');
     // obtain the status of expandAllPipelines to decide whether it needs to overwrite the
     // list of visible nodes
-    const expandAllPipelines = state.display.expandAllPipelines;
+    const expandAllPipelines =
+      state.display.expandAllPipelines || state.flags.expandAllPipelines;
     let newState = await loadJsonData(url).then((data) =>
       preparePipelineState(data, true, expandAllPipelines)
     );

--- a/src/components/app/app.js
+++ b/src/components/app/app.js
@@ -99,6 +99,12 @@ App.propTypes = {
     exportBtn: PropTypes.bool,
     sidebar: PropTypes.bool,
   }),
+  display: PropTypes.shape({
+    globalToolBar: PropTypes.bool,
+    sidebar: PropTypes.bool,
+    miniMap: PropTypes.bool,
+    expandAllPipelines: PropTypes.bool,
+  }),
 };
 
 export default App;

--- a/src/components/app/app.js
+++ b/src/components/app/app.js
@@ -99,8 +99,11 @@ App.propTypes = {
     exportBtn: PropTypes.bool,
     sidebar: PropTypes.bool,
   }),
+  /**
+   * Determines if certain elements are displayed, e.g global tool bar, sidebar
+   */
   display: PropTypes.shape({
-    globalToolBar: PropTypes.bool,
+    globalToolbar: PropTypes.bool,
     sidebar: PropTypes.bool,
     miniMap: PropTypes.bool,
     expandAllPipelines: PropTypes.bool,

--- a/src/components/flowchart-primary-toolbar/flowchart-primary-toolbar.js
+++ b/src/components/flowchart-primary-toolbar/flowchart-primary-toolbar.js
@@ -20,6 +20,7 @@ import { getVisibleLayerIDs } from '../../selectors/disabled';
  */
 export const FlowchartPrimaryToolbar = ({
   disableLayerBtn,
+  displaySidebar,
   onToggleExportModal,
   onToggleLayers,
   onToggleSidebar,
@@ -29,7 +30,11 @@ export const FlowchartPrimaryToolbar = ({
   visibleLayers,
 }) => (
   <>
-    <PrimaryToolbar onToggleSidebar={onToggleSidebar} visible={visible}>
+    <PrimaryToolbar
+      onToggleSidebar={onToggleSidebar}
+      visible={visible}
+      displaySidebar={displaySidebar}
+    >
       <IconButton
         ariaLive="polite"
         className={'pipeline-menu-button--labels'}
@@ -64,6 +69,7 @@ export const mapStateToProps = (state) => ({
   textLabels: state.textLabels,
   visible: state.visible,
   visibleLayers: Boolean(getVisibleLayerIDs(state).length),
+  displaySidebar: state.display.sideBar,
 });
 
 export const mapDispatchToProps = (dispatch) => ({

--- a/src/components/flowchart-primary-toolbar/flowchart-primary-toolbar.js
+++ b/src/components/flowchart-primary-toolbar/flowchart-primary-toolbar.js
@@ -69,7 +69,7 @@ export const mapStateToProps = (state) => ({
   textLabels: state.textLabels,
   visible: state.visible,
   visibleLayers: Boolean(getVisibleLayerIDs(state).length),
-  displaySidebar: state.display.sideBar,
+  displaySidebar: state.display.sidebar,
 });
 
 export const mapDispatchToProps = (dispatch) => ({

--- a/src/components/flowchart-primary-toolbar/flowchart-primary-toolbar.test.js
+++ b/src/components/flowchart-primary-toolbar/flowchart-primary-toolbar.test.js
@@ -46,6 +46,7 @@ describe('PrimaryToolbar', () => {
     (selector, callback) => {
       const mockFn = jest.fn();
       const props = {
+        displaySidebar: true,
         textLabels: mockState.spaceflights.textLabels,
         visible: mockState.spaceflights.visible,
         [callback]: mockFn,
@@ -61,6 +62,7 @@ describe('PrimaryToolbar', () => {
     const expectedResult = {
       disableLayerBtn: expect.any(Boolean),
       textLabels: expect.any(Boolean),
+      displaySidebar: true,
       visible: expect.objectContaining({
         exportBtn: expect.any(Boolean),
         exportModal: expect.any(Boolean),

--- a/src/components/flowchart/flowchart.js
+++ b/src/components/flowchart/flowchart.js
@@ -519,7 +519,8 @@ export class FlowChart extends Component {
    * Render React elements
    */
   render() {
-    const { chartSize, layers, visibleGraph } = this.props;
+    const { chartSize, layers, visibleGraph, displayGlobalToolbar } =
+      this.props;
     const { outerWidth = 0, outerHeight = 0 } = chartSize;
 
     return (
@@ -577,6 +578,8 @@ export class FlowChart extends Component {
         <ul
           className={classnames('pipeline-flowchart__layer-names', {
             'pipeline-flowchart__layer-names--visible': layers.length,
+            'pipeline-flowchart__layer-names--no-global-toolbar':
+              !displayGlobalToolbar,
           })}
           ref={this.layerNamesRef}
         />
@@ -605,7 +608,9 @@ export const mapStateToProps = (state, ownProps) => ({
   clickedNode: state.node.clicked,
   chartSize: getChartSize(state),
   chartZoom: getChartZoom(state),
+  displayGlobalToolbar: state.display.globalToolBar,
   edges: state.graph.edges || emptyEdges,
+  focusMode: state.visible.modularPipelineFocusMode,
   graphSize: state.graph.size || emptyGraphSize,
   hoveredParameters: state.hoveredParameters,
   layers: getLayers(state),
@@ -621,7 +626,6 @@ export const mapStateToProps = (state, ownProps) => ({
   visibleSidebar: state.visible.sidebar,
   visibleCode: state.visible.code,
   visibleMetaSidebar: getVisibleMetaSidebar(state),
-  focusMode: state.visible.modularPipelineFocusMode,
   ...ownProps,
 });
 

--- a/src/components/flowchart/flowchart.js
+++ b/src/components/flowchart/flowchart.js
@@ -608,7 +608,7 @@ export const mapStateToProps = (state, ownProps) => ({
   clickedNode: state.node.clicked,
   chartSize: getChartSize(state),
   chartZoom: getChartZoom(state),
-  displayGlobalToolbar: state.display.globalToolBar,
+  displayGlobalToolbar: state.display.globalToolbar,
   edges: state.graph.edges || emptyEdges,
   focusMode: state.visible.modularPipelineFocusMode,
   graphSize: state.graph.size || emptyGraphSize,

--- a/src/components/flowchart/flowchart.test.js
+++ b/src/components/flowchart/flowchart.test.js
@@ -40,13 +40,15 @@ const mockChartSize = (
 
 describe('FlowChart', () => {
   it('renders without crashing', () => {
-    const svg = setup.mount(<FlowChart />).find('svg');
+    const svg = setup
+      .mount(<FlowChart displayGlobalToolbar={true} />)
+      .find('svg');
     expect(svg.length).toEqual(1);
     expect(svg.hasClass('pipeline-flowchart__graph')).toBe(true);
   });
 
   it('renders nodes with D3', () => {
-    const wrapper = setup.mount(<FlowChart />);
+    const wrapper = setup.mount(<FlowChart displayGlobalToolbar={true} />);
     const nodes = wrapper.render().find('.pipeline-node');
     const nodeNames = nodes.map((i, el) => select(el).text()).get();
     const mockNodes = getVisibleNodeIDs(mockState.spaceflights);
@@ -58,7 +60,7 @@ describe('FlowChart', () => {
   });
 
   it('a transform to fit the graph in container was applied', () => {
-    const wrapper = setup.mount(<FlowChart />);
+    const wrapper = setup.mount(<FlowChart displayGlobalToolbar={true} />);
     const instance = wrapper.find('FlowChart').instance();
     const viewTransform = getViewTransform(instance.view);
 
@@ -85,7 +87,9 @@ describe('FlowChart', () => {
       codeSidebarWidth: 0,
     });
 
-    const wrapper = setup.mount(<FlowChart chartSize={chartSize} />);
+    const wrapper = setup.mount(
+      <FlowChart displayGlobalToolbar={true} chartSize={chartSize} />
+    );
     const instance = wrapper.find('FlowChart').instance();
     const viewExtents = getViewExtents(instance.view);
 
@@ -126,7 +130,9 @@ describe('FlowChart', () => {
       codeSidebarWidth: 255,
     });
 
-    const wrapper = setup.mount(<FlowChart chartSize={chartSize} />);
+    const wrapper = setup.mount(
+      <FlowChart displayGlobalToolbar={true} chartSize={chartSize} />
+    );
     const instance = wrapper.find('FlowChart').instance();
     const viewExtents = getViewExtents(instance.view);
 
@@ -176,7 +182,7 @@ describe('FlowChart', () => {
     window.addEventListener = jest.fn((event, callback) => {
       map[event] = callback;
     });
-    const wrapper = setup.mount(<FlowChart />);
+    const wrapper = setup.mount(<FlowChart displayGlobalToolbar={true} />);
     const spy = jest.spyOn(
       wrapper.find('FlowChart').instance(),
       'updateChartSize'
@@ -237,6 +243,7 @@ describe('FlowChart', () => {
   it('applies active class to nodes when nodeActive prop set', () => {
     const wrapper = setup.mount(
       <FlowChart
+        displayGlobalToolbar={true}
         nodeActive={{
           [dataScienceNodeId]: true,
           [dataProcessingNodeId]: true,
@@ -249,6 +256,7 @@ describe('FlowChart', () => {
   it('applies collapsed-hint class to nodes with input parameters are hovered during collapsed state', () => {
     const wrapper = setup.mount(
       <FlowChart
+        displayGlobalToolbar={true}
         hoveredParameters={true}
         nodeTypeDisabled={{ parameters: true }}
         nodesWithInputParams={{
@@ -265,6 +273,7 @@ describe('FlowChart', () => {
   it('applies parameter-indicator--visible class to nodes with input parameters when nodeDisabled prop set', () => {
     const wrapper = setup.mount(
       <FlowChart
+        displayGlobalToolbar={true}
         nodeTypeDisabled={{ parameters: true }}
         nodesWithInputParams={{
           [dataScienceNodeId]: ['params1'],
@@ -288,6 +297,7 @@ describe('FlowChart', () => {
   it('applies pipeline-node--dataset-input class to input dataset nodes under focus mode', () => {
     const wrapper = setup.mount(
       <FlowChart
+        displayGlobalToolbar={true}
         nodeTypeDisabled={{ parameters: true }}
         focusMode={{ id: dataScienceNodeId }}
         inputOutputDataNodes={{
@@ -303,6 +313,7 @@ describe('FlowChart', () => {
   it('applies pipeline-edge--dataset--input class to input dataset edges under focus mode', () => {
     const wrapper = setup.mount(
       <FlowChart
+        displayGlobalToolbar={true}
         nodeTypeDisabled={{ parameters: true }}
         focusMode={{ id: dataScienceNodeId }}
         inputOutputDataEdges={{
@@ -320,6 +331,7 @@ describe('FlowChart', () => {
   it('applies pipeline-node--parameter-input class to input parameter nodes under focus mode', () => {
     const wrapper = setup.mount(
       <FlowChart
+        displayGlobalToolbar={true}
         focusMode={{ id: dataScienceNodeId }}
         inputOutputDataNodes={{
           f1f1425b: { id: 'f1f1425b' },
@@ -351,7 +363,7 @@ describe('FlowChart', () => {
   });
 
   it('getHoveredParameterLabel returns parameter count when there are more than 1 hidden parameters ', () => {
-    const wrapper = setup.mount(<FlowChart />);
+    const wrapper = setup.mount(<FlowChart displayGlobalToolbar={true} />);
     const parameterNames = ['params1', 'params2'];
     const instance = wrapper.find('FlowChart').instance();
     const label = instance.getHoveredParameterLabel(parameterNames);
@@ -359,7 +371,7 @@ describe('FlowChart', () => {
   });
 
   it('getHoveredParameterLabel returns parameter name when there is 1 hidden parameter ', () => {
-    const wrapper = setup.mount(<FlowChart />);
+    const wrapper = setup.mount(<FlowChart displayGlobalToolbar={true} />);
     const parameterNames = ['params1'];
     const instance = wrapper.find('FlowChart').instance();
     const label = instance.getHoveredParameterLabel(parameterNames);
@@ -367,18 +379,21 @@ describe('FlowChart', () => {
   });
 
   it('shows layers when layers are visible', () => {
-    const wrapper = setup.mount(<FlowChart />);
+    const wrapper = setup.mount(<FlowChart displayGlobalToolbar={true} />);
     expect(wrapper.render().find('.pipeline-layer').length).toBe(2);
   });
 
   it('hides layers when layers.length is 0', () => {
-    const wrapper = setup.mount(<FlowChart layers={[]} />);
+    const wrapper = setup.mount(
+      <FlowChart displayGlobalToolbar={true} layers={[]} />
+    );
     expect(wrapper.render().find('.pipeline-layer').length).toBe(0);
   });
 
   it('shows tooltip when tooltip prop set as visible', () => {
     const wrapper = setup.mount(
       <FlowChart
+        displayGlobalToolbar={true}
         tooltip={{
           targetRect: { top: 0, left: 0, width: 10, height: 10 },
           text: 'test tooltip',
@@ -396,6 +411,7 @@ describe('FlowChart', () => {
   it('hides tooltip when tooltip prop not set as visible', () => {
     const wrapper = setup.mount(
       <FlowChart
+        displayGlobalToolbar={true}
         tooltip={{
           targetRect: { top: 0, left: 0, width: 10, height: 10 },
           text: 'test tooltip',
@@ -430,6 +446,7 @@ describe('FlowChart', () => {
       inputOutputDataNodes: expect.any(Object),
       inputOutputDataEdges: expect.any(Object),
       focusMode: expect.any(Object),
+      displayGlobalToolbar: expect.any(Boolean),
     };
     expect(mapStateToProps(mockState.spaceflights)).toEqual(expectedResult);
   });

--- a/src/components/flowchart/styles/_layers.scss
+++ b/src/components/flowchart/styles/_layers.scss
@@ -48,7 +48,7 @@
   }
 
   &--no-global-toolbar {
-    left: calc(-1 * #{$global-toolbar-width});
+    left: -#{$global-toolbar-width};
   }
 
   @media print {

--- a/src/components/flowchart/styles/_layers.scss
+++ b/src/components/flowchart/styles/_layers.scss
@@ -48,7 +48,7 @@
   }
 
   &--no-global-toolbar {
-    left: -70px;
+    left: var(--global-toolbar-width);
   }
 
   @media print {

--- a/src/components/flowchart/styles/_layers.scss
+++ b/src/components/flowchart/styles/_layers.scss
@@ -48,7 +48,7 @@
   }
 
   &--no-global-toolbar {
-    left: var(--global-toolbar-width);
+    left: calc(-1 * #{$global-toolbar-width});
   }
 
   @media print {

--- a/src/components/flowchart/styles/_layers.scss
+++ b/src/components/flowchart/styles/_layers.scss
@@ -63,4 +63,8 @@
   font-weight: bold;
   font-size: 1.6em;
   white-space: nowrap;
+
+  &--no-global-toolbar {
+    left: -70px;
+  }
 }

--- a/src/components/flowchart/styles/_layers.scss
+++ b/src/components/flowchart/styles/_layers.scss
@@ -47,6 +47,10 @@
     opacity: 1;
   }
 
+  &--no-global-toolbar {
+    left: -70px;
+  }
+
   @media print {
     display: none;
   }
@@ -63,8 +67,4 @@
   font-weight: bold;
   font-size: 1.6em;
   white-space: nowrap;
-
-  &--no-global-toolbar {
-    left: -70px;
-  }
 }

--- a/src/components/minimap-toolbar/minimap-toolbar.js
+++ b/src/components/minimap-toolbar/minimap-toolbar.js
@@ -13,6 +13,7 @@ import './minimap-toolbar.css';
  * Controls for minimap
  */
 export const MiniMapToolbar = ({
+  displayMiniMap,
   onToggleMiniMap,
   visible,
   chartZoom,
@@ -23,15 +24,17 @@ export const MiniMapToolbar = ({
   return (
     <>
       <ul className="pipeline-minimap-toolbar kedro">
-        <IconButton
-          icon={MapIcon}
-          className={'pipeline-minimap-button pipeline-minimap-button--map'}
-          ariaLabel={`Turn minimap ${visible.miniMap ? 'off' : 'on'}`}
-          onClick={() => onToggleMiniMap(!visible.miniMap)}
-          labelText={`${visible.miniMap ? 'Hide' : 'Show'} minimap`}
-          visible={visible.miniMapBtn}
-          active={visible.miniMap}
-        />
+        {displayMiniMap && (
+          <IconButton
+            icon={MapIcon}
+            className={'pipeline-minimap-button pipeline-minimap-button--map'}
+            ariaLabel={`Turn minimap ${visible.miniMap ? 'off' : 'on'}`}
+            onClick={() => onToggleMiniMap(!visible.miniMap)}
+            labelText={`${visible.miniMap ? 'Hide' : 'Show'} minimap`}
+            visible={visible.miniMapBtn}
+            active={visible.miniMap}
+          />
+        )}
         <IconButton
           icon={PlusIcon}
           className={'pipeline-minimap-button pipeline-minimap-button--zoom-in'}
@@ -79,6 +82,7 @@ const scaleZoom = ({ scale }, factor) => ({
 
 export const mapStateToProps = (state) => ({
   visible: state.visible,
+  displayMiniMap: state.display.miniMap,
   chartZoom: getChartZoom(state),
 });
 

--- a/src/components/minimap-toolbar/minimap-toolbar.test.js
+++ b/src/components/minimap-toolbar/minimap-toolbar.test.js
@@ -25,6 +25,7 @@ describe('MiniMapToolbar', () => {
       const mockFn = jest.fn();
       const props = {
         chartZoom: { scale: 1, minScale: 0.5, maxScale: 1.5 },
+        displayMiniMap: true,
         visible: { miniMap: false },
         [callback]: mockFn,
       };
@@ -37,6 +38,7 @@ describe('MiniMapToolbar', () => {
 
   it('maps state to props', () => {
     const expectedResult = {
+      displayMiniMap: true,
       chartZoom: expect.any(Object),
       visible: expect.objectContaining({
         miniMap: expect.any(Boolean),

--- a/src/components/minimap-toolbar/minimap-toolbar.test.js
+++ b/src/components/minimap-toolbar/minimap-toolbar.test.js
@@ -36,6 +36,16 @@ describe('MiniMapToolbar', () => {
     }
   );
 
+  it('does not display the toggle minimap button if displayMinimap is false', () => {
+    const props = {
+      chartZoom: { scale: 1, minScale: 0.5, maxScale: 1.5 },
+      displayMiniMap: false,
+      visible: { miniMap: false },
+    };
+    const wrapper = setup.mount(<MiniMapToolbar {...props} />);
+    expect(wrapper.find('.pipeline-minimap-button--map').length).toBe(0);
+  });
+
   it('maps state to props', () => {
     const expectedResult = {
       displayMiniMap: true,

--- a/src/components/primary-toolbar/primary-toolbar.js
+++ b/src/components/primary-toolbar/primary-toolbar.js
@@ -13,24 +13,27 @@ import './primary-toolbar.css';
  */
 export const PrimaryToolbar = ({
   children,
+  displaySidebar,
   onToggleSidebar,
   visible = { sidebar: true },
 }) => (
   <>
     <ul className="pipeline-primary-toolbar kedro">
-      <IconButton
-        ariaLabel={`${visible.sidebar ? 'Hide' : 'Show'} menu`}
-        className={classnames(
-          'pipeline-menu-button',
-          'pipeline-menu-button--menu',
-          {
-            'pipeline-menu-button--inverse': !visible.sidebar,
-          }
-        )}
-        onClick={() => onToggleSidebar(!visible.sidebar)}
-        icon={MenuIcon}
-        labelText={`${visible.sidebar ? 'Hide' : 'Show'} menu`}
-      />
+      {displaySidebar && (
+        <IconButton
+          ariaLabel={`${visible.sidebar ? 'Hide' : 'Show'} menu`}
+          className={classnames(
+            'pipeline-menu-button',
+            'pipeline-menu-button--menu',
+            {
+              'pipeline-menu-button--inverse': !visible.sidebar,
+            }
+          )}
+          onClick={() => onToggleSidebar(!visible.sidebar)}
+          icon={MenuIcon}
+          labelText={`${visible.sidebar ? 'Hide' : 'Show'} menu`}
+        />
+      )}
       {children}
     </ul>
   </>

--- a/src/components/primary-toolbar/primary-toolbar.test.js
+++ b/src/components/primary-toolbar/primary-toolbar.test.js
@@ -4,7 +4,7 @@ import { mockState, setup } from '../../utils/state.mock';
 
 describe('PrimaryToolbar', () => {
   it('renders without crashing', () => {
-    const wrapper = setup.mount(<PrimaryToolbar />);
+    const wrapper = setup.mount(<PrimaryToolbar displaySidebar={true} />);
     expect(wrapper.find('.pipeline-icon-toolbar__button').length).toBe(1);
   });
 
@@ -12,7 +12,9 @@ describe('PrimaryToolbar', () => {
     const visible = {
       sidebar: true,
     };
-    const wrapper = setup.mount(<PrimaryToolbar visible={visible} />);
+    const wrapper = setup.mount(
+      <PrimaryToolbar displaySidebar={true} visible={visible} />
+    );
     expect(wrapper.find('.pipeline-icon-toolbar__button').length).toBe(1);
   });
 
@@ -20,7 +22,9 @@ describe('PrimaryToolbar', () => {
     const visible = {
       sidebar: true,
     };
-    const wrapper = setup.mount(<PrimaryToolbar visible={visible} />);
+    const wrapper = setup.mount(
+      <PrimaryToolbar displaySidebar={true} visible={visible} />
+    );
     expect(wrapper.find('.pipeline-menu-button--inverse').length).toBe(0);
   });
 
@@ -28,7 +32,9 @@ describe('PrimaryToolbar', () => {
     const visible = {
       sidebar: false,
     };
-    const wrapper = setup.mount(<PrimaryToolbar visible={visible} />);
+    const wrapper = setup.mount(
+      <PrimaryToolbar displaySidebar={true} visible={visible} />
+    );
     expect(wrapper.find('.pipeline-menu-button--inverse').length).toBe(2);
   });
 
@@ -41,6 +47,7 @@ describe('PrimaryToolbar', () => {
       const props = {
         textLabels: mockState.spaceflights.textLabels,
         visible: mockState.spaceflights.visible,
+        displaySidebar: true,
         [callback]: mockFn,
       };
       const wrapper = setup.mount(<PrimaryToolbar {...props} />);

--- a/src/components/primary-toolbar/primary-toolbar.test.js
+++ b/src/components/primary-toolbar/primary-toolbar.test.js
@@ -18,6 +18,16 @@ describe('PrimaryToolbar', () => {
     expect(wrapper.find('.pipeline-icon-toolbar__button').length).toBe(1);
   });
 
+  it('does not shows the collapse sidebar icon button if diesplay sidebar is false', () => {
+    const visible = {
+      sidebar: false,
+    };
+    const wrapper = setup.mount(
+      <PrimaryToolbar displaySidebar={false} visible={visible} />
+    );
+    expect(wrapper.find('.pipeline-icon-toolbar__button').length).toBe(0);
+  });
+
   it('shows the original menu button when visible sidebar prop is true', () => {
     const visible = {
       sidebar: true,

--- a/src/components/sidebar/sidebar.js
+++ b/src/components/sidebar/sidebar.js
@@ -18,7 +18,6 @@ import './sidebar.css';
 export const Sidebar = ({
   disableRunSelection,
   displayGlobalToolbar,
-  displaySidebar,
   enableComparisonView,
   enableShowChanges,
   isExperimentView = false,
@@ -99,7 +98,6 @@ export const Sidebar = ({
 const mapStateToProps = (state) => ({
   visible: state.visible.sidebar,
   displayGlobalToolbar: state.display.globalToolbar,
-  displaySidebar: state.display.sidebar,
 });
 
 export default connect(mapStateToProps)(Sidebar);

--- a/src/components/sidebar/sidebar.js
+++ b/src/components/sidebar/sidebar.js
@@ -32,6 +32,7 @@ export const Sidebar = ({
   showRunDetailsModal,
   sidebarVisible,
   visible,
+  displayGlobalToolbar,
 }) => {
   const [pipelineIsOpen, togglePipeline] = useState(false);
 
@@ -76,6 +77,7 @@ export const Sidebar = ({
         <div
           className={classnames('pipeline-sidebar', {
             'pipeline-sidebar--visible': visible,
+            'pipeline-sidebar--no-global-toolbar': !displayGlobalToolbar,
           })}
         >
           <div className="pipeline-ui">
@@ -95,6 +97,7 @@ export const Sidebar = ({
 
 const mapStateToProps = (state) => ({
   visible: state.visible.sidebar,
+  displayGlobalToolbar: state.display.globalToolBar,
 });
 
 export default connect(mapStateToProps)(Sidebar);

--- a/src/components/sidebar/sidebar.js
+++ b/src/components/sidebar/sidebar.js
@@ -17,6 +17,8 @@ import './sidebar.css';
  */
 export const Sidebar = ({
   disableRunSelection,
+  displayGlobalToolbar,
+  displaySidebar,
   enableComparisonView,
   enableShowChanges,
   isExperimentView = false,
@@ -32,7 +34,6 @@ export const Sidebar = ({
   showRunDetailsModal,
   sidebarVisible,
   visible,
-  displayGlobalToolbar,
 }) => {
   const [pipelineIsOpen, togglePipeline] = useState(false);
 
@@ -97,7 +98,8 @@ export const Sidebar = ({
 
 const mapStateToProps = (state) => ({
   visible: state.visible.sidebar,
-  displayGlobalToolbar: state.display.globalToolBar,
+  displayGlobalToolbar: state.display.globalToolbar,
+  displaySidebar: state.display.sidebar,
 });
 
 export default connect(mapStateToProps)(Sidebar);

--- a/src/components/sidebar/sidebar.scss
+++ b/src/components/sidebar/sidebar.scss
@@ -9,6 +9,10 @@
   bottom: -1px;
   left: $global-toolbar-width;
 
+  &--no-global-toolbar {
+    left: 0;
+  }
+
   // Ensures sidebar tooltips are above code panel
   z-index: 1;
   display: flex;

--- a/src/components/wrapper/wrapper.js
+++ b/src/components/wrapper/wrapper.js
@@ -70,7 +70,7 @@ export const Wrapper = ({ theme, displayGlobalToolbar }) => {
 export const mapStateToProps = (state) => ({
   loading: isLoading(state),
   theme: state.theme,
-  displayGlobalToolbar: state.display.globalToolBar,
+  displayGlobalToolbar: state.display.globalToolbar,
 });
 
 export default connect(mapStateToProps)(Wrapper);

--- a/src/components/wrapper/wrapper.js
+++ b/src/components/wrapper/wrapper.js
@@ -18,7 +18,7 @@ import './wrapper.css';
 /**
  * Main app container. Handles showing/hiding the sidebar nav, and theme classes.
  */
-export const Wrapper = ({ theme }) => {
+export const Wrapper = ({ theme, displayGlobalToolbar }) => {
   const { data: versionData } = useApolloQuery(GET_VERSIONS, { client });
   const [dismissed, setDismissed] = useState(false);
   const [isOutdated, setIsOutdated] = useState(false);
@@ -41,7 +41,7 @@ export const Wrapper = ({ theme }) => {
       >
         <h1 className="pipeline-title">Kedro-Viz</h1>
         <Router>
-          <GlobalToolbar isOutdated={isOutdated} />
+          {displayGlobalToolbar && <GlobalToolbar isOutdated={isOutdated} />}
           <SettingsModal
             isOutdated={isOutdated}
             latestVersion={latestVersion}
@@ -70,6 +70,7 @@ export const Wrapper = ({ theme }) => {
 export const mapStateToProps = (state) => ({
   loading: isLoading(state),
   theme: state.theme,
+  displayGlobalToolbar: state.display.globalToolBar,
 });
 
 export default connect(mapStateToProps)(Wrapper);

--- a/src/components/wrapper/wrapper.test.js
+++ b/src/components/wrapper/wrapper.test.js
@@ -4,6 +4,7 @@ import { mockState, setup } from '../../utils/state.mock';
 const { theme } = mockState.spaceflights;
 const mockProps = {
   theme,
+  displayGlobalToolbar: true,
 };
 
 describe('Wrapper', () => {
@@ -24,6 +25,7 @@ describe('Wrapper', () => {
     expect(mapStateToProps(mockState.spaceflights)).toEqual({
       loading: false,
       theme,
+      displayGlobalToolbar: true,
     });
   });
 });

--- a/src/components/wrapper/wrapper.test.js
+++ b/src/components/wrapper/wrapper.test.js
@@ -7,6 +7,11 @@ const mockProps = {
   displayGlobalToolbar: true,
 };
 
+const mockPropsNoGlobalToolbar = {
+  theme,
+  displayGlobalToolbar: false,
+};
+
 describe('Wrapper', () => {
   it('renders without crashing', () => {
     const wrapper = setup.shallow(Wrapper, mockProps);
@@ -19,6 +24,12 @@ describe('Wrapper', () => {
     const container = wrapper.find('.kedro-pipeline');
     expect(container.hasClass(`kui-theme--light`)).toBe(theme === 'light');
     expect(container.hasClass(`kui-theme--dark`)).toBe(theme === 'dark');
+  });
+
+  it('does not display the global toolbar when displayGlobalToolbar is false', () => {
+    const wrapper = setup.mount(Wrapper, mockPropsNoGlobalToolbar);
+    const container = wrapper.find('.pipeline-global-toolbar');
+    expect(container.length).toBe(0);
   });
 
   it('maps state to props', () => {

--- a/src/config.js
+++ b/src/config.js
@@ -36,6 +36,12 @@ export const flags = {
     default: true,
     icon: '🐳',
   },
+  expandAllPipelines: {
+    name: 'Expand all modular pipelines',
+    description: 'Expand all modular pipelines on first load',
+    default: false,
+    icon: '🔛',
+  },
 };
 
 export const settings = {

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -62,6 +62,7 @@ const combinedReducer = combineReducers({
   modularPipeline,
   visible,
   // These props don't have any actions associated with them
+  display: createReducer(null),
   dataSource: createReducer(null),
   edge: createReducer({}),
   // These props have very simple non-nested actions

--- a/src/store/initial-state.js
+++ b/src/store/initial-state.js
@@ -36,10 +36,10 @@ export const createInitialState = () => ({
     modularPipelineFocusMode: null,
   },
   display: {
-    globalToolbar: false,
-    sidebar: false,
+    globalToolbar: true,
+    sidebar: true,
     miniMap: true,
-    expandAllPipelines: true,
+    expandAllPipelines: false,
   },
   zoom: {},
 });
@@ -78,6 +78,7 @@ export const preparePipelineState = (data, applyFixes, expandAllPipelines) => {
       state.pipeline.active = state.pipeline.main;
     }
   }
+
   // Cater for expandAllPipelines in component props or within flag
   // expandAllPipelines needs to happen after the deepmerge of localStorage to overwrite
   // any saved visible state of the nodes
@@ -94,6 +95,11 @@ export const preparePipelineState = (data, applyFixes, expandAllPipelines) => {
       if (!modularPipelinesIds.includes(nodeId)) {
         newModularPipelineState.visible[nodeId] = true;
       }
+    });
+
+    console.log('entered here', {
+      ...state.modularPipeline,
+      ...newModularPipelineState,
     });
     return {
       ...state,
@@ -118,8 +124,8 @@ export const prepareNonPipelineState = (props) => {
     newVisibleProps['sidebar'] = false;
   }
 
-  if (props.display?.minimap === false) {
-    newVisibleProps['minimap'] = false;
+  if (props.display?.minimap === false || state.display.miniMap === false) {
+    newVisibleProps['miniMap'] = false;
   }
 
   return {
@@ -139,6 +145,8 @@ export const prepareNonPipelineState = (props) => {
  * @return {object} Initial state
  */
 const getInitialState = (props = {}) => {
+  console.log('props', props);
+
   const nonPipelineState = prepareNonPipelineState(props);
   saveState({
     nodeType: {
@@ -147,7 +155,10 @@ const getInitialState = (props = {}) => {
     },
   });
 
-  const expandAllPipelines = nonPipelineState.display.expandAllPipelines;
+  const expandAllPipelines =
+    nonPipelineState.display.expandAllPipelines ||
+    nonPipelineState.flags.expandAllPipelines;
+
   const pipelineState = preparePipelineState(
     props.data,
     props.data !== 'json',

--- a/src/store/initial-state.js
+++ b/src/store/initial-state.js
@@ -39,7 +39,7 @@ export const createInitialState = () => ({
     globalToolbar: true,
     sidebar: true,
     miniMap: true,
-    expandAllPipelines: true,
+    expandAllPipelines: false,
   },
   zoom: {},
 });

--- a/src/store/initial-state.js
+++ b/src/store/initial-state.js
@@ -80,13 +80,11 @@ export const preparePipelineState = (data, applyFixes, expandAllPipelines) => {
   }
 
   // Cater for expandAllPipelines in component props or within flag
-  // expandAllPipelines needs to happen after the deepmerge of localStorage to overwrite
-  // any saved visible state of the nodes
   if (expandAllPipelines) {
     const modularPipelinesIds = state.modularPipeline.ids;
     const nodeIds = state.node.ids;
 
-    // filter out the nodeIds that is the same id as the modualrPipelines and assign everything else to true
+    // Filter out the nodeIds that is the same id as the modualrPipelines and assign everything else to true
     const newModularPipelineState = {
       visible: {},
       expanded: modularPipelinesIds,
@@ -97,10 +95,6 @@ export const preparePipelineState = (data, applyFixes, expandAllPipelines) => {
       }
     });
 
-    console.log('entered here', {
-      ...state.modularPipeline,
-      ...newModularPipelineState,
-    });
     return {
       ...state,
       modularPipeline: { ...state.modularPipeline, ...newModularPipelineState },
@@ -162,6 +156,7 @@ const getInitialState = (props = {}) => {
     props.data !== 'json',
     expandAllPipelines
   );
+
   return {
     ...nonPipelineState,
     ...pipelineState,

--- a/src/store/initial-state.js
+++ b/src/store/initial-state.js
@@ -39,7 +39,7 @@ export const createInitialState = () => ({
     globalToolbar: true,
     sidebar: true,
     miniMap: true,
-    expandAllPipelines: false,
+    expandAllPipelines: true,
   },
   zoom: {},
 });
@@ -71,7 +71,7 @@ export const mergeLocalStorage = (state) => {
  * @param {boolean} applyFixes Whether to override initialState
  */
 export const preparePipelineState = (data, applyFixes, expandAllPipelines) => {
-  const state = mergeLocalStorage(normalizeData(data));
+  const state = mergeLocalStorage(normalizeData(data, expandAllPipelines));
   if (applyFixes) {
     // Use main pipeline if active pipeline from localStorage isn't recognised
     if (!state.pipeline.ids.includes(state.pipeline.active)) {
@@ -79,27 +79,6 @@ export const preparePipelineState = (data, applyFixes, expandAllPipelines) => {
     }
   }
 
-  // Cater for expandAllPipelines in component props or within flag
-  if (expandAllPipelines) {
-    const modularPipelinesIds = state.modularPipeline.ids;
-    const nodeIds = state.node.ids;
-
-    // Filter out the nodeIds that is the same id as the modualrPipelines and assign everything else to true
-    const newModularPipelineState = {
-      visible: {},
-      expanded: modularPipelinesIds,
-    };
-    nodeIds.forEach((nodeId) => {
-      if (!modularPipelinesIds.includes(nodeId)) {
-        newModularPipelineState.visible[nodeId] = true;
-      }
-    });
-
-    return {
-      ...state,
-      modularPipeline: { ...state.modularPipeline, ...newModularPipelineState },
-    };
-  }
   return state;
 };
 

--- a/src/store/initial-state.js
+++ b/src/store/initial-state.js
@@ -35,6 +35,12 @@ export const createInitialState = () => ({
     miniMap: true,
     modularPipelineFocusMode: null,
   },
+  display: {
+    globalToolBar: false,
+    sidebar: true,
+    miniMap: true,
+    expandAllPipelines: false,
+  },
   zoom: {},
 });
 

--- a/src/store/initial-state.js
+++ b/src/store/initial-state.js
@@ -145,8 +145,6 @@ export const prepareNonPipelineState = (props) => {
  * @return {object} Initial state
  */
 const getInitialState = (props = {}) => {
-  console.log('props', props);
-
   const nonPipelineState = prepareNonPipelineState(props);
   saveState({
     nodeType: {

--- a/src/store/normalize-data.js
+++ b/src/store/normalize-data.js
@@ -190,7 +190,7 @@ const addLayer = (state) => (layer) => {
  * @param {Object} data Raw unformatted data input
  * @return {Object} Formatted, normalized state
  */
-const normalizeData = (data) => {
+const normalizeData = (data, expandAllPipelines) => {
   const state = createInitialPipelineState();
 
   if (data === 'json') {
@@ -215,8 +215,22 @@ const normalizeData = (data) => {
   if (data.modular_pipelines) {
     state.modularPipeline.ids = Object.keys(data.modular_pipelines);
     state.modularPipeline.tree = data.modular_pipelines;
-    for (const child of data.modular_pipelines['__root__'].children) {
-      state.modularPipeline.visible[child.id] = true;
+
+    // Case for expandAllPipelines in component props or within flag
+    if (expandAllPipelines) {
+      // assign all modular pipelines into expanded state
+      state.modularPipeline.expanded = state.modularPipeline.ids;
+      // assign all nodes as visible nodes in modular pipelines
+      const nodeIds = state.node.ids;
+      nodeIds.forEach((nodeId) => {
+        if (!state.modularPipeline.ids.includes(nodeId)) {
+          state.modularPipeline.visible[nodeId] = true;
+        }
+      });
+    } else {
+      for (const child of data.modular_pipelines['__root__'].children) {
+        state.modularPipeline.visible[child.id] = true;
+      }
     }
   }
 

--- a/src/store/normalize-data.test.js
+++ b/src/store/normalize-data.test.js
@@ -57,6 +57,15 @@ describe('normalizeData', () => {
     expect(normalizeData(data).modularPipeline.ids).toHaveLength(0);
   });
 
+  it('should add all mmodualr pipeliens and nodes if expandAllPipelines is true', () => {
+    const data = Object.assign({}, spaceflights);
+
+    const { modularPipeline } = normalizeData(data, true);
+
+    expect(modularPipeline.expanded).toHaveLength(3);
+    expect(Object.keys(modularPipeline.visible)).toHaveLength(19);
+  });
+
   it('should not add layers if layers are not supplied', () => {
     const data = Object.assign({}, spaceflights, { layers: undefined });
     data.nodes.forEach((node) => {

--- a/tools/test-lib/react-app/app.js
+++ b/tools/test-lib/react-app/app.js
@@ -24,22 +24,8 @@ const Radio = ({ current, value, onChange }) => (
 );
 
 const App = ({ initialData }) => {
-  const initialDisplayValues = {
-    globalToolbar: true,
-    sidebar: true,
-    minimap: true,
-    expandAllPipelines: false,
-  };
-
-  const [displayValues, updateDisplayValue] = useState(initialDisplayValues);
-
   const [dataKey, updateDataKey] = useState(initialData);
   const onChange = (e) => updateDataKey(e.target.value);
-  const onUpdateDisplayValue = (e) =>
-    updateDisplayValue({
-      ...displayValues,
-      [e.target.value]: e.target.checked,
-    });
 
   return (
     <div style={{ padding: 30, height: '80vh' }}>
@@ -50,28 +36,7 @@ const App = ({ initialData }) => {
         <Radio value="spaceflights" onChange={onChange} current={dataKey} />
         <Radio value="demo" onChange={onChange} current={dataKey} />
       </p>
-      <div>
-        Display:
-        <input
-          type="checkbox"
-          id="globalToolbar"
-          name="globalToolbar"
-          value="globalToolbar"
-          checked={displayValues.globalToolBar}
-          onChange={onUpdateDisplayValue}
-        />
-        <label for="globalToolbar">Global ToolBar</label>
-        <input
-          type="checkbox"
-          id="sidebar"
-          name="sidebar"
-          value="sidebar"
-          checked={displayValues.sidebar}
-          onChange={onUpdateDisplayValue}
-        />
-        <label for="sidebar">sidebar</label>
-      </div>
-      <KedroViz data={dataSources[dataKey]()} display={displayValues} />
+      <KedroViz data={dataSources[dataKey]()} />
     </div>
   );
 };

--- a/tools/test-lib/react-app/app.js
+++ b/tools/test-lib/react-app/app.js
@@ -24,8 +24,22 @@ const Radio = ({ current, value, onChange }) => (
 );
 
 const App = ({ initialData }) => {
+  const initialDisplayValues = {
+    globalToolbar: true,
+    sidebar: true,
+    minimap: true,
+    expandAllPipelines: false,
+  };
+
+  const [displayValues, updateDisplayValue] = useState(initialDisplayValues);
+
   const [dataKey, updateDataKey] = useState(initialData);
   const onChange = (e) => updateDataKey(e.target.value);
+  const onUpdateDisplayValue = (e) =>
+    updateDisplayValue({
+      ...displayValues,
+      [e.target.value]: e.target.checked,
+    });
 
   return (
     <div style={{ padding: 30, height: '80vh' }}>
@@ -36,7 +50,28 @@ const App = ({ initialData }) => {
         <Radio value="spaceflights" onChange={onChange} current={dataKey} />
         <Radio value="demo" onChange={onChange} current={dataKey} />
       </p>
-      <KedroViz data={dataSources[dataKey]()} />
+      <div>
+        Display:
+        <input
+          type="checkbox"
+          id="globalToolbar"
+          name="globalToolbar"
+          value="globalToolbar"
+          checked={displayValues.globalToolBar}
+          onChange={onUpdateDisplayValue}
+        />
+        <label for="globalToolbar">Global ToolBar</label>
+        <input
+          type="checkbox"
+          id="sidebar"
+          name="sidebar"
+          value="sidebar"
+          checked={displayValues.sidebar}
+          onChange={onUpdateDisplayValue}
+        />
+        <label for="sidebar">sidebar</label>
+      </div>
+      <KedroViz data={dataSources[dataKey]()} display={displayValues} />
     </div>
   );
 };


### PR DESCRIPTION
## Description

resolves #758 

This PR adds a set of input props to define the display of the global Toolbar, sidebar and minimap to allow the display of a simplified version of Kedro-Viz to be consumed as a third party import, as shown below. 

![image (12)](https://user-images.githubusercontent.com/27775658/159339645-364a35d0-220a-4c1b-8a3c-cb603d970a1b.png)

Given that the sidebar display can be omitted, I had added in a special `expandAllPipelines` prop that, on being specified as `true`, will allow all modular pipelines to default to the expanded view on initial load. I have also enabled this feature behind a feature flag to enable power users to access this feature if needed. 

## Development notes

1) I have added in new fields within the redux store to enable the control of the display props to control the behaviour of the app.
2) within the app, I have refactored the behaviour of various components ( sidebar, global toolbar, etc), to display according to the display states. This also includes changes to the css setup to cater for the display adjustments. 
3) I have altered the ingestion engine to allow ingesting the set of newly defined `display` props for the react-component import use case. 
4) I have added a new flag to allow the `expandAllPipelines` feature to also be accessible for power users.
5) I have altered and updated the related tests for this new set of props and fields in the redux store. 

## QA notes

The best way to test the behaviour of the display props is to manually changes the default values of the display props within `initial-state.js` to test the different setup. 

For the `expandAllPipelines` feature, this can be tested via setting the respective flag to `true`.

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [x] Added new entries to the `RELEASE.md` file
- [x] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro-viz/pull/787"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

