### PR TITLE
Bump strawberry-graphql

### DIFF
--- a/package/requirements.txt
+++ b/package/requirements.txt
@@ -8,5 +8,5 @@ watchgod~=0.8.0
 plotly>=4.0
 pandas>=0.24
 sqlalchemy~=1.2
-strawberry-graphql~=0.93.14
+strawberry-graphql>=0.93.14, <1.0
 networkx>=1.0


### PR DESCRIPTION
## Description
Closes #810. As discussed in the issue, I'm deliberately going for a more relaxed range than usual here (i.e. `<1.0`) so we don't have to keep bumping this requirement as strawberry-graphql do [extremely frequent minor releases](https://github.com/strawberry-graphql/strawberry/releases).

There's a (hopefully small) chance this will break kedro-viz in future, but if hat happens we'll know straight away through CI and can then pin the version again as required. 

<a href="https://gitpod.io/#https://github.com/kedro-org/kedro-viz/pull/813"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

