### PR TITLE
Visual fixes for metrics plots in experiment tracking

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,6 +6,12 @@ Please follow the established format:
 - Include the ID number for the related PR (or PRs) in parentheses
 -->
 
+# Next release
+
+## Bug fixes and other changes
+
+- Visual fixes for metrics plots in experiment tracking. (#1229)
+
 # Release 5.2.0
 
 ## Major features and improvements

--- a/src/components/experiment-tracking/details/details.js
+++ b/src/components/experiment-tracking/details/details.js
@@ -147,7 +147,10 @@ const Details = ({
           })}
         </div>
         {activeTab === 'Metrics' ? (
-          <MetricsPlots selectedRunIds={selectedRunIds} />
+          <MetricsPlots
+            selectedRunIds={selectedRunIds}
+            sidebarVisible={sidebarVisible}
+          />
         ) : (
           <>
             <RunMetadata
@@ -171,6 +174,7 @@ const Details = ({
               isSingleRun={isSingleRun}
               pinnedRun={pinnedRun}
               runMetadata={runMetadata}
+              selectedRunIds={selectedRunIds}
               setRunDatasetToShow={setRunDatasetToShow}
               setShowRunPlotsModal={setShowRunPlotsModal}
               showLoader={showRunLoader}

--- a/src/components/experiment-tracking/metrics-plots/metrics-plots.js
+++ b/src/components/experiment-tracking/metrics-plots/metrics-plots.js
@@ -12,7 +12,7 @@ import './metrics-plots.css';
 
 const tabLabels = ['Time-series', 'Parallel coordinates'];
 
-const MetricsPlots = ({ selectedRunIds }) => {
+const MetricsPlots = ({ selectedRunIds, sidebarVisible }) => {
   const [activeTab, setActiveTab] = useState(tabLabels[0]);
   const [chartHeight, setChartHeight] = useState(0);
   const [parCoordsWidth, setParCoordsWidth] = useState(0);
@@ -78,6 +78,7 @@ const MetricsPlots = ({ selectedRunIds }) => {
               chartWidth={timeSeriesWidth - 100}
               metricsData={runMetricsData?.data}
               selectedRuns={selectedRunIds}
+              sidebarVisible={sidebarVisible}
             />
           ) : (
             <ParallelCoordinates
@@ -85,6 +86,7 @@ const MetricsPlots = ({ selectedRunIds }) => {
               chartWidth={parCoordsWidth}
               metricsData={runMetricsData?.data}
               selectedRuns={selectedRunIds}
+              sidebarVisible={sidebarVisible}
             />
           )
         ) : null}

--- a/src/components/experiment-tracking/parallel-coordinates/parallel-coordinates.js
+++ b/src/components/experiment-tracking/parallel-coordinates/parallel-coordinates.js
@@ -31,6 +31,7 @@ export const ParallelCoordinates = ({
   chartWidth,
   metricsData,
   selectedRuns,
+  sidebarVisible,
 }) => {
   const [hoveredMetricLabel, setHoveredMetricLabel] = useState(null);
   const [showTooltip, setShowTooltip] = useState(tooltipDefaultProps);
@@ -99,7 +100,7 @@ export const ParallelCoordinates = ({
 
   const handleMouseOverMetric = (e, key) => {
     const runsCount = graph.find((each) => each[0] === key)[1].length;
-    const { x, y, direction } = getTooltipPosition(e);
+    const { x, y, direction } = getTooltipPosition(e, sidebarVisible);
 
     setHoveredMetricLabel(key);
 
@@ -126,7 +127,7 @@ export const ParallelCoordinates = ({
 
     if (e) {
       const parsedDate = new Date(formatTimestamp(key));
-      const { x, y, direction } = getTooltipPosition(e);
+      const { x, y, direction } = getTooltipPosition(e, sidebarVisible);
 
       setShowTooltip({
         content: {

--- a/src/components/experiment-tracking/run-dataset/run-dataset.js
+++ b/src/components/experiment-tracking/run-dataset/run-dataset.js
@@ -53,6 +53,7 @@ const RunDataset = ({
   enableShowChanges,
   isSingleRun,
   pinnedRun,
+  selectedRunIds,
   setRunDatasetToShow,
   setShowRunPlotsModal,
   showLoader,
@@ -62,8 +63,6 @@ const RunDataset = ({
   if (!trackingData) {
     return null;
   }
-
-  // console.log('trackingData: ', trackingData);
 
   return (
     <div
@@ -118,26 +117,34 @@ const RunDataset = ({
                   </span>
                   <TransitionGroup
                     component="div"
-                    className="details-dataset__tranistion-group-wrapper"
+                    className="details-dataset__transition-group-wrapper"
                   >
-                    <CSSTransition
-                      timeout={300}
-                      classNames="details-dataset__value-animation"
-                      enter={isSingleRun ? false : true}
-                      exit={isSingleRun ? false : true}
-                    >
-                      <span
-                        className={classnames('details-dataset__value-header', {
-                          'details-dataset__value-header--comparison-view':
-                            enableComparisonView,
-                        })}
-                        style={{
-                          display: enableComparisonView ? 'block' : 'none',
-                        }}
-                      >
-                        No data to display. Try selecting a different run.
-                      </span>
-                    </CSSTransition>
+                    {selectedRunIds.map((id, index) => {
+                      return (
+                        <CSSTransition
+                          classNames="details-dataset__value-animation"
+                          enter={isSingleRun ? false : true}
+                          exit={isSingleRun ? false : true}
+                          key={id}
+                          timeout={300}
+                        >
+                          <span
+                            className={classnames(
+                              'details-dataset__value-header',
+                              {
+                                'details-dataset__value-header--comparison-view':
+                                  enableComparisonView && index === 0,
+                              }
+                            )}
+                            style={{
+                              display: enableComparisonView ? 'flex' : 'none',
+                            }}
+                          >
+                            No data to display. Try selecting a different run.
+                          </span>
+                        </CSSTransition>
+                      );
+                    })}
                   </TransitionGroup>
                 </div>
               )}
@@ -231,7 +238,7 @@ function buildDatasetDataMarkup(
           <span className="details-dataset__name-header">Name</span>
           <TransitionGroup
             component="div"
-            className="details-dataset__tranistion-group-wrapper"
+            className="details-dataset__transition-group-wrapper"
           >
             {datasetValues.map((data, index) => (
               <CSSTransition
@@ -266,10 +273,11 @@ function buildDatasetDataMarkup(
         <span className={'details-dataset__label'}>{datasetKey}</span>
         <TransitionGroup
           component="div"
-          className="details-dataset__tranistion-group-wrapper"
+          className="details-dataset__transition-group-wrapper"
         >
           {datasetValues.map((run, index) => {
             const isSinglePinnedRun = datasetValues.length === 1;
+
             return (
               <CSSTransition
                 key={run.runId}

--- a/src/components/experiment-tracking/run-dataset/run-dataset.scss
+++ b/src/components/experiment-tracking/run-dataset/run-dataset.scss
@@ -109,11 +109,11 @@
   width: 250px;
 }
 
-.details-dataset__tranistion-group-wrapper {
+.details-dataset__transition-group-wrapper {
   display: flex;
 }
 
-.details-dataset__tranistion-group-wrapper span {
+.details-dataset__transition-group-wrapper span {
   &:first-of-type {
     margin-right: 3.5em;
   }
@@ -124,7 +124,7 @@
 }
 
 // to ensure the value header is aligned with its value
-.details-dataset__tranistion-group-wrapper .details-dataset__value-header {
+.details-dataset__transition-group-wrapper .details-dataset__value-header {
   &:nth-of-type(1) {
     margin-right: 3.8em;
   }

--- a/src/components/experiment-tracking/time-series/time-series.js
+++ b/src/components/experiment-tracking/time-series/time-series.js
@@ -25,7 +25,12 @@ const height = 150;
 const margin = { top: 20, right: 10, bottom: 80, left: 35 };
 const yScales = {};
 
-export const TimeSeries = ({ chartWidth, metricsData, selectedRuns }) => {
+export const TimeSeries = ({
+  chartWidth,
+  metricsData,
+  selectedRuns,
+  sidebarVisible,
+}) => {
   const previouslySelectedRuns = usePrevious(selectedRuns);
   const [showTooltip, setShowTooltip] = useState(tooltipDefaultProps);
   const [rangeSelection, setRangeSelection] = useState(undefined);
@@ -96,7 +101,7 @@ export const TimeSeries = ({ chartWidth, metricsData, selectedRuns }) => {
 
     if (e) {
       const parsedDate = new Date(formatTimestamp(key));
-      const { x, y, direction } = getTooltipPosition(e);
+      const { x, y, direction } = getTooltipPosition(e, sidebarVisible);
 
       setShowTooltip({
         content: {

--- a/src/components/experiment-tracking/tooltip/get-tooltip-position.js
+++ b/src/components/experiment-tracking/tooltip/get-tooltip-position.js
@@ -5,7 +5,8 @@ const tooltipLeftGap = 85;
 const tooltipRightGap = 70;
 const tooltipTopGap = 150;
 
-export const getTooltipPosition = (e) => {
+export const getTooltipPosition = (e, sidebarVisible) => {
+  const xCoordsAdjustment = sidebarVisible ? 0 : sidebarWidth.pipelineUI;
   const y = e.clientY - tooltipTopGap;
   let x, direction;
 
@@ -16,6 +17,8 @@ export const getTooltipPosition = (e) => {
     x = e.clientX - sidebarWidth.open - sidebarWidth.open / 2 - tooltipLeftGap;
     direction = 'left';
   }
+
+  x = x + xCoordsAdjustment;
 
   return { x, y, direction };
 };

--- a/src/components/settings-modal/settings-modal.scss
+++ b/src/components/settings-modal/settings-modal.scss
@@ -21,10 +21,6 @@
     align-items: flex-start;
     text-align: left;
   }
-
-  .modal__bg--visible {
-    opacity: 0.7;
-  }
 }
 
 .pipeline-settings-modal__content {

--- a/src/components/ui/icon-button/icon-button.js
+++ b/src/components/ui/icon-button/icon-button.js
@@ -1,8 +1,7 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import './icon-button.css';
-import { useOutsideClick } from '../../../utils/hooks';
 
 const labelPositionTypes = ['right', 'left', 'bottom', 'top'];
 
@@ -34,31 +33,17 @@ const IconButton = ({
     ? labelTextPosition.toLocaleLowerCase()
     : 'right';
 
-  const clearLocalStorage = () => {
-    window.localStorage.removeItem('kedro-viz-tooltip-show');
-  };
-
-  useEffect(() => {
-    clearLocalStorage();
-  }, []);
-
   const showTooltip = () => {
-    if (localStorage.getItem('kedro-viz-tooltip-show') === null) {
-      inTimeout = setTimeout(() => {
-        window.localStorage.setItem('kedro-viz-tooltip-show', true);
-        setIsTooltipVisible(true);
-      }, 1000);
-    } else {
+    inTimeout = setTimeout(() => {
+      window.localStorage.setItem('kedro-viz-tooltip-show', true);
       setIsTooltipVisible(true);
-    }
+    }, 333);
   };
 
   const hideTooltip = () => {
     clearTimeout(inTimeout);
     setIsTooltipVisible(false);
   };
-
-  const iconBtnRef = useOutsideClick(clearLocalStorage);
 
   return visible ? (
     <Wrapper container={container}>
@@ -74,7 +59,6 @@ const IconButton = ({
         onClick={onClick}
         onMouseEnter={showTooltip}
         onMouseLeave={hideTooltip}
-        ref={iconBtnRef}
       >
         {Icon && <Icon className="pipeline-icon" />}
         {labelText && (

--- a/src/components/ui/modal/modal.scss
+++ b/src/components/ui/modal/modal.scss
@@ -51,7 +51,7 @@ $duration-visibility: 0.4s;
 }
 
 .modal__bg--visible {
-  opacity: 1;
+  opacity: 0.7;
 }
 
 .modal__content {

--- a/src/config.js
+++ b/src/config.js
@@ -8,22 +8,23 @@ export const localStorageName = 'KedroViz';
 export const globalToolbarWidth = 80;
 
 export const metaSidebarWidth = {
-  open: 400,
   closed: 0,
+  open: 400,
 };
 
 export const sidebarWidth = {
-  open: 400 + globalToolbarWidth,
-  closed: 56 + globalToolbarWidth,
   breakpoint: 700,
+  closed: 56 + globalToolbarWidth,
+  open: 400 + globalToolbarWidth,
+  pipelineUI: 344,
 };
 
 export const codeSidebarWidth = {
-  open: 480,
   closed: 0,
+  open: 480,
 };
 
-// these colours variables come from styles/variables';
+// These colours variables come from styles/variables;
 const slate600 = '#0e222d';
 const slate200 = '#21333e';
 


### PR DESCRIPTION
Signed-off-by: Tynan DeBold <thdebold@gmail.com>

## Description

Since we released `5.2.0` I've noticed some small visual inconsistencies (thanks to @AntonyMilneQB for pointing one of these out to me). This PR fixes those.

## Development notes

1. Ensure tooltip on metrics plots is in correct position so this doesn't happen:
    ![Screen Shot 2023-01-20 at 15 28 11](https://user-images.githubusercontent.com/16869061/213736040-46dc52b5-b846-4412-bbd9-bed66c4977a7.png)
3. Update IconButton tooltip logic to precent the following from happening (reverting some of #1139).
    ![Screen Shot 2023-01-20 at 15 21 47](https://user-images.githubusercontent.com/16869061/213735762-5faa734d-a811-4887-8ea4-eec597e3856d.png)
4. Improve warning message for empty plots in exp. tracking to add the warning to each run and prevent this:
    ![Screen Shot 2023-01-20 at 15 21 06](https://user-images.githubusercontent.com/16869061/213735716-9e7bd6d3-cdb3-4147-8f46-c6fc661baa3c.png)

## QA notes

View the Gitpod link or checkout the branch and run Viz locally to see these three things no longer happen.

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [x] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes
