### PR TITLE
Post kedro 0.18 release fixes

### DIFF
--- a/package/tests/conftest.py
+++ b/package/tests/conftest.py
@@ -29,32 +29,28 @@ def example_pipelines():
         ...
 
     data_processing_pipeline = pipeline(
-        Pipeline(
-            [
-                node(
-                    process_data,
-                    inputs=["raw_data", "params:train_test_split"],
-                    outputs="model_inputs",
-                    name="process_data",
-                    tags=["split"],
-                )
-            ]
-        ),
+        [
+            node(
+                process_data,
+                inputs=["raw_data", "params:train_test_split"],
+                outputs="model_inputs",
+                name="process_data",
+                tags=["split"],
+            )
+        ],
         namespace="uk.data_processing",
         outputs="model_inputs",
     )
     data_science_pipeline = pipeline(
-        Pipeline(
-            [
-                node(
-                    train_model,
-                    inputs=["model_inputs", "parameters"],
-                    outputs="model",
-                    name="train_model",
-                    tags=["train"],
-                )
-            ]
-        ),
+        [
+            node(
+                train_model,
+                inputs=["model_inputs", "parameters"],
+                outputs="model",
+                name="train_model",
+                tags=["train"],
+            )
+        ],
         namespace="uk.data_science",
         inputs="model_inputs",
     )
