### PR TITLE
Update outline property for hover adn success state

### DIFF
--- a/src/components/ui/button/button.scss
+++ b/src/components/ui/button/button.scss
@@ -75,8 +75,9 @@ $secondary-underline-offset-hover: 4px;
   }
 
   &:hover:not(:disabled) {
-    color: var(--color-button__text--hover);
     background: var(--color-button--outline);
+    color: var(--color-button__text--hover);
+    outline: none;
   }
 
   &:disabled {
@@ -131,7 +132,7 @@ $secondary-underline-offset-hover: 4px;
   animation: scale 0.35s ease;
   background-color: $color-success;
   color: $color-dark;
-  outline: 2px solid $color-success;
+  outline: none;
   width: 172px; // Match the `Apply and close` width to avoid a layout shift.
 }
 
@@ -146,12 +147,15 @@ $secondary-underline-offset-hover: 4px;
   0% {
     transform: scaleX(1);
   }
+
   50% {
     transform: scaleX(1.15);
   }
+
   75% {
     transform: scaleX(0.9);
   }
+
   100% {
     transform: scaleX(1);
   }
@@ -161,9 +165,11 @@ $secondary-underline-offset-hover: 4px;
   0% {
     transform: scale(0);
   }
+
   80% {
     transform: scale(1.25);
   }
+
   100% {
     transform: scale(1);
   }


### PR DESCRIPTION
Signed-off-by: Cvetanka <cventanka_nechevska@external.mckinsey.com>

## Description

Fixes #931 

## Development notes

Set `outline: none` for hover and success state.

## QA notes

<img width="774" alt="Screenshot 2022-07-05 at 15 34 38" src="https://user-images.githubusercontent.com/88193161/177341855-22dbd8d6-7c62-42da-94fe-b8753f5565b7.png">

<img width="370" alt="Screenshot 2022-07-05 at 15 35 49" src="https://user-images.githubusercontent.com/88193161/177341873-50798336-f8b5-4d93-aa2d-6e9855f4b11d.png">


## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes
