### PR TITLE
[KED - 857] Improve telemetry to work with SVG elements

### DIFF
--- a/src/components/flowchart/draw.js
+++ b/src/components/flowchart/draw.js
@@ -159,7 +159,6 @@ export const drawNodes = function (changed) {
     enterNodes
       .attr('tabindex', '0')
       .attr('class', 'pipeline-node')
-      .attr('data-heap-event', (node) => `clicked.graph.${node.type}`)
       .attr('transform', (node) => `translate(${node.x}, ${node.y})`)
       .attr('data-id', (node) => node.id)
       .classed(
@@ -181,7 +180,12 @@ export const drawNodes = function (changed) {
       .duration(this.DURATION)
       .attr('opacity', 1);
 
-    enterNodes.append('rect').attr('class', 'pipeline-node__bg');
+    enterNodes
+      .append('rect')
+      .attr(
+        'class',
+        (node) => `pipeline-node__bg pipeline-node__bg--${node.type}`
+      );
 
     enterNodes
       .append('rect')


### PR DESCRIPTION
## Description

Resolves #857 

## Development notes

I have added the 'node type' to rectangle as on heap the rect svg is what gets registered. I have also defined multiple events on HEAP (Dataset selected, Task node selected, Parameter node selected, Modular pipelines selected' 

<img width="1121" alt="Screenshot 2022-05-24 at 18 34 04" src="https://user-images.githubusercontent.com/37628668/170097394-4830ff28-3b45-4eeb-afbb-e662af0e35ec.png">



## QA notes

<!-- How has the expected behaviour changed? What testing strategies have you used? -->

## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro-viz/pull/865"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

