### PR TITLE
Make sure we update the correct modular pipeline when expanding the tree

### DIFF
--- a/package/kedro_viz/data_access/managers.py
+++ b/package/kedro_viz/data_access/managers.py
@@ -375,8 +375,15 @@ class DataAccessManager:
             if modular_pipeline_id == ROOT_MODULAR_PIPELINE_ID:
                 continue
 
-            modular_pipeline_node = self.nodes.add_node(modular_pipeline_node)
-            modular_pipeline_node.pipelines = {registered_pipeline_id}
+            # Add the modular pipeline node to the global list of nodes if necessary
+            # and update the list of pipelines it belongs to.
+            # N.B. Ideally we will have different modular pipeline nodes for
+            # different registered pipelinesm, but that requires a bit of a bigger refactor
+            # so we will just use the same node for now.
+            self.nodes.add_node(modular_pipeline_node)
+            self.nodes.get_node_by_id(modular_pipeline_node.id).pipelines = {
+                registered_pipeline_id
+            }
 
             self.registered_pipelines.add_node(
                 registered_pipeline_id, modular_pipeline_node.id


### PR DESCRIPTION
Signed-off-by: Lim Hoang <limdauto@gmail.com>

## Description

This is a follow-up to https://github.com/kedro-org/kedro-viz/pull/871

## Development notes

* To enable global look up of node details for the sidebar, we keep a global of graph nodes in memory between requests. 
* This relies on the fact that each node as a unique identifier across _all registered pipelines_*. 
* For modular pipeline node, we just use the modular pipeline name.
* Unfortunately, if there is a modular pipeline with the same name across different pipelines, there will only ever be one modular pipeline node created. And when we create the modular pipeline node to return to the client, previously we re-use existing modular pipeline node which could have the wrong details. This PR removes that.

### Future iteration

So all of this is rather unfortunate. It's an accummulation of how registered pipelines was setup even prior to the current backend. IIRC the reason to have the same nodes reference across different pipelines so that when we switch between different pipelines, the frontend doesn't have to re-render too much. But this has caused a lot of complications over the years (this is one of many).

I think ideally we should have cleanly separated set of nodes across different registered pipelines. For Kedro node, when we hash the node to get the ID, we should incorporate the pipeline it belongs to as well.

## QA notes

I have tested the edge case by hand.

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro-viz/pull/876"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

