### PR TITLE
Feature/add tooltip label text to page links

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,6 +6,10 @@ Please follow the established format:
 - Include the ID number for the related PR (or PRs) in parentheses
 -->
 
+## Bug fixes and other changes
+
+- Add tooltip label text to page-navigation links. (#846)
+
 # Release 4.5.0
 
 ## Major features and improvements
@@ -15,7 +19,7 @@ Please follow the established format:
 ## Bug fixes and other changes
 
 - Change route name from `runsList` to `experiment-tracking`. (#820)
-- Update feature flag description to remind the user of the need for page refresh to apply settings. (#821)
+- Update feature flag description to remind the user of the need for page refresh to apply settings. (#823)
 - Fix experiment tracking not showing run details bug on Windows. (#809)
 - Fix rendering of React component instance with custom routes. (#838)
 - Improve performance when many datasets are missing. (#832)

--- a/src/components/global-toolbar/global-toolbar.js
+++ b/src/components/global-toolbar/global-toolbar.js
@@ -40,6 +40,7 @@ export const GlobalToolbar = ({
               }
               disabled={false}
               icon={TreeIcon}
+              labelText="Flowchart"
             />
           </NavLink>
           <NavLink exact to={{ pathname: '/experiment-tracking' }}>
@@ -50,6 +51,7 @@ export const GlobalToolbar = ({
               }
               disabled={false}
               icon={ExperimentsIcon}
+              labelText="Experiment tracking"
             />
           </NavLink>
         </ul>
@@ -62,20 +64,20 @@ export const GlobalToolbar = ({
             className={
               'pipeline-menu-button--theme pipeline-menu-button--large'
             }
-            onClick={() => onToggleTheme(theme === 'light' ? 'dark' : 'light')}
             icon={ThemeIcon}
             labelText="Toggle theme"
+            onClick={() => onToggleTheme(theme === 'light' ? 'dark' : 'light')}
           />
           <IconButton
             ariaLabel={'Change the settings flags'}
             className={
               'pipeline-menu-button--settings pipeline-menu-button--large'
             }
-            onClick={() => onToggleSettingsModal(true)}
-            icon={SettingsIcon}
             disabled={false}
-            labelText={'Settings'}
             hasReminder={isOutdated}
+            icon={SettingsIcon}
+            labelText={'Settings'}
+            onClick={() => onToggleSettingsModal(true)}
           />
         </ul>
       </div>

--- a/src/components/wrapper/wrapper.js
+++ b/src/components/wrapper/wrapper.js
@@ -57,12 +57,10 @@ export const Wrapper = ({ displayGlobalToolbar, theme }) => {
               />
             )}
             <Switch>
-              <Route exact path={['/', '/flowchart']}>
+              <Route exact path={['/']}>
                 <FlowChartWrapper />
               </Route>
-              <Route
-                path={['/experiment-tracking', '/experiment-tracking/:id']}
-              >
+              <Route path={['/experiment-tracking']}>
                 <ExperimentWrapper />
               </Route>
             </Switch>


### PR DESCRIPTION
## Description

Resolves #821.

## Development notes

I've added `labelText` to the `IconButton`s in the `GlobalToolbar`.

I also removed the `/flowchart` and `/experiment-tracking/:id` paths from the the React Router matching paths arrays, since we never link to those anywhere, sorted some props, and corrected a PR number in the release notes.

## QA notes

Take a look at the Gitpod deployment and hover over the global toolbar page links.

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [x] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes
