### PR TITLE
Quote `PYTHONPATH` to avoid whitespace issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ build:
 PROJECT_PATH ?= demo-project
 
 run:
-	PYTHONPATH=$(shell pwd)/package python3 package/kedro_viz/server.py $(PROJECT_PATH)
+	PYTHONPATH="$(shell pwd)/package" python3 package/kedro_viz/server.py $(PROJECT_PATH)
 
 pytest:
 	cd package && pytest --cov-fail-under=100


### PR DESCRIPTION
## Description

If there's a whitespace character in the `PYTHONPATH`, before this PR the command `make run` would fail:

```
% make run
PYTHONPATH=/Users/juan_cano/Projects/QuantumBlack Labs/kedro-viz-clean-copy/package python3 package/kedro_viz/server.py demo-project
/bin/sh: Labs/kedro-viz-clean-copy/package: No such file or directory
```

## Development notes

<!-- What have you changed? Consider adding a screenshot or GIF. -->

## QA notes

<!-- How has the expected behaviour changed? What testing strategies have you used? -->

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes
