### PR TITLE
Fix/broken docs link

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -12,6 +12,7 @@ Please follow the established format:
 
 - Fix SQLAlchemy QueuePool Overflow Error. (#1301)
 - Bug fix for where some elements on the flowchart weren't clickable. (#1322)
+- Fixed link to Kedro experiments docs ()
 
 # Release 6.0.1
 

--- a/src/components/experiment-wrapper/experiment-wrapper.js
+++ b/src/components/experiment-wrapper/experiment-wrapper.js
@@ -305,7 +305,7 @@ const ExperimentWrapper = ({ theme }) => {
                     docs.{' '}
                   </p>
                   <a
-                    href="https://kedro.readthedocs.io/en/stable/logging/experiment_tracking.html"
+                    href="https://docs.kedro.org/en/stable/visualisation/experiment_tracking.html"
                     rel="noreferrer"
                     target="_blank"
                   >


### PR DESCRIPTION
## Description

Fixed link in Experiment tracking.
old link: https://docs.kedro.org/en/stable/logging/experiment_tracking.html
new link: https://docs.kedro.org/en/stable/visualisation/experiment_tracking.html

## Development notes

Old code:
![image](https://user-images.githubusercontent.com/84031958/234443495-0356c74f-fa4f-496a-bd58-49898d0e9126.png)
New Code:
![image](https://user-images.githubusercontent.com/84031958/234443527-25f30ca3-c0d3-42b1-aae4-6f1e76a5de33.png)


## QA notes

No change in behavior, new link is correct.

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
    - N/A
- [ ] Updated the documentation to reflect the code changes
    - N/A
- [X] Added new entries to the `RELEASE.md` file
    - Will add number once PR is generated
- [ ] Added tests to cover my changes
    - N/A
