### PR TITLE
Use CircleCI context for AWS keys for ECR publish

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -386,6 +386,8 @@ workflows:
       - win_build_310:
            python_version: '3.10'
       - deploy_demo:
+          context:
+            - kedro-ecr-publish
           requires:
             - build_37
             - build_38


### PR DESCRIPTION
## Description

Using CircleCI context for AWS credentials provides an easy way to use one set of credentials over multiple repositories. Since we have an enforced key rotation scheme for the ECR instance we are using, this will make key rotations a tad easier.


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro-viz/pull/830"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

