### PR TITLE
Refactor /main response and save_file result

### DIFF
--- a/package/.pylintrc
+++ b/package/.pylintrc
@@ -292,7 +292,7 @@ ignored-classes=optparse.Values,thread._local,_thread._local
 # (useful for modules/projects where namespaces are manipulated during runtime
 # and thus existing member attributes cannot be deduced by static analysis. It
 # supports qualified module names, as well as Unix pattern matching.
-ignored-modules=
+ignored-modules=orjson
 
 # Show a hint with possible names when a member name was not found. The aspect
 # of finding the hint is based on edit distance.

--- a/package/kedro_viz/api/apps.py
+++ b/package/kedro_viz/api/apps.py
@@ -12,6 +12,7 @@ from fastapi.staticfiles import StaticFiles
 from jinja2 import Environment, FileSystemLoader
 
 from kedro_viz import __version__
+from kedro_viz.api.rest.responses import EnhancedORJSONResponse
 from kedro_viz.integrations.kedro import telemetry as kedro_telemetry
 
 from .graphql.router import router as graphql_router
@@ -27,7 +28,10 @@ def _create_etag() -> str:
 
 def _create_base_api_app() -> FastAPI:
     return FastAPI(
-        title="Kedro-Viz API", description="REST API for Kedro-Viz", version=__version__
+        title="Kedro-Viz API",
+        description="REST API for Kedro-Viz",
+        version=__version__,
+        default_response_class=EnhancedORJSONResponse,
     )
 
 

--- a/package/kedro_viz/api/rest/responses.py
+++ b/package/kedro_viz/api/rest/responses.py
@@ -1,7 +1,7 @@
 """`kedro_viz.api.rest.responses` defines REST response types."""
 # pylint: disable=missing-class-docstring,too-few-public-methods
 import abc
-from typing import Dict, List, Optional, Union, Any
+from typing import Any, Dict, List, Optional, Union
 
 import orjson
 from fastapi.encoders import jsonable_encoder
@@ -84,7 +84,8 @@ class DataNodeAPIResponse(BaseGraphNodeAPIResponse):
 
 
 NodeAPIResponse = Union[
-    TaskNodeAPIResponse, DataNodeAPIResponse,
+    TaskNodeAPIResponse,
+    DataNodeAPIResponse,
 ]
 
 
@@ -248,8 +249,10 @@ def get_default_response() -> GraphAPIResponse:
         data_access_manager.get_default_selected_pipeline().id
     )
 
