### PR TITLE
Style fix for experiment tracking background-color issue

### DIFF
--- a/src/components/experiment-tracking/run-dataset/run-dataset.scss
+++ b/src/components/experiment-tracking/run-dataset/run-dataset.scss
@@ -5,7 +5,9 @@
   display: flex;
   flex-direction: column;
   flex-shrink: 0;
+  min-width: 100%;
   padding: 5em 0 0 9em;
+  width: max-content;
 
   &--not-overview {
     background-color: var(--color-exp-tracking-bg);

--- a/src/components/experiment-tracking/run-metadata/run-metadata.scss
+++ b/src/components/experiment-tracking/run-metadata/run-metadata.scss
@@ -8,7 +8,6 @@
   min-height: 350px;
   min-width: 100%;
   padding: 5em 0 0 9em;
-  width: max-content;
 
   &--not-overview {
     background-color: var(--color-exp-tracking-bg);
@@ -116,7 +115,7 @@
   }
 
   &:last-of-type {
-    margin-right: 5em;
+    margin-right: 0;
   }
 }
 


### PR DESCRIPTION
Signed-off-by: Tynan DeBold <thdebold@gmail.com>

## Description

I noticed a small background-color issue in the overview area while reviewing a PR. This should fix it.

Here's what I saw:

<img width="1662" alt="Screenshot 2023-02-13 at 14 45 22" src="https://user-images.githubusercontent.com/16869061/218499443-dbf1ea00-1200-414c-87d8-e4672c0bf8cd.png">


## Development notes

I adjusted some width and margin properties.

## QA notes

View the branch locally or look at the Gitpod link to ensure this isn't happening anymore.

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes
