### PR TITLE
Bump uvicorn

### DIFF
--- a/package/requirements.txt
+++ b/package/requirements.txt
@@ -3,7 +3,7 @@ kedro>=0.16.0
 ipython>=7.0.0, <8.0
 fastapi>=0.63.0, <0.67.0
 aiofiles==0.6.0
-uvicorn[standard]~=0.13.4
+uvicorn[standard]~=0.17.0
 watchgod~=0.8.0
 plotly>=4.0
 pandas>=0.24


### PR DESCRIPTION
## Description

For compatibility with the kedro 0.18 project template (which includes `black`) we need to bump uvicorn to get a compatible version of click. We need to go to at least `uvicorn>=0.15.0` for them to open up the click range, but I dont' see any reason to not bump to the latest `0.17.x` if that passes CI. The current requirement of `~=0.13.4` was set in https://github.com/kedro-org/kedro-viz/pull/577.

Currently `echo -e  "black \n uvicorn[standard]~=0.13.4" | pip-compile - -o -` gives:

```
Could not find a version that matches click==7.*,>=8.0.0 (from black==22.3.0->-r -)
Tried: 0.1, 0.1, 0.2, 0.2, 0.3, 0.3, 0.4, 0.4, 0.5, 0.5, 0.5.1, 0.5.1, 0.6, 0.6, 0.7, 0.7, 1.0, 1.0, 1.1, 1.1, 2.0, 2.0, 2.1, 2.1, 2.2, 2.2, 2.3, 2.3, 2.4, 2.4, 2.5, 2.5, 2.6, 2.6, 3.0, 3.0, 3.1, 3.1, 3.2, 3.2, 3.3, 3.3, 4.0, 4.0, 4.1, 4.1, 5.0, 5.0, 5.1, 5.1, 6.0, 6.0, 6.1, 6.1, 6.2, 6.2, 6.3, 6.3, 6.4, 6.4, 6.5, 6.6, 6.6, 6.7, 6.7, 7.0, 7.0, 7.1, 7.1, 7.1.1, 7.1.1, 7.1.2, 7.1.2, 8.0.0, 8.0.0, 8.0.1, 8.0.1, 8.0.2, 8.0.2, 8.0.3, 8.0.3, 8.0.4, 8.0.4, 8.1.0, 8.1.0, 8.1.1, 8.1.1
Skipped pre-versions: 6.7.dev0, 8.0.0a1, 8.0.0a1, 8.0.0rc1, 8.0.0rc1
There are incompatible versions in the resolved dependencies:
  click>=8.0.0 (from black==22.3.0->-r -)
  click==7.* (from uvicorn[standard]==0.13.4->-r -)
```

Now `echo -e  "black \n uvicorn[standard]~=0.17.0" | pip-compile - -o -` compiles nicely.

## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes
