### PR TITLE
Fix behaviour for icons on the utility bar

### DIFF
--- a/src/components/ui/icon-button/icon-button.js
+++ b/src/components/ui/icon-button/icon-button.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import './icon-button.css';
@@ -25,11 +25,28 @@ const IconButton = ({
 }) => {
   const Icon = icon;
 
+  const [isTooltipVisible, setIsTooltipVisible] = useState(false);
+
   const labelPosition = labelPositionTypes.includes(
     labelTextPosition.toLowerCase()
   )
     ? labelTextPosition.toLocaleLowerCase()
     : 'right';
+
+  const showTooltip = () => {
+    if (localStorage.getItem('delayShow') === null) {
+      window.localStorage.setItem('delayShow', true);
+      setTimeout(() => {
+        setIsTooltipVisible(true);
+      }, 2000);
+    } else {
+      setIsTooltipVisible(true);
+    }
+  };
+
+  const hideTooltip = () => {
+    setIsTooltipVisible(false);
+  };
 
   return visible ? (
     <Wrapper container={container}>
@@ -43,9 +60,11 @@ const IconButton = ({
         data-heap-event={dataHeapEvent}
         disabled={disabled}
         onClick={onClick}
+        onMouseEnter={showTooltip}
+        onMouseLeave={hideTooltip}
       >
         {Icon && <Icon className="pipeline-icon" />}
-        {labelText && (
+        {labelText && isTooltipVisible && (
           <span
             className={classnames(
               'pipeline-toolbar__label',

--- a/src/components/ui/icon-button/icon-button.scss
+++ b/src/components/ui/icon-button/icon-button.scss
@@ -62,14 +62,13 @@ $triangle-size: 7px;
   display: inline-block;
 
   font-size: 1.4em;
-  opacity: 0;
+  opacity: 1;
 
   padding: 0.5em 0.7em;
   pointer-events: none;
 
   position: absolute;
 
-  transition: opacity ease 0.1s;
   white-space: nowrap;
 
   // to ensure the tooltip will show on the top of the bookmark dropdown
@@ -86,9 +85,7 @@ $triangle-size: 7px;
 
   .pipeline-icon-toolbar__button:hover &,
   [data-whatinput='keyboard'] .pipeline-icon-toolbar__button:focus & {
-    opacity: 1;
     pointer-events: all;
-    transition-delay: 1s;
   }
 
   &::after {


### PR DESCRIPTION
## Description

Fixes #909 

## Development notes
Changed the way tooltips on IconButtons are displayed. Instead of hovering the element and changing the visibility from the css, I've created a local state which is updated accordingly `onMouseEnter` and `onMouseLeave` events.

When a user triggers the `onMouseEnter` event for the first time in the current session, that is saved in the localStorage. So only in this scenario we will have 2s delay for displaying the tooltip, after that tooltips are displayed immediately.

**Q:** What is missing is when should the localStorage be cleared?

**Tests:**

Last three tests for the IconButton component are failing, so I will need help with that part.

I think the problem is here:

```
{labelText && isTooltipVisible && (
  <span
    className={classnames(
       'pipeline-toolbar__label',
        `pipeline-toolbar__label-${labelPosition}`
    )}
  >
     {labelText}
  </span>
)}
```
      
as now we are having plus `isTooltipVisible`, so for these tests to pass we need to specify that `isTooltipVisible=true`.

## QA notes

<!-- How has the expected behaviour changed? What testing strategies have you used? -->

## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes
