### PR TITLE
Add step to clean up existing virtualenvs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,6 +24,9 @@ commands:
             sudo apt update
             sudo apt install python3.8 python3-pip python3-venv
       - run:
+          name: Cleanup any existing virtual environment directories
+          command: rm -rf /home/circleci/.venvs
+      - run:
           name: Install Python environment
           command: |
             mkdir -p /home/circleci/.venvs && python3 -m venv /home/circleci/.venvs/kedro-viz


### PR DESCRIPTION
Signed-off-by: Merel Theisen <merel.theisen@quantumblack.com>

## Description

Builds on the `demo` branch were failing because the virtualenv aren't removed and so it had some references to python 3.10 (probably from Rashida's work adding the compatibility) 

## Development notes

<!-- What have you changed? Consider adding a screenshot or GIF. -->

## QA notes

<!-- How has the expected behaviour changed? What testing strategies have you used? -->

## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro-viz/pull/825"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

