### PR TITLE
Update demo project to 0.18.1

### DIFF
--- a/demo-project/README.md
+++ b/demo-project/README.md
@@ -4,7 +4,7 @@ This project is designed to be a realistic example of what Kedro looks like when
 
 ## Setup
 
-1. Run `pip install kedro==0.18.0`
+1. Run `pip install kedro==0.18.1`
 2. Run `kedro install --build-reqs`
 3. Run `kedro run`
 4. Run `kedro viz`

--- a/demo-project/conf/base/parameters/feature_engineering.yml
+++ b/demo-project/conf/base/parameters/feature_engineering.yml
@@ -1,8 +1,8 @@
 # This is a boilerplate parameters config generated for pipeline 'feature_engineering'
-# using Kedro 0.18.0.
+# using Kedro 0.18.1.
 #
 # Documentation for this file format can be found in "Parameters"
-# Link: https://kedro.readthedocs.io/en/0.18.0/04_kedro_project_setup/02_configuration.html#parameters
+# Link: https://kedro.readthedocs.io/en/0.18.1/04_kedro_project_setup/02_configuration.html#parameters
 feature_engineering:
   feature:
     static:

--- a/demo-project/pyproject.toml
+++ b/demo-project/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.kedro]
 package_name = "demo_project"
 project_name = "modular-spaceflights"
-project_version = "0.18.0"
+project_version = "0.18.1"
 
 [tool.isort]
 multi_line_output = 3

--- a/demo-project/src/demo_project/pipelines/data_ingestion/requirements.txt
+++ b/demo-project/src/demo_project/pipelines/data_ingestion/requirements.txt
@@ -1,1 +1,1 @@
-kedro[pandas.CSVDataSet,pandas.ExcelDataSet, pandas.ParquetDataSet]==0.18.0
+kedro[pandas.CSVDataSet,pandas.ExcelDataSet, pandas.ParquetDataSet]==0.18.1

--- a/demo-project/src/demo_project/pipelines/feature_engineering/README.md
+++ b/demo-project/src/demo_project/pipelines/feature_engineering/README.md
@@ -1,15 +1,15 @@
 # Feature engineering pipeline
 
-> *Note:* This `README.md` was generated using `Kedro 0.18.0` for illustration purposes. Please modify it according to your pipeline structure and contents.
+> _Note:_ This `README.md` was generated using `Kedro 0.18.1` for illustration purposes. Please modify it according to your pipeline structure and contents.
 
 This pipeline creates features from two different sources:
 
-* Static features - Features that already exist at the primary layer and just need to be plucked and managed in their own table.
-* Derived feature -  Where parametrised operations create new features by combining two columns.
+- Static features - Features that already exist at the primary layer and just need to be plucked and managed in their own table.
+- Derived feature - Where parametrised operations create new features by combining two columns.
 
 > Look out for the '🟨 ' in Kedro Viz it means that parameters are applied to this node. You can inspect them on the sidebar by clicking the node.
 
-* The `joiner` node has been written in a way that it will keep inner joining an arbitrary sequence of pandas DataFrame objects into one single table. It will fail if the number of rows changes during this operation. This operation creates out `model_input_table` which will be fundamental to analytical components downstream.
+- The `joiner` node has been written in a way that it will keep inner joining an arbitrary sequence of pandas DataFrame objects into one single table. It will fail if the number of rows changes during this operation. This operation creates out `model_input_table` which will be fundamental to analytical components downstream.
 
 ## Visualisation
 

--- a/demo-project/src/demo_project/pipelines/feature_engineering/__init__.py
+++ b/demo-project/src/demo_project/pipelines/feature_engineering/__init__.py
@@ -1,6 +1,6 @@
 """
 This is a boilerplate pipeline 'feature_engineering'
-generated using Kedro 0.18.0
+generated using Kedro 0.18.1
 """
 
 from .pipeline import create_pipeline  # NOQA

--- a/demo-project/src/demo_project/pipelines/feature_engineering/nodes.py
+++ b/demo-project/src/demo_project/pipelines/feature_engineering/nodes.py
@@ -1,6 +1,6 @@
 """
 This is a boilerplate pipeline 'feature_engineering'
-generated using Kedro 0.18.0
+generated using Kedro 0.18.1
 """
 
 from functools import reduce

--- a/demo-project/src/demo_project/pipelines/feature_engineering/pipeline.py
+++ b/demo-project/src/demo_project/pipelines/feature_engineering/pipeline.py
@@ -1,6 +1,6 @@
 """
 This is a boilerplate pipeline 'feature_engineering'
-generated using Kedro 0.18.0
+generated using Kedro 0.18.1
 """
 
 

--- a/demo-project/src/demo_project/pipelines/feature_engineering/requirements.txt
+++ b/demo-project/src/demo_project/pipelines/feature_engineering/requirements.txt
@@ -1,1 +1,1 @@
-kedro[pandas.ParquetDataSet]==0.18.0
+kedro[pandas.ParquetDataSet]==0.18.1

--- a/demo-project/src/demo_project/pipelines/modelling/README.md
+++ b/demo-project/src/demo_project/pipelines/modelling/README.md
@@ -1,6 +1,6 @@
 # Modelling pipeline
 
-> *Note:* This `README.md` was generated using `Kedro 0.18.0` for illustration purposes. Please modify it according to your pipeline structure and contents.
+> _Note:_ This `README.md` was generated using `Kedro 0.18.1` for illustration purposes. Please modify it according to your pipeline structure and contents.
 
 - This part of the pipeline handles the `spit` / `train` / `test` elements of the ML process.
 - The `split_data` method is parametrised to create a single source of `train` and `test` data.

--- a/demo-project/src/demo_project/pipelines/modelling/requirements.txt
+++ b/demo-project/src/demo_project/pipelines/modelling/requirements.txt
@@ -1,2 +1,2 @@
-kedro[pandas.ParquetDataSet]==0.18.0
+kedro[pandas.ParquetDataSet]==0.18.1
 scikit-learn~=1.0

--- a/demo-project/src/demo_project/pipelines/reporting/README.md
+++ b/demo-project/src/demo_project/pipelines/reporting/README.md
@@ -1,14 +1,14 @@
 # Reporting modular pipeline
 
-> *Note:* This `README.md` was generated using `Kedro 0.18.0` for illustration purposes. Please modify it according to your pipeline structure and contents.
+> _Note:_ This `README.md` was generated using `Kedro 0.18.1` for illustration purposes. Please modify it according to your pipeline structure and contents.
 
 The reporting pipeline provides 3 simple descriptive cuts from the `prm_shuttle_company_reviews` table:
 
-|Plot name|Dataset type|Description|Image|
-|-|-|-|-|
-|Cancellation Policy Breakdown|Plotly|Provides a breakdown of the top countries by fleet price, broken down by flexible each of their cancellation policies are.|![bar](../../../../.tours/images/bar_chart.png)|
-|Price histogram|Plotly|Provides a breakdown of how the different space shuttles compare from a price and scale point of view, broken down by engine type. |![hist](../../../../.tours/images/histogram.png)|
-|Cancellation Policy Grid|Custom Pillow Image|This image is not something that we would really do in practice, but has been included mostly to show how easy it is in to define and use a [custom dataset](https://kedro.readthedocs.io/en/stable/07_extend_kedro/03_custom_datasets.html) in Kedro. |![grid](../../../../.tours/images/grid.png)|
+| Plot name                     | Dataset type        | Description                                                                                                                                                                                                                                            | Image                                            |
+| ----------------------------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------ |
+| Cancellation Policy Breakdown | Plotly              | Provides a breakdown of the top countries by fleet price, broken down by flexible each of their cancellation policies are.                                                                                                                             | ![bar](../../../../.tours/images/bar_chart.png)  |
+| Price histogram               | Plotly              | Provides a breakdown of how the different space shuttles compare from a price and scale point of view, broken down by engine type.                                                                                                                     | ![hist](../../../../.tours/images/histogram.png) |
+| Cancellation Policy Grid      | Custom Pillow Image | This image is not something that we would really do in practice, but has been included mostly to show how easy it is in to define and use a [custom dataset](https://kedro.readthedocs.io/en/stable/07_extend_kedro/03_custom_datasets.html) in Kedro. | ![grid](../../../../.tours/images/grid.png)      |
 
 ## Visualisation
 

--- a/demo-project/src/demo_project/pipelines/reporting/__init__.py
+++ b/demo-project/src/demo_project/pipelines/reporting/__init__.py
@@ -1,6 +1,6 @@
 """
 This is a boilerplate pipeline 'reporting'
-generated using Kedro 0.18.0
+generated using Kedro 0.18.1
 """
 
 from .pipeline import create_pipeline

--- a/demo-project/src/demo_project/pipelines/reporting/nodes.py
+++ b/demo-project/src/demo_project/pipelines/reporting/nodes.py
@@ -1,6 +1,6 @@
 """
 This is a boilerplate pipeline 'reporting'
-generated using Kedro 0.18.0
+generated using Kedro 0.18.1
 """
 import pandas as pd
 import PIL
@@ -13,7 +13,6 @@ from .image_utils import DrawTable
 def make_cancel_policy_bar_chart(
     model_input_data: pd.DataFrame, top_counties: int = 20
 ) -> pd.DataFrame:
-
     """This function performs a group by on the input table, limits the
     results to the top n countries based on price and returns the
     data needed to visualise a stacked bar chart. The DataFrame is

--- a/demo-project/src/demo_project/pipelines/reporting/pipeline.py
+++ b/demo-project/src/demo_project/pipelines/reporting/pipeline.py
@@ -1,6 +1,6 @@
 """
 This is a boilerplate pipeline 'reporting'
-generated using Kedro 0.18.0
+generated using Kedro 0.18.1
 """
 
 from kedro.pipeline import Pipeline, node, pipeline

--- a/demo-project/src/demo_project/pipelines/reporting/requirements.txt
+++ b/demo-project/src/demo_project/pipelines/reporting/requirements.txt
@@ -1,3 +1,3 @@
-kedro[plotly.PlotlyDataSet, plotly.JSONDataSet]==0.18.0
+kedro[plotly.PlotlyDataSet, plotly.JSONDataSet]==0.18.1
 matplotlib==3.5.0
 pillow==9.0.1

--- a/demo-project/src/demo_project/requirements.in
+++ b/demo-project/src/demo_project/requirements.in
@@ -5,7 +5,7 @@ isort~=5.0
 jupyter~=1.0
 jupyter_client>=5.1, <7.0
 jupyterlab~=3.0
-kedro[pandas.CSVDataSet,pandas.ExcelDataSet, pandas.ParquetDataSet, plotly.PlotlyDataSet]==0.18.0
+kedro[pandas.CSVDataSet,pandas.ExcelDataSet, pandas.ParquetDataSet, plotly.PlotlyDataSet]==0.18.1
 nbstripout~=0.4
 pytest-cov~=2.5
 pytest-mock>=1.7.1, <2.0

--- a/demo-project/src/docker_requirements.txt
+++ b/demo-project/src/docker_requirements.txt
@@ -1,4 +1,4 @@
-kedro[pandas.CSVDataSet,pandas.ExcelDataSet, pandas.ParquetDataSet, plotly.PlotlyDataSet]==0.18.0
+kedro[pandas.CSVDataSet,pandas.ExcelDataSet, pandas.ParquetDataSet, plotly.PlotlyDataSet]==0.18.1
 scikit-learn~=1.0
 pillow~=9.0
 matplotlib==3.5.0


### PR DESCRIPTION
Signed-off-by: Tynan DeBold <thdebold@gmail.com>

## Description

Update the demo-project to the latest version of Kedro, which is 0.18.1.

## QA notes

Checkout the repo, `pip install kedro==0.18.1` in the `/demo-project` folder, and then run `make run` in the root of the project. The server should start without a hitch. 

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes
