### PR TITLE
Fix Windows CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 .PHONY: package
 
-
 clean:
 	rm -rf build package/build package/dist package/kedro_viz/html pip-wheel-metadata package/kedro_viz.egg-info
 

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,12 @@
 .PHONY: package
 
+
 clean:
-	find . -regex ".*/__pycache__" -exec rm -rf {} +
-	find . -regex ".*\.egg-info" -exec rm -rf {} +
 	rm -rf build package/build package/dist package/kedro_viz/html pip-wheel-metadata package/kedro_viz.egg-info
 
 package: clean
+        find . -regex ".*/__pycache__" -exec rm -rf {} +
+	find . -regex ".*\.egg-info" -exec rm -rf {} +
 	cd package && python setup.py clean --all
 	cd package && python setup.py sdist bdist_wheel
 


### PR DESCRIPTION
## Description

Silly Windows doesn't understand `find`, which was being executed by `make build` (through `clean`). We now only use this command in `make package`, which is only run on Linux.

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro-viz/pull/1049"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

