### PR TITLE
disable-graphiql-playground

### DIFF
--- a/package/kedro_viz/api/graphql/router.py
+++ b/package/kedro_viz/api/graphql/router.py
@@ -6,6 +6,7 @@ from .schema import schema
 
 router = APIRouter()
 
-graphql_app: GraphQL = GraphQL(schema)
+# graphiql=False can be removed if you wish to use the graphiql playground locally
+graphql_app: GraphQL = GraphQL(schema, graphiql=False)
 router.add_route("/graphql", graphql_app)
 router.add_websocket_route("/graphql", graphql_app)


### PR DESCRIPTION
## Description
Fixes #1347, to disable the graphiql playground by default

## QA notes

To test it, make sure you clone this branch, re-build your BE and re-run FE again. Access the graphiql via this link http://localhost:4142/graphql, it should show NOT FOUND message

<img width="1789" alt="Screenshot 2023-05-03 at 11 56 39" src="https://user-images.githubusercontent.com/32060364/235897509-023f8d5a-fdeb-4646-becb-14570553b925.png">

We decide to turn it off completely by default as we don't really use it anymore, and if we want to use it locally, we can remove the flag and it should work as normal. 

## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro-viz/pull/1349"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

