### PR TITLE
Show the collapse/expand icon in experiment tracking

### DIFF
--- a/src/components/experiment-tracking/experiment-primary-toolbar/experiment-primary-toolbar.js
+++ b/src/components/experiment-tracking/experiment-primary-toolbar/experiment-primary-toolbar.js
@@ -11,6 +11,7 @@ import ShowChangesIcon from '../../icons/show-changes';
 import { constructExportData } from '../../../utils/experiment-tracking-utils';
 
 export const ExperimentPrimaryToolbar = ({
+  displaySidebar,
   enableComparisonView,
   enableShowChanges,
   runMetadata,
@@ -38,8 +39,9 @@ export const ExperimentPrimaryToolbar = ({
 
   return (
     <PrimaryToolbar
-      visible={{ sidebar: sidebarVisible }}
+      displaySidebar={displaySidebar}
       onToggleSidebar={setSidebarVisible}
+      visible={{ sidebar: sidebarVisible }}
     >
       <IconButton
         ariaLive="Toggle run bookmark"

--- a/src/components/flowchart-primary-toolbar/flowchart-primary-toolbar.js
+++ b/src/components/flowchart-primary-toolbar/flowchart-primary-toolbar.js
@@ -31,9 +31,9 @@ export const FlowchartPrimaryToolbar = ({
 }) => (
   <>
     <PrimaryToolbar
+      displaySidebar={displaySidebar}
       onToggleSidebar={onToggleSidebar}
       visible={visible}
-      displaySidebar={displaySidebar}
     >
       <IconButton
         ariaLive="polite"
@@ -67,10 +67,10 @@ export const FlowchartPrimaryToolbar = ({
 
 export const mapStateToProps = (state) => ({
   disableLayerBtn: !state.layer.ids.length,
+  displaySidebar: state.display.sidebar,
   textLabels: state.textLabels,
   visible: state.visible,
   visibleLayers: Boolean(getVisibleLayerIDs(state).length),
-  displaySidebar: state.display.sidebar,
 });
 
 export const mapDispatchToProps = (dispatch) => ({

--- a/src/components/primary-toolbar/primary-toolbar.js
+++ b/src/components/primary-toolbar/primary-toolbar.js
@@ -13,28 +13,25 @@ import './primary-toolbar.css';
  */
 export const PrimaryToolbar = ({
   children,
-  displaySidebar,
   onToggleSidebar,
   visible = { sidebar: true },
 }) => (
   <>
     <ul className="pipeline-primary-toolbar kedro">
-      {displaySidebar && (
-        <IconButton
-          ariaLabel={`${visible.sidebar ? 'Hide' : 'Show'} menu`}
-          dataHeapEvent={`visible.sidebar.${visible.sidebar}`}
-          className={classnames(
-            'pipeline-menu-button',
-            'pipeline-menu-button--menu',
-            {
-              'pipeline-menu-button--inverse': !visible.sidebar,
-            }
-          )}
-          onClick={() => onToggleSidebar(!visible.sidebar)}
-          icon={MenuIcon}
-          labelText={`${visible.sidebar ? 'Hide' : 'Show'} menu`}
-        />
-      )}
+      <IconButton
+        ariaLabel={`${visible.sidebar ? 'Hide' : 'Show'} menu`}
+        dataHeapEvent={`visible.sidebar.${visible.sidebar}`}
+        className={classnames(
+          'pipeline-menu-button',
+          'pipeline-menu-button--menu',
+          {
+            'pipeline-menu-button--inverse': !visible.sidebar,
+          }
+        )}
+        onClick={() => onToggleSidebar(!visible.sidebar)}
+        icon={MenuIcon}
+        labelText={`${visible.sidebar ? 'Hide' : 'Show'} menu`}
+      />
       {children}
     </ul>
   </>

--- a/src/components/primary-toolbar/primary-toolbar.test.js
+++ b/src/components/primary-toolbar/primary-toolbar.test.js
@@ -4,7 +4,7 @@ import { mockState, setup } from '../../utils/state.mock';
 
 describe('PrimaryToolbar', () => {
   it('renders without crashing', () => {
-    const wrapper = setup.mount(<PrimaryToolbar displaySidebar={true} />);
+    const wrapper = setup.mount(<PrimaryToolbar />);
     expect(wrapper.find('.pipeline-icon-toolbar__button').length).toBe(1);
   });
 
@@ -12,29 +12,15 @@ describe('PrimaryToolbar', () => {
     const visible = {
       sidebar: true,
     };
-    const wrapper = setup.mount(
-      <PrimaryToolbar displaySidebar={true} visible={visible} />
-    );
+    const wrapper = setup.mount(<PrimaryToolbar visible={visible} />);
     expect(wrapper.find('.pipeline-icon-toolbar__button').length).toBe(1);
-  });
-
-  it('does not shows the collapse sidebar icon button if diesplay sidebar is false', () => {
-    const visible = {
-      sidebar: false,
-    };
-    const wrapper = setup.mount(
-      <PrimaryToolbar displaySidebar={false} visible={visible} />
-    );
-    expect(wrapper.find('.pipeline-icon-toolbar__button').length).toBe(0);
   });
 
   it('shows the original menu button when visible sidebar prop is true', () => {
     const visible = {
       sidebar: true,
     };
-    const wrapper = setup.mount(
-      <PrimaryToolbar displaySidebar={true} visible={visible} />
-    );
+    const wrapper = setup.mount(<PrimaryToolbar visible={visible} />);
     expect(wrapper.find('.pipeline-menu-button--inverse').length).toBe(0);
   });
 
@@ -42,9 +28,7 @@ describe('PrimaryToolbar', () => {
     const visible = {
       sidebar: false,
     };
-    const wrapper = setup.mount(
-      <PrimaryToolbar displaySidebar={true} visible={visible} />
-    );
+    const wrapper = setup.mount(<PrimaryToolbar visible={visible} />);
     expect(wrapper.find('.pipeline-menu-button--inverse').length).toBe(2);
   });
 

--- a/src/components/sidebar/sidebar.js
+++ b/src/components/sidebar/sidebar.js
@@ -18,13 +18,14 @@ import './sidebar.css';
 export const Sidebar = ({
   disableRunSelection,
   displayGlobalToolbar,
+  displaySidebar,
   enableComparisonView,
   enableShowChanges,
   isExperimentView = false,
   onRunSelection,
   onToggleComparisonView,
-  runsListData,
   runMetadata,
+  runsListData,
   runTrackingData,
   selectedRunData,
   selectedRunIds,
@@ -49,23 +50,24 @@ export const Sidebar = ({
               disableRunSelection={disableRunSelection}
               enableComparisonView={enableComparisonView}
               onRunSelection={onRunSelection}
+              onToggleComparisonView={onToggleComparisonView}
               runData={runsListData}
               selectedRunIds={selectedRunIds}
-              onToggleComparisonView={onToggleComparisonView}
             />
           </div>
           <nav className="pipeline-toolbar">
             <ExperimentPrimaryToolbar
+              displaySidebar={displaySidebar}
               enableComparisonView={enableComparisonView}
               enableShowChanges={enableShowChanges}
+              runMetadata={runMetadata}
+              runTrackingData={runTrackingData}
               selectedRunData={selectedRunData}
               setEnableShowChanges={setEnableShowChanges}
               setSidebarVisible={setSidebarVisible}
               showChangesIconDisabled={!(selectedRunIds.length > 1)}
               showRunDetailsModal={showRunDetailsModal}
               sidebarVisible={sidebarVisible}
-              runMetadata={runMetadata}
-              runTrackingData={runTrackingData}
             />
           </nav>
         </div>
@@ -96,8 +98,9 @@ export const Sidebar = ({
 };
 
 const mapStateToProps = (state) => ({
-  visible: state.visible.sidebar,
   displayGlobalToolbar: state.display.globalToolbar,
+  displaySidebar: state.display.sidebar,
+  visible: state.visible.sidebar,
 });
 
 export default connect(mapStateToProps)(Sidebar);


### PR DESCRIPTION
Signed-off-by: Tynan DeBold <thdebold@gmail.com>

## Description

Fixes #895.

## Development notes

I passed down the relevant prop and made the icon visible in the experiment-tracking route. I also sorted some props, and that's what the other changes will show.

## QA notes

View the Gitpod link, look at the experiment tracking page, and see that the icon is there, and also that you can collapse and expand the sidebar.

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [x] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro-viz/pull/904"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

