### PR TITLE
Chore - Clean up ariaLabel tags for buttons

### DIFF
--- a/demo-project/.telemetry
+++ b/demo-project/.telemetry
@@ -1,1 +1,1 @@
-consent: true
+consent: false

--- a/demo-project/.telemetry
+++ b/demo-project/.telemetry
@@ -1,1 +1,1 @@
-consent: false
+consent: true

--- a/src/components/experiment-tracking/experiment-primary-toolbar/experiment-primary-toolbar.js
+++ b/src/components/experiment-tracking/experiment-primary-toolbar/experiment-primary-toolbar.js
@@ -36,7 +36,7 @@ export const ExperimentPrimaryToolbar = ({
       visible={{ sidebar: sidebarVisible }}
     >
       <IconButton
-        ariaLive="Toggle run bookmark"
+        ariaLabel="Toggle run bookmark"
         className={'pipeline-menu-button--labels'}
         icon={selectedRunData?.bookmark ? BookmarkIcon : BookmarkStrokeIcon}
         labelText={`${selectedRunData?.bookmark ? 'Unbookmark' : 'Bookmark'}`}
@@ -44,7 +44,7 @@ export const ExperimentPrimaryToolbar = ({
         visible={!enableComparisonView}
       />
       <IconButton
-        ariaLive="Edit run details"
+        ariaLabel="Edit run details"
         className={'pipeline-menu-button--labels'}
         icon={PencilIcon}
         labelText={`Edit details`}
@@ -52,7 +52,7 @@ export const ExperimentPrimaryToolbar = ({
         visible={!enableComparisonView}
       />
       <IconButton
-        ariaLive="polite"
+        ariaLabel="Toggle show changes"
         className={'pipeline-menu-button--labels'}
         onClick={() => setEnableShowChanges(!enableShowChanges)}
         icon={ShowChangesIcon}

--- a/src/components/experiment-tracking/run-metadata/run-metadata.js
+++ b/src/components/experiment-tracking/run-metadata/run-metadata.js
@@ -148,14 +148,15 @@ const RunMetadata = ({
                         />
                         <HiddenMenu isBookmarked={run.bookmark} runId={run.id}>
                           <IconButton
-                            ariaLive="polite"
-                            className="pipeline-menu-button--labels__kebab"
+                            ariaLabel="Runs Menu"
+                            className="pipeline-menu-button--labels"
+                            dataHeapEvent=""
                             icon={KebabIcon}
                           />
                         </HiddenMenu>
                         <IconButton
-                          ariaLive="polite"
-                          className="pipeline-menu-button--labels__close"
+                          ariaLabel="Close Run"
+                          className="pipeline-menu-button--labels"
                           onClick={() => onRunSelection(run.id)}
                           icon={CloseIcon}
                         />

--- a/src/components/experiment-tracking/run-metadata/run-metadata.js
+++ b/src/components/experiment-tracking/run-metadata/run-metadata.js
@@ -148,14 +148,13 @@ const RunMetadata = ({
                         />
                         <HiddenMenu isBookmarked={run.bookmark} runId={run.id}>
                           <IconButton
-                            ariaLabel="Runs Menu"
+                            ariaLabel="Runs menu"
                             className="pipeline-menu-button--labels"
-                            dataHeapEvent=""
                             icon={KebabIcon}
                           />
                         </HiddenMenu>
                         <IconButton
-                          ariaLabel="Close Run"
+                          ariaLabel="Close run"
                           className="pipeline-menu-button--labels"
                           onClick={() => onRunSelection(run.id)}
                           icon={CloseIcon}

--- a/src/components/flowchart-primary-toolbar/flowchart-primary-toolbar.js
+++ b/src/components/flowchart-primary-toolbar/flowchart-primary-toolbar.js
@@ -36,7 +36,7 @@ export const FlowchartPrimaryToolbar = ({
       visible={visible}
     >
       <IconButton
-        ariaLive="polite"
+        ariaLabel={`${textLabels ? 'Hide' : 'Show'} text labels`}
         className={'pipeline-menu-button--labels'}
         onClick={() => onToggleTextLabels(!textLabels)}
         icon={LabelIcon}


### PR DESCRIPTION
## Description

In the code there were some places where ariaLive was used instead of ariaLabels. So i have cleaned that up. 

Also, for heap event tracking -- lot of buttons have the same class name since the same styling is applied. Aria labels are however unique to each button and are currently being used to distinguish click events from one another. 

## Development notes

<!-- What have you changed? Consider adding a screenshot or GIF. -->

## QA notes

<!-- How has the expected behaviour changed? What testing strategies have you used? -->

## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro-viz/pull/914"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

