### PR TITLE
Add clipPath for selected zoom area

### DIFF
--- a/src/components/experiment-tracking/time-series/time-series.js
+++ b/src/components/experiment-tracking/time-series/time-series.js
@@ -222,6 +222,17 @@ export const TimeSeries = ({ chartWidth, metricsData, selectedRuns }) => {
                 </clipPath>
               </defs>
 
+              <defs>
+                <clipPath id="brush_clip">
+                  <rect
+                    x={0}
+                    y={1}
+                    width={defaultChartWidth}
+                    height={height - 2}
+                  />
+                </clipPath>
+              </defs>
+
               <g
                 id={metricName}
                 transform={`translate(${margin.left},${margin.top})`}
@@ -250,7 +261,10 @@ export const TimeSeries = ({ chartWidth, metricsData, selectedRuns }) => {
 
                 <g className="time-series__brush" onDoubleClick={resetXScale} />
 
-                <g className="time-series__run-lines" clipPath="url(#clip)">
+                <g
+                  className="time-series__run-lines"
+                  clipPath="url(#brush_clip)"
+                >
                   {parsedData.map(([key, _], index) => (
                     <line
                       className={classnames('time-series__run-line', {
@@ -322,7 +336,10 @@ export const TimeSeries = ({ chartWidth, metricsData, selectedRuns }) => {
                   <path d={linePath(metricValues)} />
                 </g>
 
-                <g className="time-series__selected-group">
+                <g
+                  className="time-series__selected-group"
+                  clipPath="url(#brush_clip)"
+                >
                   {getSelectedOrderedData(runData, selectedRuns).map(
                     ([key, value], index) => (
                       <React.Fragment key={key + value}>


### PR DESCRIPTION
## Description

RunLines are rendered outside the chart - xAxis and while using brushing - out of the selected area. 

<img width="493" alt="1" src="https://user-images.githubusercontent.com/88193161/208726017-104f434b-55a6-4f40-8a39-b5a758ae71f6.png">

<img width="939" alt="2" src="https://user-images.githubusercontent.com/88193161/208726025-810e0ad1-0e85-4872-8d71-1ab13bc5838c.png">

## Development notes

Create clipPath, so runLines will be rendered inside the chart and the selected area:

<img width="670" alt="3" src="https://user-images.githubusercontent.com/88193161/208726179-f128e14c-2096-4e50-a02a-551bace61a4a.png">
<img width="758" alt="4" src="https://user-images.githubusercontent.com/88193161/208726186-7be41f2d-6219-4756-a5a4-42f583cc9025.png">


## QA notes

<!-- How has the expected behaviour changed? What testing strategies have you used? -->

## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes
