### PR TITLE
Remove "exists() not implemented" warning

### DIFF
--- a/package/kedro_viz/models/flowchart.py
+++ b/package/kedro_viz/models/flowchart.py
@@ -580,6 +580,14 @@ class DataNodeMetadata(GraphNodeMetadata):
         if not data_node.is_free_input:
             self.run_command = f'kedro run --to-outputs="{data_node.full_name}"'
 
+        # Only check for existence of dataset if we might want to load it.
+        if not (
+            data_node.is_plot_node()
+            or data_node.is_image_node()
+            or data_node.is_tracking_node()
+        ):
+            return
+            
         # dataset.release clears the cache before loading to ensure that this issue
         # does not arise: https://github.com/kedro-org/kedro-viz/pull/573.
         dataset.release()

--- a/package/kedro_viz/models/flowchart.py
+++ b/package/kedro_viz/models/flowchart.py
@@ -587,7 +587,7 @@ class DataNodeMetadata(GraphNodeMetadata):
             or data_node.is_tracking_node()
         ):
             return
-            
+
         # dataset.release clears the cache before loading to ensure that this issue
         # does not arise: https://github.com/kedro-org/kedro-viz/pull/573.
         dataset.release()


### PR DESCRIPTION
## Description

This will remove the WARNING message written about in https://github.com/kedro-org/kedro-viz/issues/1043. We no longer check for the existence of a dataset if it's not a type that we're trying to load.

This is just a quick fix without any tests since, as per my comments in #1043, this whole `DataNodeMetadata` loading scheme is a bit of a mess and ripe for a refactor and improved tests.

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro-viz/pull/1044"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

