### PR TITLE
Fix mypy issue with pydantic 

### DIFF
--- a/package/kedro_viz/api/rest/router.py
+++ b/package/kedro_viz/api/rest/router.py
@@ -17,6 +17,10 @@ from kedro_viz.models.flowchart import (
 from .responses import (
     APIErrorMessage,
     GraphAPIResponse,
+    GraphEdgeAPIResponse,
+    ModularPipelinesTreeAPIResponse,
+    NamedEntityAPIResponse,
+    NodeAPIResponse,
     NodeMetadataAPIResponse,
     get_default_response,
 )
@@ -74,17 +78,28 @@ async def get_single_pipeline_data(registered_pipeline_id: str):
     )
 
     return GraphAPIResponse(
-        nodes=data_access_manager.get_nodes_for_registered_pipeline(
-            registered_pipeline_id
-        ),
-        edges=data_access_manager.get_edges_for_registered_pipeline(
-            registered_pipeline_id
-        ),
-        tags=data_access_manager.tags.as_list(),
+        nodes=[
+            NodeAPIResponse.from_orm(node)
+            for node in data_access_manager.get_nodes_for_registered_pipeline(
+                registered_pipeline_id
+            )
+        ],
+        edges=[
+            GraphEdgeAPIResponse.from_orm(edge)
+            for edge in data_access_manager.get_edges_for_registered_pipeline(
+                registered_pipeline_id
+            )
+        ],
+        tags=[
+            NamedEntityAPIResponse.from_orm(tag)
+            for tag in data_access_manager.tags.as_list()
+        ],
         layers=data_access_manager.get_sorted_layers_for_registered_pipeline(
             registered_pipeline_id
         ),
         pipelines=data_access_manager.registered_pipelines.as_list(),
         selected_pipeline=registered_pipeline_id,
-        modular_pipelines=modular_pipelines_tree,
+        modular_pipelines=ModularPipelinesTreeAPIResponse.from_orm(
+            modular_pipelines_tree
+        ),
     )


### PR DESCRIPTION
## Description

- Checkout main branch 
- run `mypy --config-file=package/mypy.ini package` on root folder
RESULT - Kedro-viz works. Mypy error

```
checked, consider using --check-untyped-defs  [annotation-unchecked]
package/kedro_viz/api/rest/responses.py:259: error: Argument "nodes" to "GraphAPIResponse" has incompatible type "List[GraphNode]"; expected "List[Union[TaskNodeAPIResponse, DataNodeAPIResponse]]"  [arg-type]
package/kedro_viz/api/rest/responses.py:262: error: Argument "edges" to "GraphAPIResponse" has incompatible type "List[GraphEdge]"; expected "List[GraphEdgeAPIResponse]"  [arg-type]
package/kedro_viz/api/rest/responses.py:270: error: Argument "modular_pipelines" to "GraphAPIResponse" has incompatible type "Dict[str, ModularPipelineNode]"; expected "Dict[str, ModularPipelinesTreeNodeAPIResponse]"  [arg-type] 
```

- Checkout current branch 
-  run `mypy --config-file=package/mypy.ini package` on root folder. 
RESULT - Kedro-viz flowchart broken. No mypy error 

## Development notes

<!-- What have you changed? Consider adding a screenshot or GIF. -->

## QA notes

<!-- How has the expected behaviour changed? What testing strategies have you used? -->

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes
