### PR TITLE
Fix CircleCI on main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -158,7 +158,7 @@ commands:
       - restore_cache:
           keys:
             - v0-dependencies-{{ checksum "package.json" }}-{{ checksum "package/requirements.txt" }}-{{ checksum "package/test_requirements.txt" }}
-            # fallback to using the latest 0 if no exact match is found
+            # fallback to using the latest cache if no exact match is found
             - v0-dependencies-
       - setup_python_env
       - install_node_dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,7 +159,7 @@ commands:
           keys:
             - v0-{{ arch }}-dependencies-{{ checksum "package.json" }}-{{ checksum "package/requirements.txt" }}-{{ checksum "package/test_requirements.txt" }}
             # fallback to using the latest cache if no exact match is found
-            - v0-dependencies-
+            - v0-{{ arch }}-dependencies-
       - setup_python_env
       - install_node_dependencies
       - save_cache:
@@ -222,7 +222,7 @@ commands:
           keys:
             - v0-{{ arch }}-dependencies-{{ checksum "package.json" }}-{{ checksum "package/requirements.txt" }}-{{ checksum "package/test_requirements.txt" }}
             # fallback to using the latest cache if no exact match is found
-            - v0-dependencies-
+            - v0-{{ arch }}-dependencies-
       - win_setup_conda
       - win_setup_requirements
       - install_node_dependencies
@@ -231,7 +231,7 @@ commands:
             - node_modules
             - c:\tools\miniconda3\envs\kedro-viz\
             - c:\users\circleci\appdata\local\pip\cache\
-          key: v0--{{ arch }}-dependencies-{{ checksum "package.json" }}-{{ checksum "package/requirements.txt" }}-{{ checksum "package/test_requirements.txt" }}
+          key: v0-{{ arch }}-dependencies-{{ checksum "package.json" }}-{{ checksum "package/requirements.txt" }}-{{ checksum "package/test_requirements.txt" }}
       - run:
           name: Run Python unit tests
           command: |
@@ -289,7 +289,7 @@ jobs:
           keys:
             - v0-{{ arch }}-dependencies-{{ checksum "package.json" }}
              # fallback to using the latest cache if no exact match is found
-            - v0-dependencies-
+            - v0-{{ arch }}-dependencies-
       - install_node_dependencies
       - build_npm_package
       - run:
@@ -310,7 +310,7 @@ jobs:
           keys:
             - v0-{{ arch }}-dependencies-{{ checksum "package.json" }}
              # fallback to using the latest cache if no exact match is found
-            - v0-dependencies-
+            - v0-{{ arch }}-dependencies-
       - setup_python_env
       - run:
           name: Install twine

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -157,7 +157,7 @@ commands:
       - checkout
       - restore_cache:
           keys:
-            - v0-dependencies-{{ checksum "package.json" }}-{{ checksum "package/requirements.txt" }}-{{ checksum "package/test_requirements.txt" }}
+            - v0-{{ arch }}-dependencies-{{ checksum "package.json" }}-{{ checksum "package/requirements.txt" }}-{{ checksum "package/test_requirements.txt" }}
             # fallback to using the latest cache if no exact match is found
             - v0-dependencies-
       - setup_python_env
@@ -167,7 +167,7 @@ commands:
             - node_modules
             - /home/circleci/.venvs/kedro-viz
             - /home/circleci/.cache/pip/
-          key: v0-dependencies-{{ checksum "package.json" }}-{{ checksum "package/requirements.txt" }}-{{ checksum "package/test_requirements.txt" }}
+          key: v0-{{ arch }}-dependencies-{{ checksum "package.json" }}-{{ checksum "package/requirements.txt" }}-{{ checksum "package/test_requirements.txt" }}
       - test_lib_transpilation
       - test_lib_import
       - run_eslint
@@ -220,7 +220,7 @@ commands:
       - checkout
       - restore_cache:
           keys:
-            - v0-dependencies-{{ checksum "package.json" }}-{{ checksum "package/requirements.txt" }}-{{ checksum "package/test_requirements.txt" }}
+            - v0-{{ arch }}-dependencies-{{ checksum "package.json" }}-{{ checksum "package/requirements.txt" }}-{{ checksum "package/test_requirements.txt" }}
             # fallback to using the latest cache if no exact match is found
             - v0-dependencies-
       - win_setup_conda
@@ -231,7 +231,7 @@ commands:
             - node_modules
             - c:\tools\miniconda3\envs\kedro-viz\
             - c:\users\circleci\appdata\local\pip\cache\
-          key: v0-dependencies-{{ checksum "package.json" }}-{{ checksum "package/requirements.txt" }}-{{ checksum "package/test_requirements.txt" }}
+          key: v0--{{ arch }}-dependencies-{{ checksum "package.json" }}-{{ checksum "package/requirements.txt" }}-{{ checksum "package/test_requirements.txt" }}
       - run:
           name: Run Python unit tests
           command: |
@@ -287,7 +287,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - v0-dependencies-{{ checksum "package.json" }}
+            - v0-{{ arch }}-dependencies-{{ checksum "package.json" }}
              # fallback to using the latest cache if no exact match is found
             - v0-dependencies-
       - install_node_dependencies
@@ -308,7 +308,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - v0-dependencies-{{ checksum "package.json" }}
+            - v0-{{ arch }}-dependencies-{{ checksum "package.json" }}
              # fallback to using the latest cache if no exact match is found
             - v0-dependencies-
       - setup_python_env

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -157,9 +157,9 @@ commands:
       - checkout
       - restore_cache:
           keys:
-            - v${CACHE_VERSION}-{{ arch }}-dependencies-{{ checksum "package.json" }}-{{ checksum "package/requirements.txt" }}-{{ checksum "package/test_requirements.txt" }}
-            # fallback to using the latest cache if no exact match is found
-            - v${CACHE_VERSION}-{{ arch }}-dependencies-
+            - v0-dependencies-{{ checksum "package.json" }}-{{ checksum "package/requirements.txt" }}-{{ checksum "package/test_requirements.txt" }}
+            # fallback to using the latest 0 if no exact match is found
+            - v0-dependencies-
       - setup_python_env
       - install_node_dependencies
       - save_cache:
@@ -167,7 +167,7 @@ commands:
             - node_modules
             - /home/circleci/.venvs/kedro-viz
             - /home/circleci/.cache/pip/
-          key: v${CACHE_VERSION}-{{ arch }}-dependencies-{{ checksum "package.json" }}-{{ checksum "package/requirements.txt" }}-{{ checksum "package/test_requirements.txt" }}
+          key: v0-dependencies-{{ checksum "package.json" }}-{{ checksum "package/requirements.txt" }}-{{ checksum "package/test_requirements.txt" }}
       - test_lib_transpilation
       - test_lib_import
       - run_eslint
@@ -220,9 +220,9 @@ commands:
       - checkout
       - restore_cache:
           keys:
-            - v${CACHE_VERSION}-{{ arch }}-dependencies-{{ checksum "package.json" }}-{{ checksum "package/requirements.txt" }}-{{ checksum "package/test_requirements.txt" }}
+            - v0-dependencies-{{ checksum "package.json" }}-{{ checksum "package/requirements.txt" }}-{{ checksum "package/test_requirements.txt" }}
             # fallback to using the latest cache if no exact match is found
-            - v${CACHE_VERSION}-{{ arch }}-dependencies-
+            - v0-dependencies-
       - win_setup_conda
       - win_setup_requirements
       - install_node_dependencies
@@ -231,7 +231,7 @@ commands:
             - node_modules
             - c:\tools\miniconda3\envs\kedro-viz\
             - c:\users\circleci\appdata\local\pip\cache\
-          key: v${CACHE_VERSION}-{{ arch }}-dependencies-{{ checksum "package.json" }}-{{ checksum "package/requirements.txt" }}-{{ checksum "package/test_requirements.txt" }}
+          key: v0-dependencies-{{ checksum "package.json" }}-{{ checksum "package/requirements.txt" }}-{{ checksum "package/test_requirements.txt" }}
       - run:
           name: Run Python unit tests
           command: |
@@ -287,8 +287,9 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - v${CACHE_VERSION}-{{ arch }}-dependencies-{{ checksum "package.json" }}
-            - v${CACHE_VERSION}-{{ arch }}-dependencies-
+            - v0-dependencies-{{ checksum "package.json" }}
+             # fallback to using the latest cache if no exact match is found
+            - v0-dependencies-
       - install_node_dependencies
       - build_npm_package
       - run:
@@ -307,9 +308,9 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - v${CACHE_VERSION}-{{ arch }}-dependencies-{{ checksum "package.json" }}
-            # fallback to using the latest cache if no exact match is found
-            - v${CACHE_VERSION}-{{ arch }}-dependencies-
+            - v0-dependencies-{{ checksum "package.json" }}
+             # fallback to using the latest cache if no exact match is found
+            - v0-dependencies-
       - setup_python_env
       - run:
           name: Install twine

--- a/demo-project/src/demo_project/requirements.in
+++ b/demo-project/src/demo_project/requirements.in
@@ -1,4 +1,4 @@
-black==21.5b1
+black~=22.0
 flake8>=3.7.9, <4.0
 ipython~=7.0
 isort~=5.0

--- a/demo-project/src/demo_project/requirements.in
+++ b/demo-project/src/demo_project/requirements.in
@@ -1,4 +1,4 @@
-black~=22.0
+black==21.3
 flake8>=3.7.9, <4.0
 ipython~=7.0
 isort~=5.0

--- a/demo-project/src/demo_project/requirements.in
+++ b/demo-project/src/demo_project/requirements.in
@@ -1,4 +1,4 @@
-black==21.3
+black==21.5b
 flake8>=3.7.9, <4.0
 ipython~=7.0
 isort~=5.0

--- a/demo-project/src/demo_project/requirements.in
+++ b/demo-project/src/demo_project/requirements.in
@@ -1,4 +1,4 @@
-black==21.5b
+black==21.5b1
 flake8>=3.7.9, <4.0
 ipython~=7.0
 isort~=5.0

--- a/package/kedro_viz/api/graphql.py
+++ b/package/kedro_viz/api/graphql.py
@@ -41,7 +41,6 @@ if TYPE_CHECKING:  # pragma: no cover
         https://github.com/python/mypy/issues/2477
         """
 
-
 else:
     JSONObject = strawberry.scalar(
         NewType("JSONObject", dict),

--- a/package/test_requirements.txt
+++ b/package/test_requirements.txt
@@ -3,7 +3,7 @@ kedro[pandas,spark]>=0.16.0
 kedro-telemetry>=0.1.1  # for testing telemetry integration
 bandit~=1.6.2
 behave>=1.2.6, <2.0
-black==21.5b1
+black~=22.0
 flake8~=3.9.2
 isort~=5.8.0
 mypy~=0.930


### PR DESCRIPTION
## Description

This issue arises because of the new ticket to Extend Python 3.9, 3.10. The current cache version for python is now 3.10 (instead of 3.8) and this is failing circleCI on main. 
Given that the cache_version variable isn't injecting any value at the moment, we are replacing it with 0 so it can fix the main build issue. 

Following this quick fix -- we will fix the circleCI to extend support for 3.9, 3.10. 

## Development notes

<!-- What have you changed? Consider adding a screenshot or GIF. -->

## QA notes

<!-- How has the expected behaviour changed? What testing strategies have you used? -->

## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro-viz/pull/818"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

