### PR TITLE
Save and Load Kedro-viz 

### DIFF
--- a/package/kedro_viz/api/apps.py
+++ b/package/kedro_viz/api/apps.py
@@ -3,9 +3,8 @@ This data could either come from a real Kedro project or a file.
 """
 import json
 import time
-from pathlib import Path
-
 import zipfile
+from pathlib import Path
 
 from fastapi import FastAPI, HTTPException
 from fastapi.requests import Request
@@ -112,21 +111,20 @@ def create_api_app_from_file(filepath: str) -> FastAPI:
 
     @app.get("/api/main", response_class=JSONResponse)
     async def main():
-        with zipfile.ZipFile(f'{filepath}.zip', 'r') as zip_file:
-            main = zip_file.read('main')
+        with zipfile.ZipFile(f"{filepath}.zip", "r") as zip_file:
+            main = zip_file.read("main")
         return json.loads(main)
 
     @app.get("/api/nodes/{node_id}", response_class=JSONResponse)
     async def get_node_metadata(node_id):
-        with zipfile.ZipFile(f'{filepath}.zip', 'r') as zip_file:
-            node_metdata = zip_file.read(f'nodes/{node_id}')
+        with zipfile.ZipFile(f"{filepath}.zip", "r") as zip_file:
+            node_metdata = zip_file.read(f"nodes/{node_id}")
         return json.loads(node_metdata)
-    
+
     @app.get("/api/pipelines/{pipeline_id}", response_class=JSONResponse)
     async def get_registered_pipeline(pipeline_id):
-        with zipfile.ZipFile(f'{filepath}.zip', 'r') as zip_file:
-            pipeline = zip_file.read(f'pipelines/{pipeline_id}')
+        with zipfile.ZipFile(f"{filepath}.zip", "r") as zip_file:
+            pipeline = zip_file.read(f"pipelines/{pipeline_id}")
         return json.loads(pipeline)
 
     return app
-

--- a/package/kedro_viz/api/apps.py
+++ b/package/kedro_viz/api/apps.py
@@ -5,6 +5,8 @@ import json
 import time
 from pathlib import Path
 
+import zipfile
+
 from fastapi import FastAPI, HTTPException
 from fastapi.requests import Request
 from fastapi.responses import HTMLResponse, JSONResponse, Response
@@ -110,6 +112,21 @@ def create_api_app_from_file(filepath: str) -> FastAPI:
 
     @app.get("/api/main", response_class=JSONResponse)
     async def main():
-        return json.loads(Path(filepath).read_text(encoding="utf8"))
+        with zipfile.ZipFile(f'{filepath}.zip', 'r') as zip_file:
+            main = zip_file.read('main')
+        return json.loads(main)
+
+    @app.get("/api/nodes/{node_id}", response_class=JSONResponse)
+    async def get_node_metadata(node_id):
+        with zipfile.ZipFile(f'{filepath}.zip', 'r') as zip_file:
+            node_metdata = zip_file.read(f'nodes/{node_id}')
+        return json.loads(node_metdata)
+    
+    @app.get("/api/pipelines/{pipeline_id}", response_class=JSONResponse)
+    async def get_registered_pipeline(pipeline_id):
+        with zipfile.ZipFile(f'{filepath}.zip', 'r') as zip_file:
+            pipeline = zip_file.read(f'pipelines/{pipeline_id}')
+        return json.loads(pipeline)
 
     return app
+

--- a/package/kedro_viz/api/rest/responses.py
+++ b/package/kedro_viz/api/rest/responses.py
@@ -299,6 +299,7 @@ def get_default_response() -> GraphAPIResponse:
 
 
 def get_node_metadata_response(node_id: str):
+    """API response for `/api/nodes/node_id`."""
     node = data_access_manager.nodes.get_node_by_id(node_id)
     if not node:
         return JSONResponse(status_code=404, content={"message": "Invalid node ID"})
@@ -319,6 +320,7 @@ def get_node_metadata_response(node_id: str):
 
 
 def get_selected_pipeline_response(registered_pipeline_id: str):
+    """API response for `/api/pipeline/pipeline_id`."""
     if not data_access_manager.registered_pipelines.has_pipeline(
         registered_pipeline_id
     ):

--- a/package/kedro_viz/api/rest/responses.py
+++ b/package/kedro_viz/api/rest/responses.py
@@ -4,11 +4,10 @@ import abc
 from typing import Any, Dict, List, Optional, Union
 
 import orjson
-from fastapi.responses import ORJSONResponse, JSONResponse
+from fastapi.responses import JSONResponse, ORJSONResponse
 from pydantic import BaseModel
 
 from kedro_viz.data_access import data_access_manager
-
 from kedro_viz.models.flowchart import (
     DataNode,
     DataNodeMetadata,
@@ -251,6 +250,7 @@ class GraphAPIResponse(BaseAPIResponse):
     modular_pipelines: ModularPipelinesTreeAPIResponse
     selected_pipeline: str
 
+
 class EnhancedORJSONResponse(ORJSONResponse):
     @staticmethod
     def encode_to_human_readable(content: Any) -> bytes:
@@ -267,7 +267,6 @@ class EnhancedORJSONResponse(ORJSONResponse):
             | orjson.OPT_NON_STR_KEYS
             | orjson.OPT_SERIALIZE_NUMPY,
         )
-
 
 
 def get_default_response() -> GraphAPIResponse:
@@ -298,8 +297,8 @@ def get_default_response() -> GraphAPIResponse:
         selected_pipeline=default_selected_pipeline_id,
     )
 
+
 def get_node_metadata_response(node_id: str):
-        
     node = data_access_manager.nodes.get_node_by_id(node_id)
     if not node:
         return JSONResponse(status_code=404, content={"message": "Invalid node ID"})
@@ -346,5 +345,3 @@ def get_selected_pipeline_response(registered_pipeline_id: str):
         selected_pipeline=registered_pipeline_id,
         modular_pipelines=modular_pipelines_tree,
     )
-
-

--- a/package/kedro_viz/api/rest/router.py
+++ b/package/kedro_viz/api/rest/router.py
@@ -20,7 +20,7 @@ from .responses import (
     NodeMetadataAPIResponse,
     get_default_response,
     get_node_metadata_response,
-    get_selected_pipeline_response
+    get_selected_pipeline_response,
 )
 
 router = APIRouter(

--- a/package/kedro_viz/api/rest/router.py
+++ b/package/kedro_viz/api/rest/router.py
@@ -19,6 +19,8 @@ from .responses import (
     GraphAPIResponse,
     NodeMetadataAPIResponse,
     get_default_response,
+    get_node_metadata_response,
+    get_selected_pipeline_response
 )
 
 router = APIRouter(
@@ -38,23 +40,7 @@ async def main():
     response_model_exclude_none=True,
 )
 async def get_single_node_metadata(node_id: str):
-    node = data_access_manager.nodes.get_node_by_id(node_id)
-    if not node:
-        return JSONResponse(status_code=404, content={"message": "Invalid node ID"})
-
-    if not node.has_metadata():
-        return JSONResponse(content={})
-
-    if isinstance(node, TaskNode):
-        return TaskNodeMetadata(node)
-
-    if isinstance(node, DataNode):
-        return DataNodeMetadata(node)
-
-    if isinstance(node, TranscodedDataNode):
-        return TranscodedDataNodeMetadata(node)
-
-    return ParametersNodeMetadata(node)
+    return get_node_metadata_response(node_id)
 
 
 @router.get(
@@ -62,29 +48,4 @@ async def get_single_node_metadata(node_id: str):
     response_model=GraphAPIResponse,
 )
 async def get_single_pipeline_data(registered_pipeline_id: str):
-    if not data_access_manager.registered_pipelines.has_pipeline(
-        registered_pipeline_id
-    ):
-        return JSONResponse(status_code=404, content={"message": "Invalid pipeline ID"})
-
-    modular_pipelines_tree = (
-        data_access_manager.create_modular_pipelines_tree_for_registered_pipeline(
-            registered_pipeline_id
-        )
-    )
-
-    return GraphAPIResponse(
-        nodes=data_access_manager.get_nodes_for_registered_pipeline(
-            registered_pipeline_id
-        ),
-        edges=data_access_manager.get_edges_for_registered_pipeline(
-            registered_pipeline_id
-        ),
-        tags=data_access_manager.tags.as_list(),
-        layers=data_access_manager.get_sorted_layers_for_registered_pipeline(
-            registered_pipeline_id
-        ),
-        pipelines=data_access_manager.registered_pipelines.as_list(),
-        selected_pipeline=registered_pipeline_id,
-        modular_pipelines=modular_pipelines_tree,
-    )
+    return get_selected_pipeline_response(registered_pipeline_id)

--- a/package/kedro_viz/api/rest/router.py
+++ b/package/kedro_viz/api/rest/router.py
@@ -1,18 +1,6 @@
 """`kedro_viz.api.rest.router` defines REST routes and handling logic."""
 # pylint: disable=missing-function-docstring
 from fastapi import APIRouter
-from fastapi.responses import JSONResponse
-
-from kedro_viz.data_access import data_access_manager
-from kedro_viz.models.flowchart import (
-    DataNode,
-    DataNodeMetadata,
-    ParametersNodeMetadata,
-    TaskNode,
-    TaskNodeMetadata,
-    TranscodedDataNode,
-    TranscodedDataNodeMetadata,
-)
 
 from .responses import (
     APIErrorMessage,

--- a/package/kedro_viz/data_access/repositories/graph.py
+++ b/package/kedro_viz/data_access/repositories/graph.py
@@ -29,6 +29,9 @@ class GraphNodesRepository:
     def as_dict(self) -> Dict[str, GraphNode]:
         return self.nodes_dict
 
+    def get_node_ids(self) -> List[str]:
+        return self.nodes_dict.keys()
+
     def get_nodes_by_ids(self, node_ids: Set[str]) -> List[GraphNode]:
         return [n for n in self.nodes_list if n.id in node_ids]
 

--- a/package/kedro_viz/data_access/repositories/graph.py
+++ b/package/kedro_viz/data_access/repositories/graph.py
@@ -30,7 +30,7 @@ class GraphNodesRepository:
         return self.nodes_dict
 
     def get_node_ids(self) -> List[str]:
-        return self.nodes_dict.keys()
+        return list(self.nodes_dict.keys())
 
     def get_nodes_by_ids(self, node_ids: Set[str]) -> List[GraphNode]:
         return [n for n in self.nodes_list if n.id in node_ids]

--- a/package/kedro_viz/data_access/repositories/registered_pipelines.py
+++ b/package/kedro_viz/data_access/repositories/registered_pipelines.py
@@ -20,7 +20,7 @@ class RegisteredPipelinesRepository:
 
     def get_pipeline_by_id(self, pipeline_id: str) -> Optional[RegisteredPipeline]:
         return self.pipelines_dict.get(pipeline_id)
-    
+
     def get_pipeline_ids(self) -> List[str]:
         return self.pipelines_dict.keys()
 

--- a/package/kedro_viz/data_access/repositories/registered_pipelines.py
+++ b/package/kedro_viz/data_access/repositories/registered_pipelines.py
@@ -22,7 +22,7 @@ class RegisteredPipelinesRepository:
         return self.pipelines_dict.get(pipeline_id)
 
     def get_pipeline_ids(self) -> List[str]:
-        return self.pipelines_dict.keys()
+        return list(self.pipelines_dict.keys())
 
     def has_pipeline(self, pipeline_id: str) -> bool:
         return pipeline_id in self.pipelines_dict

--- a/package/kedro_viz/data_access/repositories/registered_pipelines.py
+++ b/package/kedro_viz/data_access/repositories/registered_pipelines.py
@@ -20,6 +20,9 @@ class RegisteredPipelinesRepository:
 
     def get_pipeline_by_id(self, pipeline_id: str) -> Optional[RegisteredPipeline]:
         return self.pipelines_dict.get(pipeline_id)
+    
+    def get_pipeline_ids(self) -> List[str]:
+        return self.pipelines_dict.keys()
 
     def has_pipeline(self, pipeline_id: str) -> bool:
         return pipeline_id in self.pipelines_dict

--- a/package/kedro_viz/launchers/cli.py
+++ b/package/kedro_viz/launchers/cli.py
@@ -41,7 +41,6 @@ def commands():  # pylint: disable=missing-function-docstring
 @click.option(
     "--load-file",
     default=None,
-    type=click.Path(exists=True, dir_okay=False),
     help="Path to load the pipeline JSON file",
 )
 @click.option(

--- a/package/kedro_viz/server.py
+++ b/package/kedro_viz/server.py
@@ -80,8 +80,9 @@ def run_server(
             take precedence over) the parameters retrieved from the project
             configuration.
     """
