### PR TITLE
Remove support for Kedro v16

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,6 +6,10 @@ Please follow the established format:
 - Include the ID number for the related PR (or PRs) in parentheses
 -->
 
+## Major features and improvements
+
+- Remove support for Kedro v16. (#998)
+
 # Release 4.7.2
 
 ## Bug fixes and other changes

--- a/package/kedro_viz/integrations/kedro/data_loader.py
+++ b/package/kedro_viz/integrations/kedro/data_loader.py
@@ -123,10 +123,3 @@ def load_data(
                 session_store_location = session_store.location
 
         return context.catalog, context.pipelines, session_store_location
-
-    # pre-0.17 load_context version
-    # pylint: disable=no-name-in-module
-    from kedro.framework.context import load_context  # type: ignore
-
-    context = load_context(project_path=project_path, env=env)
-    return context.catalog, context.pipelines, None

--- a/package/kedro_viz/integrations/kedro/data_loader.py
+++ b/package/kedro_viz/integrations/kedro/data_loader.py
@@ -101,25 +101,25 @@ def load_data(
 
         return context.catalog, context.pipelines, session_store_location
 
-    if KEDRO_VERSION.match("==0.17.0"):
-        from kedro.framework.session import KedroSession
-        from kedro.framework.startup import _get_project_metadata
+    # Since Viz is only compatible with kedro>=0.17.0, this just matches 0.17.0
+    from kedro.framework.session import KedroSession
+    from kedro.framework.startup import _get_project_metadata
 
-        from kedro_viz.integrations.kedro.sqlite_store import SQLiteStore
+    from kedro_viz.integrations.kedro.sqlite_store import SQLiteStore
 
-        metadata = _get_project_metadata(project_path)
-        with KedroSession.create(
-            package_name=metadata.package_name,
-            project_path=project_path,
-            env=env,
-            save_on_close=False,
-            extra_params=extra_params,
-        ) as session:
+    metadata = _get_project_metadata(project_path)
+    with KedroSession.create(
+        package_name=metadata.package_name,
+        project_path=project_path,
+        env=env,
+        save_on_close=False,
+        extra_params=extra_params,
+    ) as session:
 
-            context = session.load_context()
-            session_store = session._store
-            session_store_location = None
-            if isinstance(session_store, SQLiteStore):
-                session_store_location = session_store.location
+        context = session.load_context()
+        session_store = session._store
+        session_store_location = None
+        if isinstance(session_store, SQLiteStore):
+            session_store_location = session_store.location
 
-        return context.catalog, context.pipelines, session_store_location
+    return context.catalog, context.pipelines, session_store_location

--- a/package/requirements.txt
+++ b/package/requirements.txt
@@ -1,5 +1,5 @@
 semver~=2.10 # Needs to be at least 2.10.0 to get VersionInfo.match
-kedro>=0.16.0
+kedro>=0.17.0
 ipython>=7.0.0, <8.0
 fastapi>=0.63.0, <0.67.0
 aiofiles==0.6.0


### PR DESCRIPTION
Signed-off-by: Tynan DeBold <thdebold@gmail.com>

## Description

Resolves #967.

Would this be a breaking change if a user is still using v16 of Kedro?

## Development notes

Removed one `else` statement and bumped the version in the requirements file.

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro-viz/pull/998"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

