### PR TITLE
Fix pretty name for transcoded datasets

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,6 +6,12 @@ Please follow the established format:
 - Include the ID number for the related PR (or PRs) in parentheses
 -->
 
+# Release 5.
+
+## Bug fixes and other changes
+
+- Fix pretty name for transcoded datasets. (#1062)
+
 # Release 5.1.1
 
 ## Bug fixes and other changes

--- a/package/kedro_viz/models/flowchart.py
+++ b/package/kedro_viz/models/flowchart.py
@@ -206,7 +206,7 @@ class GraphNode(abc.ABC):
             dataset_name = _strip_transcoding(full_name)
             return TranscodedDataNode(
                 id=cls._hash(dataset_name),
-                name=_pretty_name(dataset_name),
+                name=_pretty_name(_strip_namespace(dataset_name)),
                 full_name=dataset_name,
                 tags=tags,
                 layer=layer,

--- a/package/tests/test_models/test_flowchart.py
+++ b/package/tests/test_models/test_flowchart.py
@@ -143,11 +143,24 @@ class TestGraphNodeCreation:
         assert not data_node.is_json_node()
         assert not data_node.is_tracking_node()
 
-
-    def test_create_transcoded_data_node(self):
-        dataset_name = "test.dataset@pandas2"
-        original_name = "test.dataset"
-        pretty_name = "Dataset"
+    @pytest.mark.parametrize(
+        "dataset_name, original_name, pretty_name",
+        [
+            (
+                "dataset@pandas2",
+                "dataset",
+                "Dataset",
+            ),
+            (
+                "uk.data_science.model_training.dataset@pandas2",
+                "uk.data_science.model_training.dataset",
+                "Dataset",
+            ),
+        ],
+    )
+    def test_create_transcoded_data_node(
+        self, dataset_name, original_name, pretty_name
+    ):
         kedro_dataset = CSVDataSet(filepath="foo.csv")
         data_node = GraphNode.create_data_node(
             full_name=dataset_name,

--- a/package/tests/test_models/test_flowchart.py
+++ b/package/tests/test_models/test_flowchart.py
@@ -143,9 +143,10 @@ class TestGraphNodeCreation:
         assert not data_node.is_json_node()
         assert not data_node.is_tracking_node()
 
+
     def test_create_transcoded_data_node(self):
-        dataset_name = "dataset@pandas2"
-        original_name = "dataset"
+        dataset_name = "test.dataset@pandas2"
+        original_name = "test.dataset"
         pretty_name = "Dataset"
         kedro_dataset = CSVDataSet(filepath="foo.csv")
         data_node = GraphNode.create_data_node(


### PR DESCRIPTION
## Description

Resolves #859 

## Development notes

I realised that there was a bug; for transcoded datasets we did not strip the namespace like we did for the rest so I have added that now. 

## QA notes

<!-- How has the expected behaviour changed? What testing strategies have you used? -->

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro-viz/pull/1062"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