-    modular_pipelines_tree = data_access_manager.create_modular_pipelines_tree_for_registered_pipeline(
-        default_selected_pipeline_id
+    modular_pipelines_tree = (
+        data_access_manager.create_modular_pipelines_tree_for_registered_pipeline(
+            default_selected_pipeline_id
+        )
     )
 
     return GraphAPIResponse(
@@ -269,7 +272,7 @@ def get_default_response() -> GraphAPIResponse:
     )
 
 
-class ORJSONResponse(ORJSONResponse):
+class EnhancedORJSONResponse(ORJSONResponse):
     @staticmethod
     def write_to_file(content: Any) -> bytes:
         encoded_content = jsonable_encoder(content)

--- a/package/kedro_viz/api/rest/responses.py
+++ b/package/kedro_viz/api/rest/responses.py
@@ -4,7 +4,6 @@ import abc
 from typing import Any, Dict, List, Optional, Union
 
 import orjson
-from fastapi.encoders import jsonable_encoder
 from fastapi.responses import ORJSONResponse
 from pydantic import BaseModel
 
@@ -282,9 +281,8 @@ class EnhancedORJSONResponse(ORJSONResponse):
             A bytes object containing the JSON to write.
 
         """
-        encoded_content = jsonable_encoder(content)
         return orjson.dumps(
-            encoded_content,
+            content,
             option=orjson.OPT_INDENT_2
             | orjson.OPT_NON_STR_KEYS
             | orjson.OPT_SERIALIZE_NUMPY,

--- a/package/kedro_viz/api/rest/responses.py
+++ b/package/kedro_viz/api/rest/responses.py
@@ -274,7 +274,14 @@ def get_default_response() -> GraphAPIResponse:
 
 class EnhancedORJSONResponse(ORJSONResponse):
     @staticmethod
-    def write_to_file(content: Any) -> bytes:
+    def encode_to_human_readable(content: Any) -> bytes:
+        """A method to encode the given content to JSON, with the
+        proper formatting to write a human-readable file.
+
+        Returns:
+            A bytes object containing the JSON to write.
+
+        """
         encoded_content = jsonable_encoder(content)
         return orjson.dumps(
             encoded_content,

--- a/package/kedro_viz/api/rest/router.py
+++ b/package/kedro_viz/api/rest/router.py
@@ -16,9 +16,9 @@ from kedro_viz.models.flowchart import (
 
 from .responses import (
     APIErrorMessage,
+    EnhancedORJSONResponse,
     GraphAPIResponse,
     NodeMetadataAPIResponse,
-    ORJSONResponse,
     get_default_response,
 )
 
@@ -28,7 +28,7 @@ router = APIRouter(
 )
 
 
-@router.get("/main", response_class=ORJSONResponse)
+@router.get("/main", response_class=EnhancedORJSONResponse)
 async def main():
     return get_default_response()
 

--- a/package/kedro_viz/api/rest/router.py
+++ b/package/kedro_viz/api/rest/router.py
@@ -18,6 +18,7 @@ from .responses import (
     APIErrorMessage,
     GraphAPIResponse,
     NodeMetadataAPIResponse,
+    ORJSONResponse,
     get_default_response,
 )
 
@@ -27,7 +28,7 @@ router = APIRouter(
 )
 
 
-@router.get("/main", response_model=GraphAPIResponse)
+@router.get("/main", response_class=ORJSONResponse)
 async def main():
     return get_default_response()
 

--- a/package/kedro_viz/api/rest/router.py
+++ b/package/kedro_viz/api/rest/router.py
@@ -28,7 +28,7 @@ router = APIRouter(
 )
 
 
-@router.get("/main", response_class=EnhancedORJSONResponse)
+@router.get("/main", response_model=GraphAPIResponse)
 async def main():
     return get_default_response()
 

--- a/package/kedro_viz/api/rest/router.py
+++ b/package/kedro_viz/api/rest/router.py
@@ -16,7 +16,6 @@ from kedro_viz.models.flowchart import (
 
 from .responses import (
     APIErrorMessage,
-    EnhancedORJSONResponse,
     GraphAPIResponse,
     NodeMetadataAPIResponse,
     get_default_response,

--- a/package/kedro_viz/server.py
+++ b/package/kedro_viz/server.py
@@ -89,7 +89,7 @@ def run_server(
         populate_data(data_access_manager, catalog, pipelines, session_store_location)
         if save_file:
             default_response = get_default_response()
-            encoded_default_response = EnhancedORJSONResponse.write_to_file(
+            encoded_default_response = EnhancedORJSONResponse.encode_to_human_readable(
                 default_response
             )
             Path(save_file).write_bytes(encoded_default_response)

--- a/package/kedro_viz/server.py
+++ b/package/kedro_viz/server.py
@@ -9,7 +9,7 @@ from kedro.pipeline import Pipeline
 from watchgod import run_process
 
 from kedro_viz.api import apps
-from kedro_viz.api.rest.responses import get_default_response, ORJSONResponse
+from kedro_viz.api.rest.responses import EnhancedORJSONResponse, get_default_response
 from kedro_viz.data_access import DataAccessManager, data_access_manager
 from kedro_viz.database import create_db_engine
 from kedro_viz.integrations.kedro import data_loader as kedro_data_loader
@@ -89,7 +89,9 @@ def run_server(
         populate_data(data_access_manager, catalog, pipelines, session_store_location)
         if save_file:
             default_response = get_default_response()
-            encoded_default_response = ORJSONResponse.write_to_file(default_response)
+            encoded_default_response = EnhancedORJSONResponse.write_to_file(
+                default_response
+            )
             Path(save_file).write_bytes(encoded_default_response)
         app = apps.create_api_app_from_project(path, autoreload)
     else:

--- a/package/kedro_viz/server.py
+++ b/package/kedro_viz/server.py
@@ -9,7 +9,7 @@ from kedro.pipeline import Pipeline
 from watchgod import run_process
 
 from kedro_viz.api import apps
-from kedro_viz.api.rest.responses import get_default_response
+from kedro_viz.api.rest.responses import get_default_response, ORJSONResponse
 from kedro_viz.data_access import DataAccessManager, data_access_manager
 from kedro_viz.database import create_db_engine
 from kedro_viz.integrations.kedro import data_loader as kedro_data_loader
@@ -88,14 +88,9 @@ def run_server(
         )
         populate_data(data_access_manager, catalog, pipelines, session_store_location)
         if save_file:
-            response = get_default_response()
-            try:
-                Path(save_file).write_text(response.json(indent=4, sort_keys=True))
-            except TypeError:  # pragma: no cover
-                # Keys of incomparable types (e.g. string and int) cannot be sorted.
-                Path(save_file).write_text(
-                    response.json(indent=4, sort_keys=False)
-                )  # pragma: no cover
+            default_response = get_default_response()
+            encoded_default_response = ORJSONResponse.write_to_file(default_response)
+            Path(save_file).write_bytes(encoded_default_response)
         app = apps.create_api_app_from_project(path, autoreload)
     else:
         app = apps.create_api_app_from_file(load_file)

--- a/package/kedro_viz/server.py
+++ b/package/kedro_viz/server.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import Any, Dict, Optional
 
 import uvicorn
+from fastapi.encoders import jsonable_encoder
 from kedro.io import DataCatalog
 from kedro.pipeline import Pipeline
 from watchgod import run_process
@@ -14,8 +15,6 @@ from kedro_viz.data_access import DataAccessManager, data_access_manager
 from kedro_viz.database import create_db_engine
 from kedro_viz.integrations.kedro import data_loader as kedro_data_loader
 from kedro_viz.models.experiment_tracking import Base
-
-from fastapi.encoders import jsonable_encoder
 
 DEFAULT_HOST = "127.0.0.1"
 DEFAULT_PORT = 4141

--- a/package/kedro_viz/server.py
+++ b/package/kedro_viz/server.py
@@ -15,6 +15,8 @@ from kedro_viz.database import create_db_engine
 from kedro_viz.integrations.kedro import data_loader as kedro_data_loader
 from kedro_viz.models.experiment_tracking import Base
 
+from fastapi.encoders import jsonable_encoder
+
 DEFAULT_HOST = "127.0.0.1"
 DEFAULT_PORT = 4141
 DEV_PORT = 4142
@@ -89,8 +91,9 @@ def run_server(
         populate_data(data_access_manager, catalog, pipelines, session_store_location)
         if save_file:
             default_response = get_default_response()
+            jsonable_default_response = jsonable_encoder(default_response)
             encoded_default_response = EnhancedORJSONResponse.encode_to_human_readable(
-                default_response
+                jsonable_default_response
             )
             Path(save_file).write_bytes(encoded_default_response)
         app = apps.create_api_app_from_project(path, autoreload)

--- a/package/requirements.txt
+++ b/package/requirements.txt
@@ -10,3 +10,4 @@ pandas>=0.24
 sqlalchemy~=1.2
 strawberry-graphql>=0.99.0, <1.0
 networkx>=1.0
+orjson~=3.8.0

--- a/package/requirements.txt
+++ b/package/requirements.txt
@@ -10,4 +10,4 @@ pandas>=0.24
 sqlalchemy~=1.2
 strawberry-graphql>=0.99.0, <1.0
 networkx>=1.0
-orjson~=3.8.0
+orjson~=3.8


### PR DESCRIPTION
## Description
This PR attempts a solution to two problems:

1. It resolves https://github.com/kedro-org/kedro-viz/issues/749 (including cases with arbitrarily nested values).
2. It ensures the same response is received from the /main endpoint and from specifying a save_file in server.py.

With regards to 1., it has the disadvantage that it will encode both .nan and .inf as null, I think it would be far better for the user if it encoded these as the strings "NaN" and "Infinity", respectively.

We could implement this by using a custom encoder for float with fastapi.encoders.jsonable_encoder, though we will need to upgrade fastapi to 0.73.0 for this feature. Since this seems to break a few tests, I will open a separate ticket for this.

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro-viz/pull/1087"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

