### PR TITLE
Include doc in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Live Demo: <a href="https://demo.kedro.org/" target="_blank">https://demo.kedro.
 [![PyPI version](https://img.shields.io/pypi/v/kedro-viz.svg?color=yellow)](https://pypi.org/project/kedro-viz/)
 [![License](https://img.shields.io/badge/license-Apache%202.0-3da639.svg)](https://opensource.org/licenses/Apache-2.0)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4355948.svg)](https://doi.org/10.5281/zenodo.4355948)
+[![Documentation](https://readthedocs.org/projects/kedro/badge/?version=stable)](https://docs.kedro.org/en/stable/visualisation/)
 [![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg)](https://github.com/prettier/prettier)
 
 ## Introduction
@@ -168,10 +169,10 @@ We also recommend wrapping the `Kedro-Viz` component with a parent HTML/JSX elem
 
 Kedro-Viz uses features flags to roll out some experimental features. The following flags are currently in use:
 
-| Flag        | Description                                                                             |
-| ----------- | --------------------------------------------------------------------------------------- |
-| sizewarning | From release v3.9.1. Show a warning before rendering very large graphs (default `true`) |
-| expandAllPipelines | From release v4.3.2. Expand all modular pipelines on first load (default `false`) |
+| Flag               | Description                                                                             |
+| ------------------ | --------------------------------------------------------------------------------------- |
+| sizewarning        | From release v3.9.1. Show a warning before rendering very large graphs (default `true`) |
+| expandAllPipelines | From release v4.3.2. Expand all modular pipelines on first load (default `false`)       |
 
 To enable or disable a flag, click on the settings icon in the toolbar and toggle the flag on/off.
 

--- a/README.md
+++ b/README.md
@@ -162,6 +162,8 @@ kedro viz --save-file=filename.json
 
 We also recommend wrapping the `Kedro-Viz` component with a parent HTML/JSX element that has a specified height (as seen in the above example) in order for Kedro-Viz to be styled properly.
 
+_For more examples on how to visualise with kedro-viz, please refer to the [Documentation](https://docs.kedro.org/en/stable/visualisation/)_
+
 ## Feature Flags
 
 Kedro-Viz uses features flags to roll out some experimental features. The following flags are currently in use:

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ kedro viz --save-file=filename.json
 
 We also recommend wrapping the `Kedro-Viz` component with a parent HTML/JSX element that has a specified height (as seen in the above example) in order for Kedro-Viz to be styled properly.
 
-_For more examples on how to visualise with kedro-viz, please refer to the [Documentation](https://docs.kedro.org/en/stable/visualisation/)_
+**_For more examples on how to visualise with kedro-viz, please refer to the [Documentation](https://docs.kedro.org/en/stable/visualisation/)_**
 
 ## Feature Flags
 


### PR DESCRIPTION
## Description
Fixes #1310 

## Development notes
I include a line at the end of the CLI Usage section, rather having a new section just for a doc, as It feels like the current doc we have is really the examples of the CLI usage. 

`For more examples on how to visualise with kedro-viz, please refer to the Documentation`

Let me know what you think.


### **Screenshot:**
<img width="890" alt="Screenshot 2023-05-11 at 17 07 42" src="https://github.com/kedro-org/kedro-viz/assets/32060364/dbc66635-0adb-4bd7-aca6-b9ff74734501">

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro-viz/pull/1354"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

