### PR TITLE
Add `repository` field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "build:css": "node-sass src/ -o src/",
     "postbuild": "rm -rf build/api",
     "start": "REACT_APP_DATA_SOURCE=$DATA npm-run-all -p start:css start:app start:lib",
-    "start:app": "PORT=4141 PUBLIC_URL=/ react-scripts start",
+    "start:app": "PORT=4141 react-scripts start",
     "start:css": "npm run build:css && node-sass src/ -o src/ --watch --recursive",
     "start:lib": "rm -rf lib && babel src --out-dir lib --copy-files --watch",
     "lib": "npm-run-all -s lib:clean lib:copy lib:webpack lib:babel lib:prune",

--- a/package.json
+++ b/package.json
@@ -5,14 +5,18 @@
   "files": [
     "lib"
   ],
-  "homepage": "https://github.com/kedro-org/kedro-viz",
+  "homepage": ".",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/kedro-org/kedro-viz.git"
+  },
   "proxy": "http://localhost:4142/",
   "scripts": {
     "build": "npm run build:css && react-scripts build",
     "build:css": "node-sass src/ -o src/",
     "postbuild": "rm -rf build/api",
     "start": "REACT_APP_DATA_SOURCE=$DATA npm-run-all -p start:css start:app start:lib",
-    "start:app": "PORT=4141 react-scripts start",
+    "start:app": "PORT=4141 PUBLIC_URL=/ react-scripts start",
     "start:css": "npm run build:css && node-sass src/ -o src/ --watch --recursive",
     "start:lib": "rm -rf lib && babel src --out-dir lib --copy-files --watch",
     "lib": "npm-run-all -s lib:clean lib:copy lib:webpack lib:babel lib:prune",


### PR DESCRIPTION
Signed-off-by: Tynan DeBold <thdebold@gmail.com>

## Description

We didn't have the `repository` link like this on our NPM page:

<img width="454" alt="image" src="https://user-images.githubusercontent.com/16869061/173861692-490b76e3-2da1-45a0-9766-611d3fa92ba6.png">

This will add that, as well as fix the issue where if you run the app with `npm start` you'll see this `http://localhost:4141/kedro-org/kedro-viz` instead of `http://localhost:4141`.

## QA notes

Simply look at the `package.json` file.

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro-viz/pull/913"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

