### PR TITLE
Chore/move faker package to dev dependencies

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -17,8 +17,9 @@ Please follow the established format:
 - Disabled uvicorn's logger so that log messages are no longer duplicated. (#870)
 - Enhance _Apply and close_ behavior of modals. (#875)
 - Fix namespace collison when two different registered pipelines have a modular pipeline with the same name. (#871)
-- Add --params option to `kedro viz` CLI command (#883)
+- Add --params option to `kedro viz` CLI command. (#883)
 - Fix namespace collision when two registered pipelines have a modular pipeline with the same name. (#871)
+- Improve bundle size of the JavaScript package. (#906)
 
 # Release 4.6.0
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1384,9 +1384,10 @@
       }
     },
     "@faker-js/faker": {
-      "version": "6.0.0-beta.0",
-      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-6.0.0-beta.0.tgz",
-      "integrity": "sha512-7QdsX5ZqUEz87twuoKEJe7NHn6OHQsVYQpJcK0disnR0XuVb9FEgQUcsViard9OTNN/fG/nZT63V35vieOwZ4Q=="
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-7.2.0.tgz",
+      "integrity": "sha512-dzjQ0LFT+bPLWg0yyV3MpxaLJp/+VW4a0SnjNSWJ4YpJ928LXDOZAN+kB2/JPPisI3Ra0w2BxbD4M9J7o0jcpw==",
+      "dev": true
     },
     "@gar/promisify": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
   },
   "dependencies": {
     "@apollo/client": "^3.5.6",
-    "@faker-js/faker": "^6.0.0-beta.0",
     "@graphql-tools/schema": "7.1.5",
     "@material-ui/core": "^4.11.4",
     "@material-ui/icons": "^4.11.2",
@@ -93,6 +92,7 @@
     "@babel/cli": "^7.14.5",
     "@babel/core": "^7.14.6",
     "@babel/plugin-proposal-class-properties": "^7.14.5",
+    "@faker-js/faker": "^7.2.0",
     "@testing-library/jest-dom": "^5.14.1",
     "@testing-library/react": "^11.2.7",
     "@testing-library/user-event": "^12.8.3",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "files": [
     "lib"
   ],
-  "homepage": ".",
+  "homepage": "https://github.com/kedro-org/kedro-viz",
   "proxy": "http://localhost:4142/",
   "scripts": {
     "build": "npm run build:css && react-scripts build",

--- a/src/apollo/mocks.js
+++ b/src/apollo/mocks.js
@@ -1,5 +1,5 @@
 import { Factory } from 'fishery';
-import faker from '@faker-js/faker';
+import { faker } from '@faker-js/faker';
 import { GET_RUNS, GET_RUN_METADATA, GET_RUN_TRACKING_DATA } from './queries';
 
 export const RunMock = Factory.define(({ sequence }) => {


### PR DESCRIPTION
## Description

Our friend @abezhinaru in the Brix team pointed out to us that **Faker** is bloating their JS bundle size. This PR moves Faker to be a `devDependency`, in turn removing it from their bundle.

<img width="2048" alt="Screenshot 2022-06-09 at 15 57 57" src="https://user-images.githubusercontent.com/16869061/173375662-ef573d75-6356-49de-b668-3dc554ca7fa9.png">

## Development notes

I moved the package to `devDependencies`, updated the version, and updated the way it's imported.

## QA notes

Before:

<img width="436" alt="image" src="https://user-images.githubusercontent.com/16869061/173376327-73775c02-9c26-40c8-a1e1-29d2583b47e9.png">

After:

<img width="433" alt="image" src="https://user-images.githubusercontent.com/16869061/173377238-decb8ea5-41a2-44fb-bb8a-70dec0f20fd4.png">

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [x] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro-viz/pull/906"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

