### PR TITLE
Kedro CLI startup time made shorter

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -12,6 +12,7 @@ Please follow the established format:
 
 - Allow users to hide modular pipelines on the flowchart. (#1046)
 - Create URL parameters for each element/section in the flowchart. (#1138)
+- Improve CLI loading time. (#1196)
 
 ## Bug fixes and other changes
 

--- a/package/kedro_viz/constants.py
+++ b/package/kedro_viz/constants.py
@@ -5,3 +5,6 @@ from semver import VersionInfo
 DEFAULT_REGISTERED_PIPELINE_ID = "__default__"
 KEDRO_VERSION = VersionInfo.parse(kedro.__version__)
 ROOT_MODULAR_PIPELINE_ID = "__root__"
+
+DEFAULT_HOST = "127.0.0.1"
+DEFAULT_PORT = 4141

--- a/package/kedro_viz/launchers/cli.py
+++ b/package/kedro_viz/launchers/cli.py
@@ -11,8 +11,8 @@ from semver import VersionInfo
 from watchgod import RegExpWatcher, run_process
 
 from kedro_viz import __version__
+from kedro_viz.constants import DEFAULT_HOST, DEFAULT_PORT
 from kedro_viz.integrations.pypi import get_latest_version, is_running_outdated_version
-from kedro_viz.server import DEFAULT_HOST, DEFAULT_PORT, is_localhost, run_server
 
 
 @click.group(name="Kedro-Viz")
@@ -80,8 +80,11 @@ def commands():  # pylint: disable=missing-function-docstring
     help=PARAMS_ARG_HELP,
     callback=_split_params,
 )
+# pylint: disable=import-outside-toplevel, too-many-locals
 def viz(host, port, browser, load_file, save_file, pipeline, env, autoreload, params):
     """Visualise a Kedro pipeline using Kedro viz."""
+    from kedro_viz.server import is_localhost, run_server
+
     installed_version = VersionInfo.parse(__version__)
     latest_version = get_latest_version()
 

--- a/package/kedro_viz/server.py
+++ b/package/kedro_viz/server.py
@@ -11,13 +11,12 @@ from watchgod import run_process
 
 from kedro_viz.api import apps
 from kedro_viz.api.rest.responses import EnhancedORJSONResponse, get_default_response
+from kedro_viz.constants import DEFAULT_HOST, DEFAULT_PORT
 from kedro_viz.data_access import DataAccessManager, data_access_manager
 from kedro_viz.database import create_db_engine
 from kedro_viz.integrations.kedro import data_loader as kedro_data_loader
 from kedro_viz.models.experiment_tracking import Base
 
-DEFAULT_HOST = "127.0.0.1"
-DEFAULT_PORT = 4141
 DEV_PORT = 4142
 
 

--- a/package/tests/test_launchers/test_cli.py
+++ b/package/tests/test_launchers/test_cli.py
@@ -6,6 +6,7 @@ from watchgod import RegExpWatcher
 
 from kedro_viz import __version__
 from kedro_viz.launchers import cli
+from kedro_viz.server import run_server
 
 
 @pytest.mark.parametrize(
@@ -57,7 +58,7 @@ from kedro_viz.launchers import cli
     ],
 )
 def test_kedro_viz_command_run_server(command_options, run_server_args, mocker):
-    run_server = mocker.patch("kedro_viz.launchers.cli.run_server")
+    run_server = mocker.patch("kedro_viz.server.run_server")
     runner = CliRunner()
     with runner.isolated_filesystem():
         runner.invoke(cli.commands, command_options)
@@ -74,7 +75,7 @@ def test_kedro_viz_command_should_log_outdated_version(mocker, mock_http_respons
     )
     mock_click_echo = mocker.patch("click.echo")
 
-    mocker.patch("kedro_viz.launchers.cli.run_server")
+    mocker.patch("kedro_viz.server.run_server")
     runner = CliRunner()
     with runner.isolated_filesystem():
         runner.invoke(cli.commands, ["viz"])
@@ -96,7 +97,7 @@ def test_kedro_viz_command_should_not_log_latest_version(mocker, mock_http_respo
     )
     mock_click_echo = mocker.patch("click.echo")
 
-    mocker.patch("kedro_viz.launchers.cli.run_server")
+    mocker.patch("kedro_viz.server.run_server")
     runner = CliRunner()
     with runner.isolated_filesystem():
         runner.invoke(cli.commands, ["viz"])
@@ -109,7 +110,7 @@ def test_kedro_viz_command_should_not_log_if_pypi_is_down(mocker, mock_http_resp
     requests_get.side_effect = requests.exceptions.RequestException("PyPI is down")
     mock_click_echo = mocker.patch("click.echo")
 
-    mocker.patch("kedro_viz.launchers.cli.run_server")
+    mocker.patch("kedro_viz.server.run_server")
     runner = CliRunner()
     with runner.isolated_filesystem():
         runner.invoke(cli.commands, ["viz"])
@@ -128,7 +129,7 @@ def test_kedro_viz_command_with_autoreload(mocker):
 
     run_process.assert_called_once_with(
         path=mock_project_path,
-        target=cli.run_server,
+        target=run_server,
         kwargs={
             "host": "127.0.0.1",
             "port": 4141,


### PR DESCRIPTION
- server.py: Moved `DEFAULT_HOST` and `DEFAULT_PORT` to `constants.py`
- launchers/cli.py: Moved `from kedro_viz.server ...` statement to viz function

Signed-off-by: Konrad Sikorski <znfgnu@gmail.com>

## Description

Some `kedro-viz` users experience very long startup time of `kedro` CLI script right after installing `kedro-viz`.
On my computer (Intel® Core™ i7-5600U CPU @ 2.60GHz × 4 w/ some SSD drive), running `kedro` command took:
- without `kedro-viz` installed: 0,61-0,75s (10 tries)
- with `kedro-viz` installed: 2,39-3,76s (10 tries)

On slower machines the problem is even more disturbing - I experienced almost ~10s delay each kedro execution.
**Every time** one runs the pipeline via kedro CLI, kedro_viz and its dependencies are imported, even if they're not used.

<details>
<summary>Time measurements</summary>

```
$ for i in {1..10}; do time kedro >/dev/null; done
kedro > /dev/null  0,68s user 0,09s system 99% cpu 0,771 total
kedro > /dev/null  0,65s user 0,06s system 99% cpu 0,713 total
kedro > /dev/null  0,68s user 0,07s system 99% cpu 0,753 total
kedro > /dev/null  0,67s user 0,07s system 99% cpu 0,739 total
kedro > /dev/null  0,67s user 0,04s system 99% cpu 0,717 total
kedro > /dev/null  0,71s user 0,08s system 99% cpu 0,797 total
kedro > /dev/null  0,64s user 0,06s system 99% cpu 0,706 total
kedro > /dev/null  0,61s user 0,10s system 99% cpu 0,710 total
kedro > /dev/null  0,65s user 0,05s system 99% cpu 0,697 total
kedro > /dev/null  0,75s user 0,06s system 99% cpu 0,803 total
$ yes | pip install kedro-viz >/dev/null       
$ for i in {1..10}; do time kedro >/dev/null; done
kedro > /dev/null  3,76s user 0,42s system 98% cpu 4,236 total
kedro > /dev/null  3,60s user 0,36s system 97% cpu 4,072 total
kedro > /dev/null  2,64s user 0,37s system 109% cpu 2,741 total
kedro > /dev/null  2,44s user 0,37s system 110% cpu 2,534 total
kedro > /dev/null  2,48s user 0,34s system 110% cpu 2,540 total
kedro > /dev/null  2,42s user 0,36s system 111% cpu 2,506 total
kedro > /dev/null  2,39s user 0,37s system 110% cpu 2,494 total
kedro > /dev/null  2,44s user 0,33s system 111% cpu 2,495 total
kedro > /dev/null  2,54s user 0,32s system 110% cpu 2,581 total
kedro > /dev/null  2,72s user 0,37s system 108% cpu 2,839 total
```
</details>

After small changes I made it's 0,67-0,79s, preserving usability.

<details>
<summary>Time measurements after rearranging imports</summary>

```
$ yes | pip uninstall kedro-viz >/dev/null
$ pip install -e ./package/ >/dev/null   
$ for i in {1..10}; do time kedro >/dev/null; done
kedro > /dev/null  0,79s user 0,04s system 99% cpu 0,834 total
kedro > /dev/null  0,70s user 0,06s system 99% cpu 0,760 total
kedro > /dev/null  0,71s user 0,04s system 99% cpu 0,752 total
kedro > /dev/null  0,68s user 0,07s system 99% cpu 0,755 total
kedro > /dev/null  0,69s user 0,06s system 99% cpu 0,755 total
kedro > /dev/null  0,67s user 0,08s system 99% cpu 0,757 total
kedro > /dev/null  0,72s user 0,05s system 99% cpu 0,770 total
kedro > /dev/null  0,70s user 0,06s system 99% cpu 0,756 total
kedro > /dev/null  0,70s user 0,07s system 99% cpu 0,768 total
kedro > /dev/null  0,68s user 0,06s system 99% cpu 0,746 total
```
</details>

The problem was also noted in  kedro-org/kedro#1476

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [x] Added new entries to the `RELEASE.md` file
- [x] Added tests to cover my changes
