### PR TITLE
Chore: add Rich dependency to demo-project

### DIFF
--- a/demo-project/src/demo_project/requirements.in
+++ b/demo-project/src/demo_project/requirements.in
@@ -15,3 +15,4 @@ wheel>=0.35, <0.37
 pillow~=9.0
 matplotlib==3.5.0
 pre-commit~=1.17
+rich~=12.4.4


### PR DESCRIPTION
Signed-off-by: Tynan DeBold <thdebold@gmail.com>

## Description

Gitpod is failing because Rich is missing. This will fix that.

## QA notes

Open the Gitpod preview and ensure it loads properly.

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes
