### PR TITLE
Handle 'null' values on metric plots

### DIFF
--- a/src/components/experiment-tracking/parallel-coordinates/parallel-coordinates.js
+++ b/src/components/experiment-tracking/parallel-coordinates/parallel-coordinates.js
@@ -262,7 +262,7 @@ export const ParallelCoordinates = ({ metricsData, selectedRuns }) => {
                       transform: 'translate(-10,4)',
                     }}
                   >
-                    {value.toFixed(3)}
+                    {value?.toFixed(3)}
                   </text>
                 );
               })}
@@ -354,7 +354,7 @@ export const ParallelCoordinates = ({ metricsData, selectedRuns }) => {
                       transform: 'translate(-10,4)',
                     }}
                   >
-                    {value.toFixed(3)}
+                    {value?.toFixed(3)}
                   </text>
                 </React.Fragment>
               );

--- a/src/components/experiment-tracking/time-series/time-series.js
+++ b/src/components/experiment-tracking/time-series/time-series.js
@@ -162,6 +162,10 @@ export const TimeSeries = ({ metricsData, selectedRuns }) => {
           );
         };
 
+        const lineGenerator = d3.line().defined(function (d) {
+          return d !== null;
+        });
+
         const linePath = (data) => {
           let points = data.map((x, i) => {
             if (x !== null) {
@@ -171,7 +175,7 @@ export const TimeSeries = ({ metricsData, selectedRuns }) => {
             }
           });
 
-          return d3.line()(points);
+          return lineGenerator(points);
         };
 
         const trendLinePath = (data) => {
@@ -295,7 +299,7 @@ export const TimeSeries = ({ metricsData, selectedRuns }) => {
                                 x={xScale(hoveredElementDate)}
                                 y={yScales[index](value)}
                               >
-                                {value.toFixed(3)}
+                                {value?.toFixed(3)}
                               </text>
                             </g>
                           </React.Fragment>
@@ -323,7 +327,7 @@ export const TimeSeries = ({ metricsData, selectedRuns }) => {
                         x={xScale(key)}
                         y={yScales[metricIndex](value[metricIndex])}
                       >
-                        {value[metricIndex].toFixed(3)}
+                        {value[metricIndex]?.toFixed(3)}
                       </text>
                       <path
                         className={`time-series__marker--selected-${index}`}


### PR DESCRIPTION
## Description

Currently, if we have null values in the data -- they are not handled correctly on the front-end. 
This is mainly around :- 
1. value.toFixed() on both plots where it throws the error that toFixed() cannot be applied to null 
2. also for time-series -- nulls weren't handled whilst drawing linePath. 

in this ticket, both of the above are fixed. 

## Development notes

<!-- What have you changed? Consider adding a screenshot or GIF. -->

## QA notes

<!-- How has the expected behaviour changed? What testing strategies have you used? -->

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes
