### PR TITLE
Fix/loading indicator flashing and React fragment class name error

### DIFF
--- a/src/components/icons/loading.scss
+++ b/src/components/icons/loading.scss
@@ -21,6 +21,7 @@ $path2-gap: $section-length;
 
   &--visible {
     opacity: 1;
+    transition-delay: 0.5s;
   }
 
   path {

--- a/src/components/ui/icon-button/icon-button.js
+++ b/src/components/ui/icon-button/icon-button.js
@@ -14,7 +14,7 @@ const IconButton = ({
   ariaLive,
   children,
   className,
-  container: Container = 'li',
+  container = 'li',
   dataHeapEvent,
   disabled,
   icon,
@@ -32,7 +32,7 @@ const IconButton = ({
     : 'right';
 
   return visible ? (
-    <Container className="pipeline-icon--container">
+    <Wrapper container={container}>
       <button
         aria-label={ariaLabel}
         aria-live={ariaLive}
@@ -57,8 +57,18 @@ const IconButton = ({
         )}
       </button>
       {children}
-    </Container>
+    </Wrapper>
   ) : null;
+};
+
+const Wrapper = ({ children, container: Container = 'li' }) => {
+  if (typeof Container === 'symbol') {
+    return <React.Fragment>{children}</React.Fragment>;
+  } else {
+    return (
+      <Container className="pipeline-icon--container">{children}</Container>
+    );
+  }
 };
 
 IconButton.propTypes = {

--- a/src/components/ui/icon-button/icon-button.test.js
+++ b/src/components/ui/icon-button/icon-button.test.js
@@ -12,7 +12,7 @@ describe('IconButton', () => {
       labelText: 'Toggle theme',
       visible: true,
     });
-    expect(wrapper.find('li').length).toBe(1);
+    expect(wrapper.find('Wrapper').length).toBe(1);
     expect(wrapper.find('.pipeline-icon-toolbar__button').length).toBe(1);
   });
 


### PR DESCRIPTION
## Description

After #970, the loading indicator became a bit of nuisance with the new placement. This change will ensure it only appears after half a second.

It also fixes a `console` error that cropped up in the `IconButton` component:

<img width="832" alt="image" src="https://user-images.githubusercontent.com/16869061/181590054-76ad4a22-ddec-49ac-b5aa-9d408ed3d911.png">

## Development notes

I only added a `transition-delay` to fix the icon flashing.

## QA notes

Look at the Gitpod link and then load the demo dataset (add this to the end of the Gitpod URL: `/?data=demo`), which is larger, to see the icon appear on initial page load. Then click on some nodes and notice that it doesn't appear again.

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro-viz/pull/991"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

