### PR TITLE
FixCircleCI by fixing python version to 3.10 for win-builds 

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -18,7 +18,7 @@ orbs:
 
 # No windows executor is listed here since windows builds use win/default and modify
 # the Python version through the conda environment.
-# Python 3.10 is pinned to 3.10.6 to work with current version of mypy
+# Python 3.10 is pinned temporarily to 3.10.6 to work with current version of mypy
 executors:
   docker:
     parameters:
@@ -312,7 +312,8 @@ workflows:
       - win_e2e_tests:
           matrix:
             parameters:
-              python_version: ['3.7', '3.8', '3.9', '3.10.6']
+              #3.10.6 fails with win-build, hence reverting it to 3.10 
+              python_version: ['3.7', '3.8', '3.9', '3.10']
           filters:
             branches:
               only:


### PR DESCRIPTION
## Description

We recently pinned python to 3.10.6 on circleCI so that it works with mypy (until [mypy](https://github.com/python/mypy/issues/13627) patch version to fix this issue is released). But 3.10.6 fails on Windows, so for now we only win e2e tests for 3.10 version 

## Development notes

<!-- What have you changed? Consider adding a screenshot or GIF. -->

## QA notes

<!-- How has the expected behaviour changed? What testing strategies have you used? -->

## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro-viz/pull/1095"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

