### PR TITLE
[Bug Fix] Modular pipelines with the same name on different pipelines do not render corrected in Kedro Viz

### DIFF
--- a/package/kedro_viz/data_access/managers.py
+++ b/package/kedro_viz/data_access/managers.py
@@ -433,6 +433,12 @@ class DataAccessManager:
                 edges.remove_edge(GraphEdge(bad_input, modular_pipeline_id))
                 node_dependencies[bad_input].remove(modular_pipeline_id)
 
+        modular_pipelines_ids = modular_pipelines_tree.keys()
+
+        for modular_pipeline_id in modular_pipelines_ids:
+            if not modular_pipeline_id == ROOT_MODULAR_PIPELINE_ID:
+                modular_pipelines_tree[modular_pipeline_id].children = set()
+
         for node_id, node in self.nodes.as_dict().items():
             if (
                 node.type == GraphNodeType.MODULAR_PIPELINE
@@ -445,5 +451,17 @@ class DataAccessManager:
                         node_id, self.nodes.get_node_by_id(node_id).type
                     )
                 )
+
+            for modular_pipeline_id in modular_pipelines_ids:
+                if not modular_pipeline_id == ROOT_MODULAR_PIPELINE_ID:
+                    if (
+                        node.belongs_to_pipeline(registered_pipeline_id)
+                        and modular_pipeline_id in node.modular_pipelines
+                    ):
+                        modular_pipelines_tree[modular_pipeline_id].children.add(
+                            ModularPipelineChild(
+                                node.id, self.nodes.get_node_by_id(node.id).type
+                            )
+                        )
 
         return modular_pipelines_tree

--- a/package/kedro_viz/data_access/repositories/modular_pipelines.py
+++ b/package/kedro_viz/data_access/repositories/modular_pipelines.py
@@ -213,12 +213,6 @@ class ModularPipelinesRepository:
         # so does the modular pipeline.
         modular_pipeline.pipelines.update(node.pipelines)
 
-        # Since we extract the modular pipeline from the node's namespace,
-        # the node is by definition a child of the modular pipeline.
-        self.add_child(
-            modular_pipeline_id,
-            ModularPipelineChild(id=node.id, type=GraphNodeType(node.type)),
-        )
         return modular_pipeline_id
 
     def has_modular_pipeline(self, modular_pipeline_id: str) -> bool:


### PR DESCRIPTION
## Description

This bug was found when trying to fix this issue #858 raised by a user. 

Currently if you have multiple kedro pipelines where the namespace (modular pipeline name) is the same it causes an issue on Kedro Viz. 

Let's say you have the below pipeline 
 

```python

    return {"__default__": pipeline([node(func=lambda a: False, inputs='a', outputs='d')
    ,node(func=lambda a: False, inputs='d', outputs='e')],namespace='tst'), 
             "pipe2": pipeline([node(func=lambda b: False, inputs='b', outputs='c')],namespace='tst'),
    }
```
then if you render on Kedro-viz you get the extra empty rows for pipelines __default__ .tst and __pipe2__ .tst (see below screenshots)

<img width="1204" alt="Screenshot 2022-05-26 at 12 50 33" src="https://user-images.githubusercontent.com/37628668/170482783-4c5eb8f7-e148-40a6-b85f-cfa2d3e771b0.png">

<img width="1375" alt="Screenshot 2022-05-26 at 12 50 44" src="https://user-images.githubusercontent.com/37628668/170482791-80dd5ca3-302b-4aa8-8408-a52f3968b078.png">


this is because in the api, it always includes all children of the modular pipeline (in this instance - tst) from both pipelines instead of from the selected pipeline 

<img width="919" alt="Screenshot 2022-05-26 at 12 51 14" src="https://user-images.githubusercontent.com/37628668/170482805-ea71c0e1-2a84-4ce7-ab1d-b1ad02cb7266.png">

<img width="971" alt="Screenshot 2022-05-26 at 12 51 30" src="https://user-images.githubusercontent.com/37628668/170482816-a84c477c-4702-4264-91b7-3bad3936a2ce.png">



## Development notes

When i went through the code, i realised children are added to the modular pipeline in the repository layer which runs only the first time. I changed this so that children specific to the pipeline selected are added in the mangers.py. Also because modular_pipeline names are the same, i ensure that the modular_pipeline is first made empty and then the children of only the current registered pipeline are added. 

## QA notes

Once implementation is accepted, will write the required tests 

## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro-viz/pull/868"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>
