### PR TITLE
Fix makefile indentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ clean:
 	rm -rf build package/build package/dist package/kedro_viz/html pip-wheel-metadata package/kedro_viz.egg-info
 
 package: clean
-        find . -regex ".*/__pycache__" -exec rm -rf {} +
+	find . -regex ".*/__pycache__" -exec rm -rf {} +
 	find . -regex ".*\.egg-info" -exec rm -rf {} +
 	cd package && python setup.py clean --all
 	cd package && python setup.py sdist bdist_wheel


### PR DESCRIPTION
Signed-off-by: Tynan DeBold <thdebold@gmail.com>

## Description

The indentation was saved incorrectly. This fixes that.

## QA notes

Ensure you can run the `make` commands locally.

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro-viz/pull/1050"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

