### PR TITLE
Fix Windows CircleCI nvm issue

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -62,6 +62,7 @@ commands:
             Start-Process powershell -verb runAs -Args "-start GeneralProfile"
             nvm install 16.13.2
             nvm use 16.13.2
+            npm install
 
   npm_build:
     steps:

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -50,7 +50,7 @@ commands:
           name: Install Node dependencies
           command: npm install
 
-  win_install_node_dependencies:
+  win_install_nvm:
     steps:
       - run: choco install wget -y
       - run:
@@ -62,9 +62,6 @@ commands:
             Start-Process powershell -verb runAs -Args "-start GeneralProfile"
             nvm install 16.13.2
             nvm use 16.13.2
-      - run:
-          name: Install Node dependencies
-          command: npm install
 
   npm_build:
     steps:
@@ -117,7 +114,8 @@ commands:
       - checkout
       - win_setup_python_env:
           python_version: <<parameters.python_version>>
-      - win_install_node_dependencies
+      - win_install_nvm
+      - install_node_dependencies
       - npm_build
 
 jobs:
@@ -337,7 +335,6 @@ workflows:
               only:
                 - main
                 - demo
-                - chore/fix-windows-circleci-npm-issue
       - unit_tests:
           matrix:
             parameters:

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -50,6 +50,19 @@ commands:
           name: Install Node dependencies
           command: npm install
 
+  win_install_node_dependencies:
+    steps:
+      - run: choco install wget -y
+        - run:
+          command: wget https://nodejs.org/dist/v16.13.2/node-v16.13.2-x86.msi -P C:\Users\circleci\Downloads\
+          shell: cmd.exe
+        - run: MsiExec.exe /i C:\Users\circleci\Downloads\node-v16.13.2-x86.msi /qn
+        - run: 
+            command: |
+                Start-Process powershell -verb runAs -Args "-start GeneralProfile"
+                nvm install 16.13.2
+                nvm use 16.13.2
+  
   npm_build:
     steps:
       - run:
@@ -101,7 +114,7 @@ commands:
       - checkout
       - win_setup_python_env:
           python_version: <<parameters.python_version>>
-      - install_node_dependencies
+      - win_install_node_dependencies
       - npm_build
 
 jobs:

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -62,7 +62,9 @@ commands:
             Start-Process powershell -verb runAs -Args "-start GeneralProfile"
             nvm install 16.13.2
             nvm use 16.13.2
-            npm install
+      - run:
+          name: Install Node dependencies
+          command: npm install
 
   npm_build:
     steps:

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -334,6 +334,7 @@ workflows:
               only:
                 - main
                 - demo
+                - chore/fix-windows-circleci-npm-issue
       - unit_tests:
           matrix:
             parameters:

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -53,16 +53,16 @@ commands:
   win_install_node_dependencies:
     steps:
       - run: choco install wget -y
-        - run:
+      - run:
           command: wget https://nodejs.org/dist/v16.13.2/node-v16.13.2-x86.msi -P C:\Users\circleci\Downloads\
           shell: cmd.exe
-        - run: MsiExec.exe /i C:\Users\circleci\Downloads\node-v16.13.2-x86.msi /qn
-        - run: 
-            command: |
-                Start-Process powershell -verb runAs -Args "-start GeneralProfile"
-                nvm install 16.13.2
-                nvm use 16.13.2
-  
+      - run: MsiExec.exe /i C:\Users\circleci\Downloads\node-v16.13.2-x86.msi /qn
+      - run:
+          command: |
+            Start-Process powershell -verb runAs -Args "-start GeneralProfile"
+            nvm install 16.13.2
+            nvm use 16.13.2
+
   npm_build:
     steps:
       - run:


### PR DESCRIPTION
Signed-off-by: Tynan DeBold <thdebold@gmail.com>

## Description

Our Windows jobs are [erroring out](https://app.circleci.com/pipelines/github/kedro-org/kedro-viz/8479/workflows/4d233ff0-a51f-4937-85fd-dc1966ba0c7f/jobs/35507). This is a remedy to that.

## Development notes

I've added a specific `win_install_node_dependencies` job that will explicitly install NVM, as that [seemed to be the issue](https://app.circleci.com/pipelines/github/kedro-org/kedro-viz/8560/workflows/f6dc2fda-7569-428c-801b-a11818a3c74d/jobs/36124).

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes
