### PR TITLE
Make package a phony target to fix release_to_pypi

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+.PHONY: package
+
 package:
 	find . -regex ".*/__pycache__" -exec rm -rf {} +
 	find . -regex ".*\.egg-info" -exec rm -rf {} +


### PR DESCRIPTION
## Description

This should mean that `make package` no longer gives the "up to date" message (no need to use `-B` to force it any more). See https://www.gnu.org/software/make/manual/html_node/Phony-Targets.html.

## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro-viz/pull/996"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

