### PR TITLE
Extend Plotly support for all chart types

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Kedro-Viz is an interactive development tool for building data science pipelines
 - 🔎 Highly interactive, filterable and searchable
 - 🔬 Focus mode for modular pipeline visualisation
 - 📊 Rich metadata side panel to display parameters, plots, etc.
-- 📊 Supports all types of [plotly charts](https://plotly.com/javascript/)
+- 📊 Supports all types of [Plotly charts](https://plotly.com/javascript/)
 - ♻️ Autoreload on code change
 - 🧪 Supports tracking and comparing runs in a Kedro project
 - 🎩 Many more to come

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Kedro-Viz is an interactive development tool for building data science pipelines
 - 🔎 Highly interactive, filterable and searchable
 - 🔬 Focus mode for modular pipeline visualisation
 - 📊 Rich metadata side panel to display parameters, plots, etc.
+- 📊 Supports all types of [plotly charts](https://plotly.com/javascript/)
 - ♻️ Autoreload on code change
 - 🧪 Supports tracking and comparing runs in a Kedro project
 - 🎩 Many more to come

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,6 +6,12 @@ Please follow the established format:
 - Include the ID number for the related PR (or PRs) in parentheses
 -->
 
+# Release 4.5.1
+
+## Major features and improvements
+
+- Added support for all Plotly chart types. (#853)
+
 ## Bug fixes and other changes
 
 - Add tooltip label text to page-navigation links. (#846)

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "lodash.debounce": "^4.0.8",
     "lodash.noop": "^3.0.1",
     "lodash.sortby": "^4.7.0",
-    "plotly.js-cartesian-dist": "^1.58.4",
+    "plotly.js-dist-min": "^1.58.4",
     "react-csv": "^2.2.2",
     "react-custom-scrollbars": "^4.2.1",
     "react-json-view": "^1.21.3",

--- a/src/components/plotly-chart/plotly-chart.js
+++ b/src/components/plotly-chart/plotly-chart.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import createPlotlyComponent from 'react-plotly.js/factory';
-import Plotly from 'plotly.js-cartesian-dist';
+import Plotly from 'plotly.js-dist-min';
 import deepmerge from 'deepmerge';
 import { connect } from 'react-redux';
 import './plotly-chart.css';


### PR DESCRIPTION
## Description

Resolves #782 

## Development notes

Just updated package.json file to include full plotly js library (min version) 

## QA notes

Tested this with a kedro project where you create a Sankey chart and now the Sankey chart shows up. 

## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro-viz/pull/853"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

