### PR TITLE
Add metric plot data query on front-end

### DIFF
--- a/package/kedro_viz/api/graphql/schema.py
+++ b/package/kedro_viz/api/graphql/schema.py
@@ -119,7 +119,7 @@ class RunsQuery:
         for dataset in metric_dataset_models:
             metric_data[dataset.dataset_name] = dataset.runs
 
-        formatted_metric_data = format_run_metric_data(metric_data)
+        formatted_metric_data = format_run_metric_data(metric_data, run_ids)
         return MetricPlotDataset(data=formatted_metric_data)
 
 

--- a/package/kedro_viz/api/graphql/serializers.py
+++ b/package/kedro_viz/api/graphql/serializers.py
@@ -131,7 +131,7 @@ def format_run_tracking_data(
     return formatted_tracking_data
 
 
-def format_run_metric_data(metric_data: Dict) -> Dict:
+def format_run_metric_data(metric_data: Dict, run_ids = List[ID]) -> Dict:
     """Format metric data to conforms to the schema required by plots on the front
     end. Parallel Coordinate plots and Timeseries plots are supported.
 
@@ -142,12 +142,12 @@ def format_run_metric_data(metric_data: Dict) -> Dict:
         a dictionary containing metric data in two sub-dictionaries, containing
         metric data aggregated by run_id and by metric respectively.
     """
-    formatted_metric_data = _initialise_metric_data_template(metric_data)
+    formatted_metric_data = _initialise_metric_data_template(metric_data, run_ids)
     _populate_metric_data_template(metric_data, **formatted_metric_data)
     return formatted_metric_data
 
 
-def _initialise_metric_data_template(metric_data: Dict) -> Dict:
+def _initialise_metric_data_template(metric_data: Dict, run_ids = List[ID]) -> Dict:
     """Initialise a dictionary to store formatted metric data.
 
     Arguments:
@@ -161,7 +161,7 @@ def _initialise_metric_data_template(metric_data: Dict) -> Dict:
     metrics: Dict = {}
     for dataset_name in metric_data:
         dataset = metric_data[dataset_name]
-        for run_id in dataset:
+        for run_id in run_ids:
             runs[run_id] = []
             for metric in dataset[run_id]:
                 metric_name = f"{dataset_name}.{metric}"
@@ -186,7 +186,7 @@ def _populate_metric_data_template(
         runs: a dictionary to store metric data aggregated by run
         metrics: a dictionary to store metric data aggregated by metric
     """
-    print(metric_data)
+
     for (run_idx, run_id), (metric_idx, metric) in product(
         enumerate(runs), enumerate(metrics)
     ):

--- a/package/kedro_viz/api/graphql/serializers.py
+++ b/package/kedro_viz/api/graphql/serializers.py
@@ -131,12 +131,13 @@ def format_run_tracking_data(
     return formatted_tracking_data
 
 
-def format_run_metric_data(metric_data: Dict, run_ids = List[ID]) -> Dict:
+def format_run_metric_data(metric_data: Dict, run_ids: List[ID]) -> Dict:
     """Format metric data to conforms to the schema required by plots on the front
     end. Parallel Coordinate plots and Timeseries plots are supported.
 
     Arguments:
         metric_data: the data to format
+        run_ids: list of specified runs
 
     Returns:
         a dictionary containing metric data in two sub-dictionaries, containing
@@ -147,11 +148,12 @@ def format_run_metric_data(metric_data: Dict, run_ids = List[ID]) -> Dict:
     return formatted_metric_data
 
 
-def _initialise_metric_data_template(metric_data: Dict, run_ids = List[ID]) -> Dict:
+def _initialise_metric_data_template(metric_data: Dict, run_ids: List[ID]) -> Dict:
     """Initialise a dictionary to store formatted metric data.
 
     Arguments:
         metric_data: the data being formatted
+        run_ids: list of specified runs
 
     Returns:
         A dictionary with two sub-dictionaries containing lists (initialised

--- a/src/apollo/queries.js
+++ b/src/apollo/queries.js
@@ -53,6 +53,15 @@ export const GET_RUN_DATA = gql`
   }
 `;
 
+/** query for runMetricsData  */
+export const GET_METRIC_PLOT_DATA = gql`
+  query getMetricPlotData($limit: Int) {
+    runMetricsData(limit: $limit) {
+      data
+    }
+  }
+`;
+
 /** query for obtaining installed and latest Kedro-Viz versions */
 export const GET_VERSIONS = gql`
   query getVersion {

--- a/src/components/experiment-tracking/metrics-plots/metrics-plots.js
+++ b/src/components/experiment-tracking/metrics-plots/metrics-plots.js
@@ -4,6 +4,8 @@ import classnames from 'classnames';
 import { GET_METRIC_PLOT_DATA } from '../../../apollo/queries';
 import { useApolloQuery } from '../../../apollo/utils';
 
+import { METRIC_LIMIT } from '../../../config';
+
 import './metrics-plots.css';
 
 const tabLabels = ['Time-series', 'Parallel coordinates'];
@@ -15,7 +17,7 @@ const MetricsPlots = () => {
   const { data: { runMetricsData = [] } = [] } = useApolloQuery(
     GET_METRIC_PLOT_DATA,
     {
-      variables: { limit: 10 },
+      variables: { limit: METRIC_LIMIT },
     }
   );
 

--- a/src/components/experiment-tracking/metrics-plots/metrics-plots.js
+++ b/src/components/experiment-tracking/metrics-plots/metrics-plots.js
@@ -43,6 +43,7 @@ const MetricsPlots = () => {
           ? 'Time-series chart goes here'
           : 'Parallel-coordinates chart goes here'}
       </div>
+      <div>{JSON.stringify(runMetricsData, null, 2)}</div>
     </div>
   );
 };

--- a/src/components/experiment-tracking/metrics-plots/metrics-plots.js
+++ b/src/components/experiment-tracking/metrics-plots/metrics-plots.js
@@ -1,12 +1,23 @@
 import React, { useState } from 'react';
 import classnames from 'classnames';
 
+import { GET_METRIC_PLOT_DATA } from '../../../apollo/queries';
+import { useApolloQuery } from '../../../apollo/utils';
+
 import './metrics-plots.css';
 
 const tabLabels = ['Time-series', 'Parallel coordinates'];
 
 const MetricsPlots = () => {
   const [activeTab, setActiveTab] = useState(tabLabels[0]);
+
+  // Fetch metric plot data for
+  const { data: { runMetricsData = [] } = [] } = useApolloQuery(
+    GET_METRIC_PLOT_DATA,
+    {
+      variables: { limit: 10 },
+    }
+  );
 
   return (
     <div className="metrics-plots-wrapper">

--- a/src/components/experiment-tracking/metrics-plots/metrics-plots.js
+++ b/src/components/experiment-tracking/metrics-plots/metrics-plots.js
@@ -4,7 +4,7 @@ import classnames from 'classnames';
 import { GET_METRIC_PLOT_DATA } from '../../../apollo/queries';
 import { useApolloQuery } from '../../../apollo/utils';
 
-import { METRIC_LIMIT } from '../../../config';
+import { metricLimit } from '../../../config';
 
 import './metrics-plots.css';
 
@@ -17,7 +17,7 @@ const MetricsPlots = () => {
   const { data: { runMetricsData = [] } = [] } = useApolloQuery(
     GET_METRIC_PLOT_DATA,
     {
-      variables: { limit: METRIC_LIMIT },
+      variables: { limit: metricLimit },
     }
   );
 

--- a/src/config.js
+++ b/src/config.js
@@ -37,6 +37,8 @@ export const experimentTrackingLazyLoadingColours = {
   foregroundDarkTheme: slate200,
 };
 
+export const METRIC_LIMIT = 10;
+
 export const experimentTrackingLazyLoadingGap = 38;
 
 export const chartMinWidthScale = 0.25;

--- a/src/config.js
+++ b/src/config.js
@@ -37,7 +37,7 @@ export const experimentTrackingLazyLoadingColours = {
   foregroundDarkTheme: slate200,
 };
 
-export const METRIC_LIMIT = 10;
+export const metricLimit = 10;
 
 export const experimentTrackingLazyLoadingGap = 38;
 


### PR DESCRIPTION
## Description

In this PR, we simple connect the front-end to the backend by adding a query for Metrics Plot Data

```
query MyQuery {
  runMetricsData(limit: 10) {
    data
  }
}
```


## Development notes

<!-- What have you changed? Consider adding a screenshot or GIF. -->

## QA notes

<!-- How has the expected behaviour changed? What testing strategies have you used? -->

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes
