### PR TITLE
Fix: empty pipeline warning flash and tooltip alignment issue

### DIFF
--- a/src/components/pipeline-warning/pipeline-warning.js
+++ b/src/components/pipeline-warning/pipeline-warning.js
@@ -17,12 +17,13 @@ export const PipelineWarning = ({
   const [componentLoaded, setComponentLoaded] = useState(false);
   const isEmptyPipeline = nodes.length === 0;
 
-  // Only run this once, when the component mounts
+  // Only run this once, when the component mounts.
   useEffect(() => {
-    setTimeout(() => {
+    const timer = setTimeout(() => {
       setComponentLoaded(true);
     }, 1500);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+
+    return () => clearTimeout(timer);
   }, []);
 
   return (

--- a/src/components/pipeline-warning/pipeline-warning.js
+++ b/src/components/pipeline-warning/pipeline-warning.js
@@ -19,9 +19,9 @@ export const PipelineWarning = ({
 
   // Only run this once, when the component mounts
   useEffect(() => {
-    if (nodes.length > 0) {
+    setTimeout(() => {
       setComponentLoaded(true);
-    }
+    }, 1500);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -47,10 +47,9 @@ export const PipelineWarning = ({
           </Button>
         </div>
       )}
-      {isEmptyPipeline && (
+      {isEmptyPipeline && componentLoaded && (
         <div
-          className={classnames('kedro', {
-            'pipeline-warning': componentLoaded,
+          className={classnames('kedro', 'pipeline-warning', {
             'pipeline-warning--sidebar-visible': sidebarVisible,
           })}
         >

--- a/src/components/pipeline-warning/pipeline-warning.test.js
+++ b/src/components/pipeline-warning/pipeline-warning.test.js
@@ -5,6 +5,7 @@ import {
   mapDispatchToProps,
 } from './pipeline-warning';
 import { mockState, setup } from '../../utils/state.mock';
+import { act } from 'react-dom/test-utils';
 
 describe('PipelineWarning', () => {
   describe('LargePipelineWarning', () => {
@@ -48,20 +49,29 @@ describe('PipelineWarning', () => {
   });
 
   describe('EmptyPipelineWarning', () => {
+    let wrapper;
+    const mockFn = jest.fn();
+    const emptyProps = {
+      onDisable: mockFn,
+      onHide: mockFn,
+      nodes: [],
+      visible: false,
+    };
+
+    beforeAll(() => {
+      jest.useFakeTimers();
+      wrapper = setup.mount(<PipelineWarning {...emptyProps} />);
+    });
+
     it('renders empty pipeline warning without crashing', () => {
-      const mockFn = jest.fn();
-      const props = {
-        onDisable: mockFn,
-        onHide: mockFn,
-        nodes: [],
-        visible: false,
-      };
-      const wrapper = setup.mount(<PipelineWarning {...props} />);
+      act(() => {
+        jest.runOnlyPendingTimers();
+      });
+      wrapper.update();
       expect(wrapper.find('.pipeline-warning__title').length).toBe(1);
     });
 
     it('does not render empty pipeline warning when pipeline is not empty', () => {
-      const mockFn = jest.fn();
       const props = {
         onDisable: mockFn,
         onHide: mockFn,


### PR DESCRIPTION
Signed-off-by: Tynan DeBold <thdebold@gmail.com>

## Description

After #864 and then #867, there was a small flash of text for the empty pipeline warning and then a misalignment of the tooltip on first page load. This fixes that issue.

![image](https://user-images.githubusercontent.com/16869061/172410776-288cbb15-6568-4c67-8bea-97065beda019.png)


## Development notes

We'll use a `setTimeout` to hold off on rendering any empty pipeline message. That should never happen by default anyways. Credit to @rashidakanchwala for suggesting this earlier.

## QA notes

Check out the branch or look at the Gitpod link to see no flash and the tooltips on the nodes aligning correctly.

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro-viz/pull/888"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

