### PR TITLE
Keep graph visible when switching pipelines

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -15,6 +15,7 @@ Please follow the established format:
 ## Bug fixes and other changes
 
 - Fix pretty naming for transcoded datasets. (#1062)
+- Keep graph visible when switching pipelines. (#1063)
 
 # Release 5.1.1
 

--- a/src/actions/pipelines.js
+++ b/src/actions/pipelines.js
@@ -1,7 +1,7 @@
 import { getUrl } from '../utils';
 import loadJsonData from '../store/load-data';
 import { preparePipelineState } from '../store/initial-state';
-import { resetData, toggleGraph } from './index';
+import { resetData } from './index';
 
 /**
  * This file contains actions that update the active pipeline, and if loading data
@@ -69,6 +69,7 @@ export const requiresSecondRequest = (pipeline) => {
   if (!pipeline.ids.length || !pipeline.main) {
     return false;
   }
+
   // There is no active pipeline set
   if (!pipeline.active) {
     return false;
@@ -122,22 +123,25 @@ export function loadInitialPipelineData() {
 export function loadPipelineData(pipelineID) {
   return async function (dispatch, getState) {
     const { dataSource, pipeline, display, flags } = getState();
+
     if (pipelineID && pipelineID === pipeline.active) {
       return;
     }
+
     if (dataSource === 'json') {
       dispatch(toggleLoading(true));
-      // Remove the previous graph to show that a new pipeline is being loaded
-      dispatch(toggleGraph(false));
+
       const url = getPipelineUrl({
         main: pipeline.main,
         active: pipelineID,
       });
+
       const expandAllPipelines =
         display.expandAllPipelines || flags.expandAllPipelines;
       const newState = await loadJsonData(url).then((data) =>
         preparePipelineState(data, false, expandAllPipelines)
       );
+
       // Set active pipeline here rather than dispatching two separate actions,
       // to improve performance by only requiring one state recalculation
       newState.pipeline.active = pipelineID;

--- a/src/actions/pipelines.test.js
+++ b/src/actions/pipelines.test.js
@@ -181,16 +181,6 @@ describe('pipeline actions', () => {
         expect(store.getState().loading.pipeline).toBe(true);
       });
 
-      it('should hide the current graph before loading the new pipeline', () => {
-        const store = createStore(reducer, {
-          ...mockState.spaceflights,
-          dataSource: 'json',
-        });
-        expect(store.getState().visible.graph).toBe(true);
-        loadPipelineData(active)(store.dispatch, store.getState);
-        expect(store.getState().visible.graph).toBe(false);
-      });
-
       it('should set loading to false when complete', async () => {
         const store = createStore(reducer, mockState.json);
         await loadPipelineData(active)(store.dispatch, store.getState);


### PR DESCRIPTION
Signed-off-by: Tynan DeBold <thdebold@gmail.com>

## Description

Fixes #1059 and reverts #296.

## Development notes

We no longer set the graph's visibility to `false` when changing pipelines. This removes the flash of a blank graph area just before the newly selected pipeline loads.

## QA notes

Check the Gitpod link and select different pipelines from the dropdown. Notice the nicely morph into each other instead of flashing. Compare with what happens on the [demo site](https://demo.kedro.org/) to see the flashing.

I haven't checked this on a massive pipeline. I believe it should work just fine though.

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro-viz/pull/1063"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

