### PR TITLE
Feature/show all metrics and table cells

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Live Demo: <a href="https://demo.kedro.org/" target="_blank">https://demo.kedro.
 
 ## Introduction
 
-Kedro-Viz is an interactive development tool for building data science pipelines with [Kedro](https://github.com/kedro-org/kedro). Kedro-Viz also allows users to view and compare different runs in the Kedro project. 
+Kedro-Viz is an interactive development tool for building data science pipelines with [Kedro](https://github.com/kedro-org/kedro). Kedro-Viz also allows users to view and compare different runs in the Kedro project.
 
 ## Features
 
@@ -39,26 +39,26 @@ Kedro-Viz is an interactive development tool for building data science pipelines
 - 🧪 Supports tracking and comparing runs in a Kedro project
 - 🎩 Many more to come
 
-
 ## Installation
 
 There are two ways you can use Kedro-Viz:
 
-* As a [Kedro plugin](https://kedro.readthedocs.io/en/stable/07_extend_kedro/04_plugins.html) (the most common way).
+- As a [Kedro plugin](https://kedro.readthedocs.io/en/stable/07_extend_kedro/04_plugins.html) (the most common way).
 
-    To install Kedro-Viz as a Kedro plugin:
+  To install Kedro-Viz as a Kedro plugin:
 
-    ```bash
-    pip install kedro-viz
-    ```
+  ```bash
+  pip install kedro-viz
+  ```
 
-* As a standalone React component (for embedding Kedro-Viz in your web application).
+- As a standalone React component (for embedding Kedro-Viz in your web application).
 
-   To install the standalone React component:
+  To install the standalone React component:
 
-    ```bash
-    npm install @quantumblack/kedro-viz
-    ```
+  ```bash
+  npm install @quantumblack/kedro-viz
+  ```
+
 ## Usage
 
 ### CLI Usage
@@ -107,7 +107,7 @@ Options:
 
 To enable [experiment tracking](https://kedro.readthedocs.io/en/stable/08_logging/02_experiment_tracking.html) in Kedro-Viz, you need to add the Kedro-Viz `SQLiteStore` to your Kedro project.
 
-This can be done by adding the below code to `settings.py` in the `src` folder of your Kedro project. 
+This can be done by adding the below code to `settings.py` in the `src` folder of your Kedro project.
 
 ```python
 from kedro_viz.integrations.kedro.sqlite_store import SQLiteStore
@@ -120,8 +120,8 @@ Once the above set-up is complete, tracking datasets can be used to track releva
 
 **Notes:**
 
-* Experiment Tracking is only available for Kedro-Viz >= 4.0.2 and Kedro >= 0.17.5
-* Prior to Kedro 0.17.6, when using tracking datasets, you will have to explicitly mark the datasets as `versioned` for it to show up properly in Kedro-Viz experiment tracking tab. From Kedro >= 0.17.6, this is done automatically:
+- Experiment Tracking is only available for Kedro-Viz >= 4.0.2 and Kedro >= 0.17.5
+- Prior to Kedro 0.17.6, when using tracking datasets, you will have to explicitly mark the datasets as `versioned` for it to show up properly in Kedro-Viz experiment tracking tab. From Kedro >= 0.17.6, this is done automatically:
 
 ```yaml
 train_evaluation.r2_score_linear_regression:
@@ -138,12 +138,10 @@ To use Kedro-Viz as a standalone React component, import the component and suppl
 import KedroViz from '@quantumblack/kedro-viz';
 
 const MyApp = () => (
-  <div style={{ height: "100vh" }}>
-    <KedroViz
-      data={json}
-    />
+  <div style={{ height: '100vh' }}>
+    <KedroViz data={json} />
   </div>
-)
+);
 ```
 
 The JSON can be obtained by running:
@@ -158,8 +156,8 @@ We also recommend wrapping the `Kedro-Viz` component with a parent HTML/JSX elem
 
 Kedro-Viz uses features flags to roll out some experimental features. The following flags are currently in use:
 
-| Flag | Description |
-|------| ------------|
+| Flag        | Description                                                                             |
+| ----------- | --------------------------------------------------------------------------------------- |
 | sizewarning | From release v3.9.1. Show a warning before rendering very large graphs (default `true`) |
 
 To enable or disable a flag, click on the settings icon in the toolbar and toggle the flag on/off.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -23,8 +23,8 @@ Please follow the established format:
 - Create a `version` GraphQL query to get versions of Kedro-Viz. (#727)
 - Fix Kedro-Viz to work with projects that have no `__default__` registered pipeline. This also fixes the `--pipeline` CLI option. (#729)
 - Fix lazy pipelines loading causes `get_current_session` to throw an error. (#726, #727)
-- Fix experiment tracking not showing all metrics. (#788)
-- Fix experiment tracking not display the correct empty table cells. (#788)
+- Fix experiment tracking not showing all metrics. (#798)
+- Fix experiment tracking not display the correct empty table cells. (#798)
 
 # Release 4.3.1
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -9,6 +9,7 @@ Please follow the established format:
 -->
 
 ## Major features and improvements
+
 - Set up of a pop-up reminder to nudge users to upgrade Kedro-Viz when a new version is released. (#746)
 - Set up the 'export run' button to allow exporting of selected run data into a csv file for download. (#757)
 
@@ -20,6 +21,8 @@ Please follow the established format:
 - Create a `version` GraphQL query to get versions of Kedro-Viz. (#727)
 - Fix Kedro-Viz to work with projects that have no `__default__` registered pipeline. This also fixes the `--pipeline` CLI option. (#729)
 - Fix lazy pipelines loading causes `get_current_session` to throw an error. (#726, #727)
+- Fix experiment tracking not showing all metrics. (#788)
+- Fix experiment tracking not display the correct empty table cells. (#788)
 
 # Release 4.3.1
 

--- a/demo-project/data/09_tracking/rf_params.json/2021-12-16T09.45.55.269Z/rf_params.json
+++ b/demo-project/data/09_tracking/rf_params.json/2021-12-16T09.45.55.269Z/rf_params.json
@@ -11,5 +11,6 @@
   "oob_score": false,
   "verbose": 0,
   "warm_start": false,
-  "ccp_alpha": 0
+  "ccp_alpha": 0,
+  "model_author": "richard feynman"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5561,12 +5561,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001260",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001260.tgz",
-      "integrity": "sha512-Fhjc/k8725ItmrvW5QomzxLeojewxvqiYCKeFcfFEhut28IVLdpHU19dneOmltZQIE5HNbawj1HYD+1f2bM1Dg==",
-      "requires": {
-        "nanocolors": "^0.1.0"
-      }
+      "version": "1.0.30001322",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001322.tgz",
+      "integrity": "sha512-neRmrmIrCGuMnxGSoh+x7zYtQFFgnSY2jaomjU56sCkTA6JINqQrxutF459JpWcWRajvoyn95sOXq4Pqrnyjew=="
     },
     "canvas": {
       "version": "2.8.0",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   },
   "dependencies": {
     "@apollo/client": "^3.5.6",
+    "@faker-js/faker": "^6.0.0-beta.0",
     "@graphql-tools/schema": "7.1.5",
     "@material-ui/core": "^4.11.4",
     "@material-ui/icons": "^4.11.2",
@@ -55,7 +56,6 @@
     "d3-zoom": "^2.0.0",
     "dayjs": "^1.10.7",
     "deepmerge": "^4.2.2",
-    "@faker-js/faker": "^6.0.0-beta.0",
     "fetch-mock": "^9.11.0",
     "fishery": "^1.4.0",
     "graphql": "^15.8.0",

--- a/src/components/experiment-tracking/details/details.js
+++ b/src/components/experiment-tracking/details/details.js
@@ -66,6 +66,7 @@ const Details = ({
           enableShowChanges={enableShowChanges}
           isSingleRun={isSingleRun}
           pinnedRun={pinnedRun}
+          selectedRunIds={selectedRunIds}
           trackingData={runTrackingData}
         />
       </div>

--- a/src/components/experiment-tracking/details/details.js
+++ b/src/components/experiment-tracking/details/details.js
@@ -12,6 +12,8 @@ const Details = ({
   metadataError,
   onRunSelection,
   pinnedRun,
+  runMetadata,
+  runTrackingData,
   selectedRunIds,
   setPinnedRun,
   setShowRunDetailsModal,
@@ -19,8 +21,6 @@ const Details = ({
   sidebarVisible,
   theme,
   trackingDataError,
-  runMetadata,
-  runTrackingData,
 }) => {
   const [runMetadataToEdit, setRunMetadataToEdit] = useState(null);
 

--- a/src/components/experiment-tracking/run-dataset/run-dataset.js
+++ b/src/components/experiment-tracking/run-dataset/run-dataset.js
@@ -33,7 +33,10 @@ const resolveRunDataWithPin = (runData, pinnedRun) => {
 
 /**
  * Display the dataset of the experiment tracking run.
- * @param {array} props.isSingleRun Whether or not this is a single run.
+ * @param {boolean} props.enableShowChanges Are changes enabled or not.
+ * @param {boolean} props.isSingleRun Whether or not this is a single run.
+ * @param {string} props.pinnedRun ID of the pinned run.
+ * @param {array} props.selectedRunIds Array of strings of runIds.
  * @param {array} props.trackingData The experiment tracking run data.
  */
 const RunDataset = ({
@@ -89,6 +92,9 @@ const RunDataset = ({
  * @param {array} datasetValues A single dataset array from a run.
  * @param {number} rowIndex The array index of the dataset data.
  * @param {boolean} isSingleRun Whether or not this is a single run.
+ * @param {string} pinnedRun ID of the pinned run.
+ * @param {boolean} enableShowChanges Are changes enabled or not.
+ * @param {array} selectedRunIds Array of strings of runIds.
  */
 function buildDatasetDataMarkup(
   datasetKey,
@@ -149,7 +155,18 @@ function buildDatasetDataMarkup(
   );
 }
 
+/**
+ * Fill in missing run metrics if they don't match the number of runIds.
+ * @param {array} datasetValues Array of objects for a metric, e.g. r2_score.
+ * @param {array} selectedRunIds Array of strings of runIds.
+ * @returns Array of objects, the length of which matches the length
+ * of the selectedRunIds.
+ */
 function fillEmptyMetrics(datasetValues, selectedRunIds) {
+  if (datasetValues.length === selectedRunIds.length) {
+    return datasetValues;
+  }
+
   const metrics = [];
 
   selectedRunIds.forEach((id) => {
@@ -157,7 +174,7 @@ function fillEmptyMetrics(datasetValues, selectedRunIds) {
       return item.runId === id;
     });
 
-    // We didn't find a metric with this runID, so add a placeholder
+    // We didn't find a metric with this runId, so add a placeholder.
     if (foundIdIndex === -1) {
       metrics.push({ runId: id, value: null });
     } else {

--- a/src/components/experiment-tracking/run-dataset/run-dataset.js
+++ b/src/components/experiment-tracking/run-dataset/run-dataset.js
@@ -34,7 +34,7 @@ const resolveRunDataWithPin = (runData, pinnedRun) => {
 /**
  * Display the dataset of the experiment tracking run.
  * @param {boolean} props.enableShowChanges Are changes enabled or not.
- * @param {boolean} props.isSingleRun Whether or not this is a single run.
+ * @param {boolean} props.isSingleRun Indication to display a single run.
  * @param {string} props.pinnedRun ID of the pinned run.
  * @param {array} props.selectedRunIds Array of strings of runIds.
  * @param {array} props.trackingData The experiment tracking run data.

--- a/src/components/experiment-tracking/run-dataset/run-dataset.js
+++ b/src/components/experiment-tracking/run-dataset/run-dataset.js
@@ -37,10 +37,11 @@ const resolveRunDataWithPin = (runData, pinnedRun) => {
  * @param {array} props.trackingData The experiment tracking run data.
  */
 const RunDataset = ({
-  isSingleRun,
-  trackingData = [],
-  pinnedRun,
   enableShowChanges,
+  isSingleRun,
+  pinnedRun,
+  selectedRunIds,
+  trackingData = [],
 }) => {
   return (
     <div
@@ -61,7 +62,9 @@ const RunDataset = ({
             size="large"
           >
             {Object.keys(data)
-              .sort()
+              .sort((a, b) => {
+                return a.localeCompare(b);
+              })
               .map((key, rowIndex) => {
                 return buildDatasetDataMarkup(
                   key,
@@ -69,7 +72,8 @@ const RunDataset = ({
                   rowIndex,
                   isSingleRun,
                   pinnedRun,
-                  enableShowChanges
+                  enableShowChanges,
+                  selectedRunIds
                 );
               })}
           </Accordion>
@@ -92,10 +96,11 @@ function buildDatasetDataMarkup(
   rowIndex,
   isSingleRun,
   pinnedRun,
-  enableShowChanges
+  enableShowChanges,
+  selectedRunIds
 ) {
-  // function to return new set of runData with appropriate pin from datasetValues and pinnedRun
-  const runDataWithPin = resolveRunDataWithPin(datasetValues, pinnedRun);
+  const updatedDatasetValues = fillEmptyMetrics(datasetValues, selectedRunIds);
+  const runDataWithPin = resolveRunDataWithPin(updatedDatasetValues, pinnedRun);
 
   return (
     <React.Fragment key={datasetKey + rowIndex}>
@@ -142,6 +147,25 @@ function buildDatasetDataMarkup(
       </div>
     </React.Fragment>
   );
+}
+
+function fillEmptyMetrics(datasetValues, selectedRunIds) {
+  const metrics = [];
+
+  selectedRunIds.forEach((id) => {
+    const foundIdIndex = datasetValues.findIndex((item) => {
+      return item.runId === id;
+    });
+
+    // We didn't find a metric with this runID, so add a placeholder
+    if (foundIdIndex === -1) {
+      metrics.push({ runId: id, value: null });
+    } else {
+      metrics.push(datasetValues[foundIdIndex]);
+    }
+  });
+
+  return metrics;
 }
 
 export default RunDataset;

--- a/src/components/experiment-tracking/run-dataset/run-dataset.test.js
+++ b/src/components/experiment-tracking/run-dataset/run-dataset.test.js
@@ -38,6 +38,7 @@ describe('RunDataset', () => {
     const wrapper = shallow(
       <RunDataset
         isSingleRun={runs.length === 1 ? true : false}
+        selectedRunIds={['abc']}
         trackingData={trackingData}
       />
     );
@@ -48,7 +49,11 @@ describe('RunDataset', () => {
 
   it('renders a boolean value as a string', () => {
     const wrapper = mount(
-      <RunDataset isSingleRun={true} trackingData={booleanTrackingData} />
+      <RunDataset
+        isSingleRun={true}
+        selectedRunIds={['abc']}
+        trackingData={booleanTrackingData}
+      />
     );
 
     expect(wrapper.find('.details-dataset__value').text()).toBe('false');
@@ -56,7 +61,11 @@ describe('RunDataset', () => {
 
   it('renders a boolean value as a string', () => {
     const wrapper = mount(
-      <RunDataset isSingleRun={true} trackingData={ObjectTrackingData} />
+      <RunDataset
+        isSingleRun={true}
+        selectedRunIds={['abc']}
+        trackingData={ObjectTrackingData}
+      />
     );
 
     const datasetValue = wrapper.find('.details-dataset__value').text();
@@ -67,10 +76,11 @@ describe('RunDataset', () => {
   it('renders the comparison arrow when showChanges is on', () => {
     const wrapper = mount(
       <RunDataset
-        isSingleRun={false}
-        trackingData={ComparisonTrackingData}
         enableShowChanges={true}
+        isSingleRun={false}
         pinnedRun={'My Favorite Sprint'}
+        selectedRunIds={['abc', 'def']}
+        trackingData={ComparisonTrackingData}
       />
     );
 

--- a/src/components/experiment-tracking/run-dataset/run-dataset.test.js
+++ b/src/components/experiment-tracking/run-dataset/run-dataset.test.js
@@ -41,7 +41,7 @@ const showDiffTrackingData = [
         { runId: 'My Favorite Sprint', value: 12 },
         { runId: 'My second Favorite Sprint', value: 13 },
       ],
-      r2Score: [{ runId: 'My Favorite Sprint', value: 0.2342356 }],
+      r2Score: [{ runId: 'My second Favorite Sprint', value: 0.2342356 }],
     },
   },
 ];
@@ -109,6 +109,8 @@ describe('RunDataset', () => {
       />
     );
 
-    expect(wrapper.find('.details-dataset__value').last().text()).toBe('-');
+    console.log(wrapper.debug());
+
+    expect(wrapper.find('.details-dataset__value').at(2).text()).toBe('-');
   });
 });

--- a/src/components/experiment-tracking/run-dataset/run-dataset.test.js
+++ b/src/components/experiment-tracking/run-dataset/run-dataset.test.js
@@ -103,7 +103,7 @@ describe('RunDataset', () => {
   it('for runs with different metrics, it renders a cell with a - value', () => {
     const wrapper = mount(
       <RunDataset
-        isSingleRun={true}
+        isSingleRun={false}
         selectedRunIds={['My Favorite Sprint', 'My second Favorite Sprint']}
         trackingData={showDiffTrackingData}
       />

--- a/src/components/experiment-tracking/run-dataset/run-dataset.test.js
+++ b/src/components/experiment-tracking/run-dataset/run-dataset.test.js
@@ -12,7 +12,7 @@ const booleanTrackingData = [
   },
 ];
 
-const ObjectTrackingData = [
+const objectTrackingData = [
   {
     datasetName: 'Data Analysis',
     data: {
@@ -21,7 +21,7 @@ const ObjectTrackingData = [
   },
 ];
 
-const ComparisonTrackingData = [
+const comparisonTrackingData = [
   {
     datasetName: 'Data Analysis',
     data: {
@@ -29,6 +29,19 @@ const ComparisonTrackingData = [
         { runId: 'My Favorite Sprint', value: 12 },
         { runId: 'My second Favorite Sprint', value: 13 },
       ],
+    },
+  },
+];
+
+const showDiffTrackingData = [
+  {
+    datasetName: 'Data Analysis',
+    data: {
+      classWeight: [
+        { runId: 'My Favorite Sprint', value: 12 },
+        { runId: 'My second Favorite Sprint', value: 13 },
+      ],
+      r2Score: [{ runId: 'My Favorite Sprint', value: 0.2342356 }],
     },
   },
 ];
@@ -64,7 +77,7 @@ describe('RunDataset', () => {
       <RunDataset
         isSingleRun={true}
         selectedRunIds={['abc']}
-        trackingData={ObjectTrackingData}
+        trackingData={objectTrackingData}
       />
     );
 
@@ -80,10 +93,22 @@ describe('RunDataset', () => {
         isSingleRun={false}
         pinnedRun={'My Favorite Sprint'}
         selectedRunIds={['abc', 'def']}
-        trackingData={ComparisonTrackingData}
+        trackingData={comparisonTrackingData}
       />
     );
 
     expect(wrapper.find('.dataset-arrow-icon').length).toBe(1);
+  });
+
+  it('for runs with different metrics, it renders a cell with a - value', () => {
+    const wrapper = mount(
+      <RunDataset
+        isSingleRun={true}
+        selectedRunIds={['My Favorite Sprint', 'My second Favorite Sprint']}
+        trackingData={showDiffTrackingData}
+      />
+    );
+
+    expect(wrapper.find('.details-dataset__value').last().text()).toBe('-');
   });
 });

--- a/src/components/experiment-wrapper/experiment-wrapper.js
+++ b/src/components/experiment-wrapper/experiment-wrapper.js
@@ -14,7 +14,7 @@ import Sidebar from '../sidebar';
 
 import './experiment-wrapper.css';
 
-const MAX_NUMBER_COMPARISONS = 2; // 0-based, so three
+const MAX_NUMBER_COMPARISONS = 2; // 0-based, so three.
 
 const ExperimentWrapper = ({ theme }) => {
   const [disableRunSelection, setDisableRunSelection] = useState(false);
@@ -26,9 +26,10 @@ const ExperimentWrapper = ({ theme }) => {
   const [selectedRunData, setSelectedRunData] = useState(null);
   const [showRunDetailsModal, setShowRunDetailsModal] = useState(false);
 
+  // Fetch all runs.
   const { subscribeToMore, data, loading } = useApolloQuery(GET_RUNS);
 
-  // Fetch all metadata and tracking data from selected runs
+  // Fetch all metadata for selected runs.
   const { data: { runMetadata } = [], metadataError } = useApolloQuery(
     GET_RUN_METADATA,
     {
@@ -37,6 +38,7 @@ const ExperimentWrapper = ({ theme }) => {
     }
   );
 
+  // Fetch all tracking data for selected runs.
   const { data: { runTrackingData } = [], error: trackingDataError } =
     useApolloQuery(GET_RUN_TRACKING_DATA, {
       skip: selectedRunIds.length === 0,
@@ -163,8 +165,8 @@ const ExperimentWrapper = ({ theme }) => {
             isExperimentView
             onRunSelection={onRunSelection}
             onToggleComparisonView={onToggleComparisonView}
-            runsListData={data.runsList}
             runMetadata={runMetadata}
+            runsListData={data.runsList}
             runTrackingData={runTrackingData}
             selectedRunData={selectedRunData}
             selectedRunIds={selectedRunIds}
@@ -177,9 +179,11 @@ const ExperimentWrapper = ({ theme }) => {
             <Details
               enableComparisonView={enableComparisonView}
               enableShowChanges={enableShowChanges && selectedRunIds.length > 1}
-              onRunSelection={onRunSelection}
               metadataError={metadataError}
+              onRunSelection={onRunSelection}
               pinnedRun={pinnedRun}
+              runMetadata={runMetadata}
+              runTrackingData={runTrackingData}
               selectedRunIds={selectedRunIds}
               setPinnedRun={setPinnedRun}
               setShowRunDetailsModal={setShowRunDetailsModal}
@@ -187,8 +191,6 @@ const ExperimentWrapper = ({ theme }) => {
               sidebarVisible={isSidebarVisible}
               theme={theme}
               trackingDataError={trackingDataError}
-              runMetadata={runMetadata}
-              runTrackingData={runTrackingData}
             />
           ) : null}
         </>

--- a/src/components/experiment-wrapper/experiment-wrapper.js
+++ b/src/components/experiment-wrapper/experiment-wrapper.js
@@ -40,7 +40,7 @@ const ExperimentWrapper = ({ theme }) => {
   const { data: { runTrackingData } = [], error: trackingDataError } =
     useApolloQuery(GET_RUN_TRACKING_DATA, {
       skip: selectedRunIds.length === 0,
-      variables: { runIds: selectedRunIds, showDiff: false },
+      variables: { runIds: selectedRunIds, showDiff: true },
     });
 
   const onRunSelection = (id) => {

--- a/src/components/ui/button/button.scss
+++ b/src/components/ui/button/button.scss
@@ -31,7 +31,7 @@ $secondary-underline-offset-hover: 4px;
 
 .button__btn {
   font-size: 1.6em;
-  line-height: 1em;
+  line-height: 1.3;
   font-weight: 600;
   letter-spacing: 0.1px;
   color: var(--color-button__text);
@@ -53,6 +53,7 @@ $secondary-underline-offset-hover: 4px;
 .button__btn--small {
   font-size: 1.4em;
   letter-spacing: 0.1px;
+  line-height: 1.4;
   padding: 0.6em 0.85em 0.7em;
 }
 
@@ -62,6 +63,10 @@ $secondary-underline-offset-hover: 4px;
     outline-width: 0;
     color: var(--color-button__text--hover);
     background: var(--color-button--active);
+  }
+
+  &:focus {
+    box-shadow: 0 0 0 7px $color-accent-blue;
   }
 
   &:hover {
@@ -90,6 +95,10 @@ $secondary-underline-offset-hover: 4px;
     transition: transform ease 0.1s, background ease 0.1s;
 
     background: none;
+  }
+
+  &:focus {
+    outline: 4px solid $color-accent-blue;
   }
 
   &:hover::after {


### PR DESCRIPTION
## Description

Resolves #773 and #780.

## Development notes

First, I set `showDiff` to true in the `experiment-wrapper.js` file.

Next, the real crux of this is the `fillEmptyMetrics()` function in the `run-dataset.js` file. This is what fills in the empty data, which results in the correct empty cells in the table now being displayed.

I also added some comments to the code and expanded on some that were already there, as they were lacking some arguments.

I found some missing styles on the `focus` states on the buttons, too, so I've added those in.

There are some smaller changes here as well, mostly resulting from auto formatting the readme and release notes file.

Lastly, I was seeing this console warning:

```bash
Browserslist: caniuse-lite is outdated. Please run:
  npx browserslist@latest --update-db
```

so I ran that command, and that's why there are changes in the `package.json` and `package-lock.json` files.

## QA notes

To test this, select the run with the name `2021-12-16T09.45.55.269Z`. That has a metric called `model_author` with the value of `richard feynman`. That differs from any of the other runs. If you select this run along with any of the others, you should be able to see that this metric is shown and the other runs that don't have this metric have the `-` in the table cell(s).

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [x] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro-viz/pull/798"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

