### PR TITLE
Fix Kedro-viz to work with strawberry 0.128.0

### DIFF
--- a/package/kedro_viz/api/graphql/schema.py
+++ b/package/kedro_viz/api/graphql/schema.py
@@ -129,7 +129,7 @@ class Mutation:
             updated_run.bookmark,
             updated_run.notes,
         )
-        return UpdateRunDetailsSuccess(updated_run)
+        return UpdateRunDetailsSuccess(run=updated_run)
 
 
 @strawberry.type

--- a/package/requirements.txt
+++ b/package/requirements.txt
@@ -8,5 +8,5 @@ watchgod~=0.8.0
 plotly>=4.0
 pandas>=0.24
 sqlalchemy~=1.2
-strawberry-graphql>=0.99.0, <=0.127.0
+strawberry-graphql>=0.99.0, <1.0
 networkx>=1.0


### PR DESCRIPTION
## Description

A small fix in mutation UpdateRunDetails based on the latest strawberry release that introduced a breaking change  (https://github.com/strawberry-graphql/strawberry/releases/tag/0.128.0)

## Development notes

<!-- What have you changed? Consider adding a screenshot or GIF. -->

## QA notes

<!-- How has the expected behaviour changed? What testing strategies have you used? -->

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro-viz/pull/1056"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

