### PR TITLE
Fix plots not showing on Metadata panel

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -9,6 +9,7 @@ Please follow the established format:
 ## Bug fixes and other changes
 
 - Don't reset the zoom each time a node is selected. (#988)
+- Fix for plots not showing on Metadata panel. (#1014)
 
 # Release 5.0.0
 

--- a/package/kedro_viz/models/experiment_tracking.py
+++ b/package/kedro_viz/models/experiment_tracking.py
@@ -106,8 +106,7 @@ class TrackingDatasetModel:
                 exc,
             )
             self.runs[run_id] = {}
-
-        self.dataset._version = None
+            self.dataset._version = None
 
 
 def get_dataset_type(dataset: AbstractVersionedDataSet) -> str:


### PR DESCRIPTION
Signed-off-by: Rashida Kanchwala <rashida.kanchwala@quantumblack.com>

## Description

Plots were not showing on metadata panel after you clicked on experiment tracking and refreshed the page. This was a bug noticed on the demo site but we were also able to replicate it locally. 

The issue was in models/experiment_tracking.py we set self.dataset._version = None everytime and we only need to set it when there's no run/no dataset. I have fixed this 

## Development notes

<!-- What have you changed? Consider adding a screenshot or GIF. -->

## QA notes

<!-- How has the expected behaviour changed? What testing strategies have you used? -->

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [x] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro-viz/pull/1014"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

