### PR TITLE
Create initial depandabot.yml to tackle batch python dependency update

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "pip" # See documentation for possible values
+    directory: "/package" # Location of package manifests
+    schedule:
+      interval: "weekly"
+updates:
+  - package-ecosystem: "pip" # See documentation for possible values
+    directory: "/demo-project/src" # Location of package manifests
+    schedule:
+      interval: "weekly"
+updates:
+  - package-ecosystem: "npm" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"
+

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,15 +8,11 @@ updates:
   - package-ecosystem: "pip" # See documentation for possible values
     directory: "/package" # Location of package manifests
     schedule:
-      interval: "weekly"
-updates:
-  - package-ecosystem: "pip" # See documentation for possible values
-    directory: "/demo-project/src" # Location of package manifests
-    schedule:
-      interval: "weekly"
-updates:
-  - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/" # Location of package manifests
-    schedule:
-      interval: "weekly"
-
+      interval: "daily"
+    target-branch: "dependency-update"
+    ignore:
+      - dependency-name: "types-*"
+    labels:
+      - "python"
+      - "dependencies"
+    open-pull-requests-limit: 50


### PR DESCRIPTION
## Description

Resolves #814

This ticket adds 'Dependabot Version Update' for all python dependencies except mypy dependencies in test_requirements. 
We made a decision (@AntonyMilneQB , @tynandebold ) to limit front-end to only 'Dependabot Security Updates'

Since this is the first time we are doing this, there's a long list of python dependencies that needs to be updated (~20) For this purpose we have set up this ticket as the initial dependabot PR to do a batch update. 

Following this we will create another PR with slightly different configurations to handle regular updates. 

## Development notes

Since this is the initial depandabot.yml file to tackle a batch (~20) python dependency updates, I have made some temporary changes in the yml file 

open-pull-request-limit : 50 (This will be removed post the batch and set to default 5)
target-branch : dependency update (This might be removed, or maybe kept for future) 
schedule : this is a mandatory config to depandabot.yml. for now, I have set it to daily but moving forward it will be weekly.

I have implmented a version of this dependabot PR on a forked branch and it works as expected - https://github.com/rashidakanchwala/kedro-viz-5/pulls  


## QA notes

<!-- How has the expected behaviour changed? What testing strategies have you used? -->

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro-viz/pull/1060"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

