### PR TITLE
Fix: render without routing when using as a React component

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -7,6 +7,7 @@ Please follow the established format:
 -->
 
 ## Major features and improvements
+
 - Added support for Python 3.9 and 3.10. (#815)
 
 ## Bug fixes and other changes
@@ -14,6 +15,7 @@ Please follow the established format:
 - Change route name from `runsList` to `experiment-tracking`. (#820)
 - Update feature flag description to remind the user of the need for page refresh to apply settings. (#821)
 - Fix experiment tracking not showing run details bug on Windows. (#809)
+- Fix rendering of React component instance with custom routes. (#838)
 
 # Release 4.4.0
 

--- a/src/components/global-toolbar/global-toolbar.js
+++ b/src/components/global-toolbar/global-toolbar.js
@@ -21,7 +21,6 @@ export const GlobalToolbar = ({
   onToggleSettingsModal,
   onToggleTheme,
   theme,
-  visible,
 }) => {
   return (
     <>

--- a/src/components/wrapper/wrapper.js
+++ b/src/components/wrapper/wrapper.js
@@ -5,7 +5,6 @@ import { useApolloQuery } from '../../apollo/utils';
 import { client } from '../../apollo/config';
 import { GraphQLProvider } from '../provider/provider';
 import { GET_VERSIONS } from '../../apollo/queries';
-import { isLoading } from '../../selectors/loading';
 import classnames from 'classnames';
 import GlobalToolbar from '../global-toolbar';
 import FlowChartWrapper from '../flowchart-wrapper';
@@ -18,8 +17,11 @@ import './wrapper.css';
 /**
  * Main app container. Handles showing/hiding the sidebar nav, and theme classes.
  */
-export const Wrapper = ({ theme, displayGlobalToolbar }) => {
-  const { data: versionData } = useApolloQuery(GET_VERSIONS, { client });
+export const Wrapper = ({ displayGlobalToolbar, theme }) => {
+  const { data: versionData } = useApolloQuery(GET_VERSIONS, {
+    client,
+    skip: !displayGlobalToolbar,
+  });
   const [dismissed, setDismissed] = useState(false);
   const [isOutdated, setIsOutdated] = useState(false);
   const [latestVersion, setLatestVersion] = useState(null);
@@ -32,45 +34,50 @@ export const Wrapper = ({ theme, displayGlobalToolbar }) => {
   }, [versionData]);
 
   return (
-    <GraphQLProvider useMocks={false}>
-      <div
-        className={classnames('kedro-pipeline kedro', {
-          'kui-theme--dark': theme === 'dark',
-          'kui-theme--light': theme === 'light',
-        })}
-      >
-        <h1 className="pipeline-title">Kedro-Viz</h1>
-        <Router>
-          {displayGlobalToolbar && <GlobalToolbar isOutdated={isOutdated} />}
-          <SettingsModal
-            isOutdated={isOutdated}
-            latestVersion={latestVersion}
-          />
-          {versionData && isOutdated && !dismissed && (
-            <UpdateReminder
-              dismissed={dismissed}
-              versions={versionData.version}
-              setDismiss={setDismissed}
+    <div
+      className={classnames('kedro-pipeline kedro', {
+        'kui-theme--dark': theme === 'dark',
+        'kui-theme--light': theme === 'light',
+      })}
+    >
+      <h1 className="pipeline-title">Kedro-Viz</h1>
+      {displayGlobalToolbar ? (
+        <GraphQLProvider>
+          <Router>
+            {displayGlobalToolbar && <GlobalToolbar isOutdated={isOutdated} />}
+            <SettingsModal
+              isOutdated={isOutdated}
+              latestVersion={latestVersion}
             />
-          )}
-          <Switch>
-            <Route exact path={['/', '/flowchart']}>
-              <FlowChartWrapper />
-            </Route>
-            <Route path={['/experiment-tracking', '/experiment-tracking/:id']}>
-              <ExperimentWrapper />
-            </Route>
-          </Switch>
-        </Router>
-      </div>
-    </GraphQLProvider>
+            {versionData && isOutdated && !dismissed && (
+              <UpdateReminder
+                dismissed={dismissed}
+                setDismiss={setDismissed}
+                versions={versionData.version}
+              />
+            )}
+            <Switch>
+              <Route exact path={['/', '/flowchart']}>
+                <FlowChartWrapper />
+              </Route>
+              <Route
+                path={['/experiment-tracking', '/experiment-tracking/:id']}
+              >
+                <ExperimentWrapper />
+              </Route>
+            </Switch>
+          </Router>
+        </GraphQLProvider>
+      ) : (
+        <FlowChartWrapper />
+      )}
+    </div>
   );
 };
 
 export const mapStateToProps = (state) => ({
-  loading: isLoading(state),
-  theme: state.theme,
   displayGlobalToolbar: state.display.globalToolbar,
+  theme: state.theme,
 });
 
 export default connect(mapStateToProps)(Wrapper);

--- a/src/components/wrapper/wrapper.test.js
+++ b/src/components/wrapper/wrapper.test.js
@@ -3,13 +3,13 @@ import { mockState, setup } from '../../utils/state.mock';
 
 const { theme } = mockState.spaceflights;
 const mockProps = {
-  theme,
   displayGlobalToolbar: true,
+  theme,
 };
 
 const mockPropsNoGlobalToolbar = {
-  theme,
   displayGlobalToolbar: false,
+  theme,
 };
 
 describe('Wrapper', () => {
@@ -34,9 +34,8 @@ describe('Wrapper', () => {
 
   it('maps state to props', () => {
     expect(mapStateToProps(mockState.spaceflights)).toEqual({
-      loading: false,
-      theme,
       displayGlobalToolbar: true,
+      theme,
     });
   });
 });


### PR DESCRIPTION
Signed-off-by: Tynan DeBold <thdebold@gmail.com>

## Description

The Brix team tried to render the component instance of Viz on a page with a route like this: `/post/:id`. That didn't work because of the exact path matching we have [here](https://github.com/kedro-org/kedro-viz/blob/main/src/components/wrapper/wrapper.js#L57-L62). Nothing was rendered.

## Development notes

Now we use the `displayGlobalToolbar` variable as a switch case: if we display to global toolbar, then we also want all other app elements (`UpdateReminder`, `ExperimentTracking`, etc.). If not, we only render the `FlowChartWrapper` component.

## QA notes

You need to test locally in a dummy repo. You can use `npm link` to do that, but it's tedious. I can show you, as I've already done with @studioswong.

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [x] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes
