### PR TITLE
Toggle pretty name only on apply and close

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -8,7 +8,7 @@ Please follow the established format:
 
 ## Bug fixes and other changes
 
-- General design-debt fixes. (#933)
+- General design-debt fixes. (#933, #934)
 
 # Release 4.7.0
 

--- a/src/components/settings-modal/settings-modal.js
+++ b/src/components/settings-modal/settings-modal.js
@@ -9,8 +9,8 @@ import { getFlagsState } from '../../utils/flags';
 import SettingsModalRow from './settings-modal-row';
 import { settings as settingsConfig } from '../../config';
 
-import Modal from '../ui/modal';
 import Button from '../ui/button';
+import Modal from '../ui/modal';
 
 import './settings-modal.css';
 
@@ -22,15 +22,16 @@ const SettingsModal = ({
   flags,
   isOutdated,
   latestVersion,
-  showSettingsModal,
   onToggleFlag,
   onTogglePrettyName,
   prettyName,
+  showSettingsModal,
   visible,
 }) => {
+  const flagData = getFlagsState();
   const [hasNotInteracted, setHasNotInteracted] = useState(true);
   const [hasClickedApplyAndClose, setHasClickApplyAndClose] = useState(false);
-  const flagData = getFlagsState();
+  const [isPrettyNameOn, setIsPrettyNameOn] = useState(prettyName);
 
   useEffect(() => {
     let modalTimeout, resetTimeout;
@@ -42,8 +43,10 @@ const SettingsModal = ({
 
       // Delay the reset so the user can't see the button text change.
       resetTimeout = setTimeout(() => {
+        onTogglePrettyName(isPrettyNameOn);
         setHasNotInteracted(true);
         setHasClickApplyAndClose(false);
+
         window.location.reload();
       }, 2000);
     }
@@ -52,7 +55,12 @@ const SettingsModal = ({
       clearTimeout(modalTimeout);
       clearTimeout(resetTimeout);
     };
-  }, [hasClickedApplyAndClose, showSettingsModal]);
+  }, [
+    hasClickedApplyAndClose,
+    isPrettyNameOn,
+    onTogglePrettyName,
+    showSettingsModal,
+  ]);
 
   const resetStateCloseModal = () => {
     showSettingsModal(false);
@@ -78,10 +86,10 @@ const SettingsModal = ({
           <SettingsModalRow
             id="prettyName"
             name={settingsConfig['prettyName'].name}
-            toggleValue={prettyName}
+            toggleValue={isPrettyNameOn}
             description={settingsConfig['prettyName'].description}
             onToggleChange={(event) => {
-              onTogglePrettyName(event.target.checked);
+              setIsPrettyNameOn(event.target.checked);
               setHasNotInteracted(false);
             }}
           />

--- a/src/components/settings-modal/settings-modal.js
+++ b/src/components/settings-modal/settings-modal.js
@@ -75,57 +75,61 @@ const SettingsModal = ({
         visible={visible.settingsModal}
       >
         <div className="pipeline-settings-modal__content">
-          <div className="pipeline-settings-modal__subtitle">General</div>
-          <div className="pipeline-settings-modal__header">
-            <div className="pipeline-settings-modal__name">Name</div>
-            <div className="pipeline-settings-modal__state">State</div>
-            <div className="pipeline-settings-modal__description">
-              Description
+          <div className="pipeline-settings-modal__group">
+            <div className="pipeline-settings-modal__subtitle">General</div>
+            <div className="pipeline-settings-modal__header">
+              <div className="pipeline-settings-modal__name">Name</div>
+              <div className="pipeline-settings-modal__state">State</div>
+              <div className="pipeline-settings-modal__description">
+                Description
+              </div>
             </div>
-          </div>
-          <SettingsModalRow
-            id="prettyName"
-            name={settingsConfig['prettyName'].name}
-            toggleValue={isPrettyNameOn}
-            description={settingsConfig['prettyName'].description}
-            onToggleChange={(event) => {
-              setIsPrettyNameOn(event.target.checked);
-              setHasNotInteracted(false);
-            }}
-          />
-          <div className="pipeline-settings-modal__subtitle">Experiments</div>
-          {flagData.map(({ name, value, description }) => (
             <SettingsModalRow
-              description={description}
-              id={value}
-              key={value}
-              name={name}
+              id="prettyName"
+              name={settingsConfig['prettyName'].name}
+              toggleValue={isPrettyNameOn}
+              description={settingsConfig['prettyName'].description}
               onToggleChange={(event) => {
-                onToggleFlag(value, event.target.checked);
+                setIsPrettyNameOn(event.target.checked);
                 setHasNotInteracted(false);
               }}
-              toggleValue={flags[value]}
             />
-          ))}
-          {isOutdated ? (
-            <div className="pipeline-settings-modal__upgrade-reminder">
-              <span>&#8226; Kedro-Viz {latestVersion} is here! </span>
-              <a
-                href="https://github.com/kedro-org/kedro-viz/releases"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                View release notes
-              </a>
-            </div>
-          ) : (
-            <div className="pipeline-settings-modal__already-latest">
-              <span>
-                &#8226; You are on the latest version of Kedro-Viz (
-                {latestVersion})
-              </span>
-            </div>
-          )}
+          </div>
+          <div className="pipeline-settings-modal__group">
+            <div className="pipeline-settings-modal__subtitle">Experiments</div>
+            {flagData.map(({ name, value, description }) => (
+              <SettingsModalRow
+                description={description}
+                id={value}
+                key={value}
+                name={name}
+                onToggleChange={(event) => {
+                  onToggleFlag(value, event.target.checked);
+                  setHasNotInteracted(false);
+                }}
+                toggleValue={flags[value]}
+              />
+            ))}
+            {isOutdated ? (
+              <div className="pipeline-settings-modal__upgrade-reminder">
+                <span>&#8226; Kedro-Viz {latestVersion} is here! </span>
+                <a
+                  href="https://github.com/kedro-org/kedro-viz/releases"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  View release notes
+                </a>
+              </div>
+            ) : (
+              <div className="pipeline-settings-modal__already-latest">
+                <span>
+                  &#8226; You are on the latest version of Kedro-Viz (
+                  {latestVersion})
+                </span>
+              </div>
+            )}
+          </div>
           <div className="run-details-modal-button-wrapper">
             <Button
               mode="secondary"

--- a/src/components/settings-modal/settings-modal.scss
+++ b/src/components/settings-modal/settings-modal.scss
@@ -37,7 +37,6 @@
 }
 
 .pipeline-settings-modal__content {
-  font-size: 1.25em;
   width: 100%;
 
   &--short {
@@ -47,13 +46,25 @@
   .button {
     margin: 0 10px;
   }
+
+  .pipeline-toggle {
+    margin-bottom: 0;
+  }
+}
+
+.pipeline-settings-modal__group:nth-of-type(2) {
+  margin-top: 50px;
+}
+
+.pipeline-settings-modal__column {
+  margin-bottom: 1.145em;
 }
 
 .pipeline-settings-modal__column,
 .pipeline-settings-modal__header {
   display: flex;
   flex-wrap: wrap;
-  font-size: 1.2em;
+  font-size: 1.4em;
 }
 
 .pipeline-settings-modal__header {
@@ -62,8 +73,8 @@
 }
 
 .pipeline-settings-modal__subtitle {
-  margin-bottom: 10px;
-  font-size: 1.5em;
+  margin-bottom: 24px;
+  font-size: 1.8em;
 }
 
 .pipeline-settings-modal__name {
@@ -89,5 +100,6 @@
 
 .pipeline-settings-modal__already-latest {
   color: var(--color-modal-header-text);
-  margin-bottom: 2.4em;
+  font-size: 1.3em;
+  margin: 2em 0 2.4em;
 }

--- a/src/components/ui/modal/modal.scss
+++ b/src/components/ui/modal/modal.scss
@@ -87,7 +87,7 @@ $duration-visibility: 0.4s;
 }
 
 .modal__title {
-  font-size: 1.8em;
+  font-size: 2em;
   line-height: 1.4;
   width: 100%;
   color: var(--color-modal-title);

--- a/src/config.js
+++ b/src/config.js
@@ -31,16 +31,14 @@ export const largeGraphThreshold = 1000;
 // Remember to update the 'Flags' section in the README when updating these:
 export const flags = {
   sizewarning: {
-    name: 'Size Warning',
-    description:
-      'Show a warning before rendering very large graphs (page reload required)',
+    name: 'Size warning',
+    description: 'Show a warning before rendering very large graphs',
     default: true,
     icon: '🐳',
   },
   expandAllPipelines: {
     name: 'Expand all modular pipelines',
-    description:
-      'Expand all modular pipelines on first load (page reload required)',
+    description: 'Expand all modular pipelines on first load',
     default: false,
     icon: '🔛',
   },
@@ -48,7 +46,7 @@ export const flags = {
 
 export const settings = {
   prettyName: {
-    name: 'Pretty Name',
+    name: 'Pretty name',
     description: 'Display a formatted name for the kedro nodes',
     default: true,
   },

--- a/src/styles/_mixins.scss
+++ b/src/styles/_mixins.scss
@@ -35,5 +35,4 @@
 
 @mixin flexColumn($col-num) {
   flex: 0 0 calc(100% / 12 * #{$col-num});
-  margin-top: 10px;
 }


### PR DESCRIPTION
Signed-off-by: Tynan DeBold <thdebold@gmail.com>

## Description

Fixes #877 

## Development notes

A state variable is created, and based on that `boolean`, the pretty name will be on/off when **Apply and close** is clicked.

## QA notes

View the Gitpod link, open the settings panel, and toggle **Pretty Name**.  Nothing should happen until you click on **Apply and close**, just liked the other two toggles.

Also note I removed the `(page reload required)` language, since we're not auto reloading the page when the apply button is clicked.

Further, I noticed that some of the elements didn't match the [design](https://zpl.io/2Z3WqYl), so I fixed that as well.

Before:

<img width="895" alt="image" src="https://user-images.githubusercontent.com/16869061/174784253-3eb1f2bf-7e44-47f5-a41f-00bf9bcfb41a.png">

After:

<img width="894" alt="image" src="https://user-images.githubusercontent.com/16869061/174784149-21ebbda0-d2f3-41e7-a751-bc8f6c3acb33.png">

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [x] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro-viz/pull/934"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

