### PR TITLE
Fix lambda function in demo-project

### DIFF
--- a/demo-project/src/demo_project/pipelines/data_ingestion/pipeline.py
+++ b/demo-project/src/demo_project/pipelines/data_ingestion/pipeline.py
@@ -56,8 +56,8 @@ def create_pipeline(**kwargs) -> Pipeline:
             ),
             node(
                 func=lambda x: x,
-                inputs='x',
-                outputs='y'
+                inputs="prm_spine_table",
+                outputs="prm_spine_table_clone",
             )
         ],
         namespace="ingestion",  # provide inputs


### PR DESCRIPTION
## Description

#851 added a lambda function to the demo-project, which shows fine in kedro-viz but breaks `kedro run` with `ValueError: Pipeline input(s) {'ingestion.x'} not found in the DataCatalog`. I've fixed it.

## QA notes

`kedro run` now works.

## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro-viz/pull/866"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

