### PR TITLE
Fix/Faded nodes not part of clicked dataset

### DIFF
--- a/src/components/flowchart/draw.js
+++ b/src/components/flowchart/draw.js
@@ -269,7 +269,7 @@ export const drawNodes = function (changed) {
       );
   }
 
-  if (changed('nodes', 'nodeActive', 'hoveredFocusMode')) {
+  if (changed('hoveredFocusMode', 'nodes')) {
     allNodes.classed(
       'pipeline-node--faded',
       (node) => hoveredFocusMode && !nodeActive[node.id]

--- a/src/components/flowchart/draw.js
+++ b/src/components/flowchart/draw.js
@@ -269,7 +269,7 @@ export const drawNodes = function (changed) {
       );
   }
 
-  if (changed('hoveredFocusMode', 'nodes')) {
+  if (changed('hoveredFocusMode')) {
     allNodes.classed(
       'pipeline-node--faded',
       (node) => hoveredFocusMode && !nodeActive[node.id]

--- a/src/components/flowchart/flowchart.js
+++ b/src/components/flowchart/flowchart.js
@@ -144,13 +144,10 @@ export class FlowChart extends Component {
         'hoveredParameters',
         'nodesWithInputParams',
         'focusMode',
-        'inputOutputDataNodes'
+        'inputOutputDataNodes',
+        'hoveredFocusMode'
       )
     ) {
-      drawNodes.call(this, changed);
-    }
-
-    if (changed('hoveredFocusMode', 'nodes')) {
       drawNodes.call(this, changed);
     }
 

--- a/src/components/flowchart/flowchart.js
+++ b/src/components/flowchart/flowchart.js
@@ -150,7 +150,7 @@ export class FlowChart extends Component {
       drawNodes.call(this, changed);
     }
 
-    if (changed('nodes', 'nodeActive', 'hoveredFocusMode')) {
+    if (changed('hoveredFocusMode', 'nodes')) {
       drawNodes.call(this, changed);
     }
 


### PR DESCRIPTION
## Description
A small fix in flowchart, faded nodes not part of clicked dataset. Found by @tynandebold , after this PR was merged: #1107.


## Development notes
Remove 'nodeActive' from the condition that was created for adding 'faded' class when hovering on FocusModeIcon because nodes were not updated properly, when some dataset is clicked.

Before:
<img width="1783" alt="Screenshot 2022-10-10 at 16 55 07" src="https://user-images.githubusercontent.com/88193161/194895221-5106bc0e-5cbd-4bcb-8bf5-7c5a64d31f7d.png">

After:
<img width="1575" alt="Screenshot 2022-10-10 at 16 54 17" src="https://user-images.githubusercontent.com/88193161/194895258-9f52332a-2a2d-468b-9a57-fba4264206bc.png">


## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro-viz/pull/1131"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