@@ -75,7 +71,7 @@ def example_catalog():
         },
         feed_dict={
             "parameters": {"train_test_split": 0.1, "num_epochs": 1000},
-            "params:train_test_split": 0.1,
+            "params:uk.data_processing.train_test_split": 0.1,
         },
         layers={
             "raw": {
@@ -95,24 +91,22 @@ def example_transcoded_pipelines():
         ...
 
     data_processing_pipeline = pipeline(
-        Pipeline(
-            [
-                node(
-                    process_data,
-                    inputs=["raw_data", "params:train_test_split"],
-                    outputs="model_inputs@spark",
-                    name="process_data",
-                    tags=["split"],
-                ),
-                node(
-                    train_model,
-                    inputs=["model_inputs@pandas", "parameters"],
-                    outputs="model",
-                    name="train_model",
-                    tags=["train"],
-                ),
-            ]
-        ),
+        [
+            node(
+                process_data,
+                inputs=["raw_data", "params:uk.data_processing.train_test_split"],
+                outputs="model_inputs@spark",
+                name="process_data",
+                tags=["split"],
+            ),
+            node(
+                train_model,
+                inputs=["model_inputs@pandas", "parameters"],
+                outputs="model",
+                name="train_model",
+                tags=["train"],
+            ),
+        ]
     )
 
     yield {
@@ -130,7 +124,7 @@ def example_transcoded_catalog():
         },
         feed_dict={
             "parameters": {"train_test_split": 0.1, "num_epochs": 1000},
-            "params:train_test_split": 0.1,
+            "params:uk.data_processing.train_test_split": 0.1,
         },
     )
 

--- a/package/tests/example_pipelines.json
+++ b/package/tests/example_pipelines.json
@@ -1,23 +1,23 @@
 {
   "nodes": [
     {
-      "id": "fdba147b",
+      "id": "f2e4bf0e",
       "name": "Process Data",
       "full_name": "process_data",
       "tags": ["split"],
       "pipelines": ["data_processing", "__default__"],
       "type": "task",
       "modular_pipelines": ["uk", "uk.data_processing"],
-      "parameters": { "train_test_split": 0.1 }
+      "parameters": { "uk.data_processing.train_test_split": 0.1 }
     },
     {
-      "id": "c506f374",
+      "id": "f0ebef01",
       "name": "Params: Train Test Split",
-      "full_name": "params:train_test_split",
+      "full_name": "params:uk.data_processing.train_test_split",
       "tags": ["split"],
       "pipelines": ["data_processing", "__default__"],
       "type": "parameters",
-      "modular_pipelines": [],
+      "modular_pipelines": ["uk", "uk.data_processing"],
       "layer": null,
       "dataset_type": null
     },
@@ -73,7 +73,7 @@
       "type": "data",
       "modular_pipelines": ["uk", "uk.data_science"],
       "layer": null,
-      "dataset_type": "kedro.io.memory_data_set.MemoryDataSet"
+      "dataset_type": "kedro.io.memory_dataset.MemoryDataSet"
     },
     {
       "id": "uk.data_processing",
@@ -112,18 +112,18 @@
   "edges": [
     { "source": "f1f1425b", "target": "7b140b3f" },
     { "source": "0ecea0de", "target": "uk.data_science" },
-    { "source": "c506f374", "target": "uk" },
+    { "source": "f0ebef01", "target": "uk" },
     { "source": "7b140b3f", "target": "d5a8b994" },
-    { "source": "c506f374", "target": "uk.data_processing" },
-    { "source": "13399a82", "target": "fdba147b" },
+    { "source": "f0ebef01", "target": "uk.data_processing" },
+    { "source": "13399a82", "target": "f2e4bf0e" },
     { "source": "uk.data_science", "target": "d5a8b994" },
     { "source": "f1f1425b", "target": "uk" },
     { "source": "0ecea0de", "target": "7b140b3f" },
     { "source": "uk", "target": "d5a8b994" },
     { "source": "f1f1425b", "target": "uk.data_science" },
-    { "source": "fdba147b", "target": "0ecea0de" },
+    { "source": "f2e4bf0e", "target": "0ecea0de" },
     { "source": "uk.data_processing", "target": "0ecea0de" },
-    { "source": "c506f374", "target": "fdba147b" },
+    { "source": "f0ebef01", "target": "f2e4bf0e" },
     { "source": "13399a82", "target": "uk" },
     { "source": "13399a82", "target": "uk.data_processing" }
   ],
@@ -146,24 +146,23 @@
       "children": [
         { "id": "f1f1425b", "type": "parameters" },
         { "id": "uk", "type": "modularPipeline" },
-        { "id": "c506f374", "type": "parameters" },
         { "id": "0ecea0de", "type": "data" }
       ]
     },
     "uk.data_processing": {
       "id": "uk.data_processing",
       "name": "Data Processing",
-      "inputs": ["13399a82", "c506f374"],
+      "inputs": ["13399a82", "f0ebef01"],
       "outputs": ["0ecea0de"],
       "children": [
         { "id": "13399a82", "type": "data" },
-        { "id": "fdba147b", "type": "task" }
+        { "id": "f2e4bf0e", "type": "task" }
       ]
     },
     "uk": {
       "id": "uk",
       "name": "Uk",
-      "inputs": ["13399a82", "c506f374", "f1f1425b"],
+      "inputs": ["13399a82", "f0ebef01", "f1f1425b"],
       "outputs": ["d5a8b994"],
       "children": [
         { "id": "uk.data_science", "type": "modularPipeline" },

--- a/package/tests/test_api/test_apps.py
+++ b/package/tests/test_api/test_apps.py
@@ -71,18 +71,18 @@ def assert_example_data(response_data):
     """Assert graph response for the `example_pipelines` and `example_catalog` fixtures."""
     expected_edges = [
         {"source": "7b140b3f", "target": "d5a8b994"},
-        {"source": "fdba147b", "target": "0ecea0de"},
-        {"source": "13399a82", "target": "fdba147b"},
+        {"source": "f2e4bf0e", "target": "0ecea0de"},
+        {"source": "13399a82", "target": "f2e4bf0e"},
         {"source": "f1f1425b", "target": "7b140b3f"},
         {"source": "0ecea0de", "target": "7b140b3f"},
-        {"source": "c506f374", "target": "fdba147b"},
+        {"source": "f0ebef01", "target": "f2e4bf0e"},
         {"source": "13399a82", "target": "uk.data_processing"},
         {"source": "uk.data_processing", "target": "0ecea0de"},
-        {"source": "c506f374", "target": "uk.data_processing"},
+        {"source": "f0ebef01", "target": "uk.data_processing"},
         {"source": "f1f1425b", "target": "uk"},
         {"source": "13399a82", "target": "uk"},
         {"source": "f1f1425b", "target": "uk.data_science"},
-        {"source": "c506f374", "target": "uk"},
+        {"source": "f0ebef01", "target": "uk"},
         {"source": "uk.data_science", "target": "d5a8b994"},
         {"source": "0ecea0de", "target": "uk.data_science"},
         {"source": "uk", "target": "d5a8b994"},
@@ -93,14 +93,14 @@ def assert_example_data(response_data):
     # compare nodes
     expected_nodes = [
         {
-            "id": "fdba147b",
+            "id": "f2e4bf0e",
             "name": "Process Data",
             "full_name": "process_data",
             "tags": ["split"],
             "pipelines": ["__default__", "data_processing"],
             "modular_pipelines": ["uk", "uk.data_processing"],
             "type": "task",
-            "parameters": {"train_test_split": 0.1},
+            "parameters": {"uk.data_processing.train_test_split": 0.1},
         },
         {
             "id": "13399a82",
@@ -114,12 +114,12 @@ def assert_example_data(response_data):
             "dataset_type": "kedro.extras.datasets.pandas.csv_dataset.CSVDataSet",
         },
         {
-            "id": "c506f374",
+            "id": "f0ebef01",
             "name": "Params: Train Test Split",
-            "full_name": "params:train_test_split",
+            "full_name": "params:uk.data_processing.train_test_split",
             "tags": ["split"],
             "pipelines": ["__default__", "data_processing"],
-            "modular_pipelines": [],
+            "modular_pipelines": ["uk", "uk.data_processing"],
             "type": "parameters",
             "layer": None,
             "dataset_type": None,
@@ -143,7 +143,10 @@ def assert_example_data(response_data):
             "pipelines": ["__default__", "data_science"],
             "modular_pipelines": ["uk", "uk.data_science"],
             "type": "task",
-            "parameters": {"train_test_split": 0.1, "num_epochs": 1000},
+            "parameters": {
+                "train_test_split": 0.1,
+                "num_epochs": 1000,
+            },
         },
         {
             "id": "f1f1425b",
@@ -165,7 +168,7 @@ def assert_example_data(response_data):
             "modular_pipelines": ["uk", "uk.data_science"],
             "type": "data",
             "layer": None,
-            "dataset_type": "kedro.io.memory_data_set.MemoryDataSet",
+            "dataset_type": "kedro.io.memory_dataset.MemoryDataSet",
         },
         {
             "id": "uk.data_processing",
@@ -209,7 +212,6 @@ def assert_example_data(response_data):
             "children": [
                 {"id": "0ecea0de", "type": "data"},
                 {"id": "f1f1425b", "type": "parameters"},
-                {"id": "c506f374", "type": "parameters"},
                 {"id": "uk", "type": "modularPipeline"},
             ],
             "id": "__root__",
@@ -223,17 +225,17 @@ def assert_example_data(response_data):
                 {"id": "uk.data_processing", "type": "modularPipeline"},
             ],
             "id": "uk",
-            "inputs": ["c506f374", "13399a82", "f1f1425b"],
+            "inputs": ["f0ebef01", "13399a82", "f1f1425b"],
             "name": "Uk",
             "outputs": ["d5a8b994"],
         },
         "uk.data_processing": {
             "children": [
                 {"id": "13399a82", "type": "data"},
-                {"id": "fdba147b", "type": "task"},
+                {"id": "f2e4bf0e", "type": "task"},
             ],
             "id": "uk.data_processing",
-            "inputs": ["c506f374", "13399a82"],
+            "inputs": ["f0ebef01", "13399a82"],
             "name": "Data Processing",
             "outputs": ["0ecea0de"],
         },
@@ -270,9 +272,9 @@ def assert_example_transcoded_data(response_data):
     and `example_transcoded_catalog` fixtures."""
     expected_edges = [
         {"source": "f1f1425b", "target": "2302ea78"},
-        {"source": "20c83b96", "target": "0ecea0de"},
-        {"source": "c506f374", "target": "20c83b96"},
-        {"source": "7c58d8e6", "target": "20c83b96"},
+        {"source": "f2b74919", "target": "0ecea0de"},
+        {"source": "f0ebef01", "target": "f2b74919"},
+        {"source": "7c58d8e6", "target": "f2b74919"},
         {"source": "2302ea78", "target": "1d06a0d7"},
         {"source": "0ecea0de", "target": "2302ea78"},
     ]
@@ -282,14 +284,14 @@ def assert_example_transcoded_data(response_data):
     # compare nodes
     expected_nodes = [
         {
-            "id": "20c83b96",
+            "id": "f2b74919",
             "name": "Process Data",
             "full_name": "process_data",
             "tags": ["split"],
             "pipelines": ["__default__", "data_processing"],
             "modular_pipelines": [],
             "type": "task",
-            "parameters": {"train_test_split": 0.1},
+            "parameters": {"uk.data_processing.train_test_split": 0.1},
         },
         {
             "id": "7c58d8e6",
@@ -303,12 +305,12 @@ def assert_example_transcoded_data(response_data):
             "dataset_type": None,
         },
         {
-            "id": "c506f374",
+            "id": "f0ebef01",
             "name": "Params: Train Test Split",
-            "full_name": "params:train_test_split",
+            "full_name": "params:uk.data_processing.train_test_split",
             "tags": ["split"],
             "pipelines": ["__default__", "data_processing"],
-            "modular_pipelines": [],
+            "modular_pipelines": ["uk", "uk.data_processing"],
             "type": "parameters",
             "layer": None,
             "dataset_type": None,
@@ -332,7 +334,10 @@ def assert_example_transcoded_data(response_data):
             "pipelines": ["__default__", "data_processing"],
             "modular_pipelines": [],
             "type": "task",
-            "parameters": {"train_test_split": 0.1, "num_epochs": 1000},
+            "parameters": {
+                "train_test_split": 0.1,
+                "num_epochs": 1000,
+            },
         },
         {
             "id": "f1f1425b",
@@ -465,13 +470,13 @@ class TestNodeMetadataEndpoint:
         assert response.status_code == 404
 
     def test_task_node_metadata(self, client):
-        response = client.get("/api/nodes/fdba147b")
+        response = client.get("/api/nodes/f2e4bf0e")
         metadata = response.json()
         assert (
             metadata["code"].lstrip()
             == "def process_data(raw_data, train_test_split):\n        ...\n"
         )
-        assert metadata["parameters"] == {"train_test_split": 0.1}
+        assert metadata["parameters"] == {"uk.data_processing.train_test_split": 0.1}
         assert metadata["inputs"] == ["Raw Data", "Params: Train Test Split"]
         assert metadata["outputs"] == ["Model Inputs"]
         assert metadata["run_command"] == 'kedro run --to-nodes="process_data"'
@@ -499,12 +504,14 @@ class TestNodeMetadataEndpoint:
         }
 
     def test_single_parameter_node_metadata(self, client):
-        response = client.get("/api/nodes/c506f374")
-        assert response.json() == {"parameters": {"train_test_split": 0.1}}
+        response = client.get("/api/nodes/f0ebef01")
+        assert response.json() == {
+            "parameters": {"uk.data_processing.train_test_split": 0.1}
+        }
 
     def test_no_metadata(self, client):
         with mock.patch.object(TaskNode, "has_metadata", return_value=False):
-            response = client.get("/api/nodes/fdba147b")
+            response = client.get("/api/nodes/f2e4bf0e")
         assert response.json() == {}
 
 
@@ -547,7 +554,10 @@ class TestSinglePipelineEndpoint:
                 "pipelines": ["__default__", "data_science"],
                 "modular_pipelines": ["uk", "uk.data_science"],
                 "type": "task",
-                "parameters": {"train_test_split": 0.1, "num_epochs": 1000},
+                "parameters": {
+                    "train_test_split": 0.1,
+                    "num_epochs": 1000,
+                },
             },
             {
                 "id": "f1f1425b",
@@ -569,7 +579,7 @@ class TestSinglePipelineEndpoint:
                 "modular_pipelines": ["uk", "uk.data_science"],
                 "type": "data",
                 "layer": None,
-                "dataset_type": "kedro.io.memory_data_set.MemoryDataSet",
+                "dataset_type": "kedro.io.memory_dataset.MemoryDataSet",
             },
             {
                 "id": "uk",

--- a/package/tests/test_data_access/test_managers.py
+++ b/package/tests/test_data_access/test_managers.py
@@ -302,7 +302,7 @@ class TestAddPipelines:
             "uk.data_processing.raw_data",
             "model_inputs",
             "parameters",
-            "params:train_test_split",
+            "params:uk.data_processing.train_test_split",
         }
         assert data_access_manager.tags.as_list() == [Tag("split"), Tag("train")]
         assert sorted(data_access_manager.modular_pipelines.as_dict().keys()) == sorted(


### PR DESCRIPTION
## Description

Some fixes are needed after the release of 0.18:
* linting ignores now that `load_context` no longer exists (in https://github.com/kedro-org/kedro-viz/pull/807)
* changes to parameters namespaces in tests
* `memory_data_set` is now `memory_dataset`

## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro-viz/pull/808"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