+    path = Path(project_path) if project_path else Path.cwd()
+
     if load_file is None:
-        path = Path(project_path) if project_path else Path.cwd()
         catalog, pipelines, session_store_location = kedro_data_loader.load_data(
             path, env, extra_params
         )
@@ -118,12 +119,12 @@ def run_server(
                 for node in encoded_node_response:
                     zip_file.writestr(f'nodes/{node}', encoded_node_response[node])
 
-            with open(f'/{project_path}/{save_file}.zip', 'wb') as zip_file:
+            with open(f'/{path}/{save_file}.zip', 'wb') as zip_file:
                 zip_file.write(zip_buffer.getvalue())
 
         app = apps.create_api_app_from_project(path, autoreload)
     else:
-        app = apps.create_api_app_from_file(f'{project_path}/{load_file}')
+        app = apps.create_api_app_from_file(f'{path}/{load_file}')
 
     if browser and is_localhost(host):
         webbrowser.open_new(f"http://{host}:{port}/")

--- a/package/kedro_viz/server.py
+++ b/package/kedro_viz/server.py
@@ -1,6 +1,5 @@
 """`kedro_viz.server` provides utilities to launch a webserver for Kedro pipeline visualisation."""
 import io
-import json
 import webbrowser
 import zipfile
 from pathlib import Path
@@ -99,14 +98,10 @@ def run_server(
         populate_data(data_access_manager, catalog, pipelines, session_store_location)
 
         if save_file:
-            default_pipeline_response = get_default_response()
-            jsonable_default_pipeline_response = jsonable_encoder(
-                default_pipeline_response
-            )
-            encoded_default_pipeline_response = (
-                EnhancedORJSONResponse.encode_to_human_readable(
-                    jsonable_default_pipeline_response
-                )
+            default_response = get_default_response()
+            jsonable_default_response = jsonable_encoder(default_response)
+            encoded_default_response = EnhancedORJSONResponse.encode_to_human_readable(
+                jsonable_default_response
             )
 
             encoded_node_response = {}
@@ -134,13 +129,11 @@ def run_server(
             zip_buffer = io.BytesIO()
 
             with zipfile.ZipFile(zip_buffer, "w", zipfile.ZIP_DEFLATED) as zip_file:
-                zip_file.writestr("main", encoded_default_pipeline_response)
-                for node in encoded_node_response:
-                    zip_file.writestr(f"nodes/{node}", encoded_node_response[node])
-                for pipeline in encoded_pipeline_response:
-                    zip_file.writestr(
-                        f"pipelines/{pipeline}", encoded_pipeline_response[pipeline]
-                    )
+                zip_file.writestr("main", encoded_default_response)
+                for node_id, node_metadata in encoded_node_response.items():
+                    zip_file.writestr(f"nodes/{node_id}", node_metadata)
+                for pipeline_id, pipeline_data in encoded_pipeline_response.items():
+                    zip_file.writestr(f"pipelines/{pipeline_id}", pipeline_data)
 
             with open(f"/{path}/{save_file}.zip", "wb") as zip_file:
                 zip_file.write(zip_buffer.getvalue())


### PR DESCRIPTION
## Description

Resolves #1101 

## Development notes

Initially, --save-file would only save **the json for the default pipeline** which is why metadata panel or switching pipelines wouldn't work because api/endpoints for those were missing. 

Now --save-file creates a zip file with the following files/folders
 - main (This is default pipeline json response)
 - nodes/node-id (this is folder nodes with json response for all nodes) 
 - pipelines/pipeline-id (this is a folder pipelines with json response for all registered pipelines) 
 **(server.py)**

When you do --load-file, this zip file is extracted and the correct json file is loaded based on the user selection **(apps.py)** 

## QA notes

For testing. 
- Go to kedro-viz on cli, do `pip uninstall kedro-viz` and `pip install -e package`  to install dev version of kedro-viz in your conda env
- then go to  demo-project and type `kedro viz --save-file mytest` and then `kedro viz --load-file mytest`


I will write/fix tests once the implementation is reviewed and agreed. 

## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes
