### PR TITLE
Add safeguard to check that npm package has been built

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,9 @@
-.PHONY: package
+.PHONY: package build
 
 package:
 	find . -regex ".*/__pycache__" -exec rm -rf {} +
 	find . -regex ".*\.egg-info" -exec rm -rf {} +
+	test -f package/kedro_viz/html/index.html || (echo "Built npm package not found; packaging process cancelled."; exit 1)
 	cd package && python setup.py clean --all
 	cd package && python setup.py sdist bdist_wheel
 


### PR DESCRIPTION
It's unlikely to ever happen again, but just to be sure... 5.1.1 was a patch release necessitated by an innocuous-looking but actually disastrous change I made to the `Makefile`.

I've put a check in so that it's no longer possible to run `make package` without the Javascript having successfully built first. I've put the test in the `Makefile ` rather than CircleCI config so that, in addition to preventing any future releases failing in this way, it'll protect us against accidentally distributing a .whl file without the required html (I've made this mistake before also, e.g. when trying things out on databricks).

Tested locally and all seems to work well.
## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes
