### PR TITLE
Simplify dataset `suggest` handling code

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -18,7 +18,7 @@ Please follow the established format:
 - Update feature flag description to remind the user of the need for page refresh to apply settings. (#821)
 - Fix experiment tracking not showing run details bug on Windows. (#809)
 - Fix rendering of React component instance with custom routes. (#838)
-- Improve performance when many datasets are missing. (#832)
+- Improve performance when many datasets are missing (requires `kedro>=0.18.1`). (#832)
 - Fix flowchart not showing on initial load for static data inputs. (#843)
 
 # Release 4.4.0

--- a/package/kedro_viz/data_access/repositories/catalog.py
+++ b/package/kedro_viz/data_access/repositories/catalog.py
@@ -14,32 +14,6 @@ from kedro.io import (
 
 from kedro_viz.constants import KEDRO_VERSION
 
-# Kedro-Viz doesn't need to know the close matches for missing datasets,
-# and `difflib.get_close_matches` is too costly if performed repeatedly.
-# Before Kedro 0.18.1, use the `_get_dataset` method without the verbose
-# error introduced in https://github.com/kedro-org/kedro/commit/f7dd247.
-if KEDRO_VERSION.match(">=0.16.0") and KEDRO_VERSION.match("<0.18.1"):
-
-    def _get_dataset(
-        self, data_set_name: str, version: Version = None
-    ) -> AbstractDataSet:
-        if data_set_name not in self._data_sets:
-            raise DataSetNotFoundError(
-                "DataSet '{}' not found in the catalog".format(data_set_name)
-            )
-
-        data_set = self._data_sets[data_set_name]
-        if version and isinstance(
-            data_set, AbstractVersionedDataSet
-        ):  # pragma: no cover
-            # we only want to return a similar-looking dataset,
-            # not modify the one stored in the current catalog
-            data_set = data_set._copy(  # pylint: disable=protected-access
-                _version=version
-            )
-
-        return data_set
-
 
 class CatalogRepository:
     _catalog: DataCatalog
@@ -83,13 +57,14 @@ class CatalogRepository:
         dataset_obj: Optional[AbstractDataSet]
         if KEDRO_VERSION.match(">=0.16.0"):
             try:
-                if KEDRO_VERSION.match(">=0.18.1"):  # pragma: no cover
-                    dataset_obj = self._catalog._get_dataset(  # type: ignore
+                # Kedro 0.18.1 introduced the `suggest` argument to disable the expensive
+                # fuzzy-matching process.
+                if KEDRO_VERSION.match(">=0.18.1"):
+                    dataset_obj = self._catalog._get_dataset(
                         dataset_name, suggest=False
                     )
-                else:
-                    with patch.object(DataCatalog, "_get_dataset", new=_get_dataset):
-                        dataset_obj = self._catalog._get_dataset(dataset_name)
+                else:  # pragma: no cover
+                    dataset_obj = self._catalog._get_dataset(dataset_name)
             except DataSetNotFoundError:  # pragma: no cover
                 dataset_obj = None
         else:


### PR DESCRIPTION
## Description

https://github.com/kedro-org/kedro-viz/pull/832 and https://github.com/kedro-org/kedro/pull/1482 added the `suggest` argument to `_get_dataset` and made sure it's used in kedro-viz (released in kedro 0.18.1).

#832 also patched `_get_dataset` to manually disable `suggest` if the user has kedro < 0.18.1 so that users of older version of kedro could also benefit from the performance improvement. Now that kedro 0.18.1 is released, we need to add additional test cases to get coverage on these lines by manually setting `KEDRO_VERSION` in a unit test. This is definitely possible but not something we currently do in any unit tests.

Overall I think we should try to minimise the number of switches that depend on `KEDRO_VERSION` in our codebase. In this case I don't think the importance of the change justifies the additional complexity to make it work on older versions of kedro. Given that this is quite a niche, recently fixed issue and just a performance improvement rather than a big bug, I think it's fine to say that you only get the performance improvement if you're on >=0.18.1.

@deepyaman I'm not absolutely set on this, so let me know if this is very offensive to you and I will leave your changes as they were and update the tests to get coverage.

## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes
