### PR TITLE
Add improved security headers to FastAPI responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ kedro viz --save-file=filename.json
 
 We also recommend wrapping the `Kedro-Viz` component with a parent HTML/JSX element that has a specified height (as seen in the above example) in order for Kedro-Viz to be styled properly.
 
-**_Our documentation contains [additional examples on how to visualise with kedro-viz](https://docs.kedro.org/en/stable/visualisation/)_**
+**_Our documentation contains [additional examples on how to visualise with Kedro-Viz.](https://docs.kedro.org/en/stable/visualisation/)_**
 
 ## Feature Flags
 

--- a/package/kedro_viz/api/apps.py
+++ b/package/kedro_viz/api/apps.py
@@ -2,10 +2,10 @@
 This data could either come from a real Kedro project or a file.
 """
 import json
-import secure
 import time
 from pathlib import Path
 
+import secure
 from fastapi import FastAPI, HTTPException
 from fastapi.requests import Request
 from fastapi.responses import HTMLResponse, JSONResponse, Response

--- a/package/kedro_viz/api/apps.py
+++ b/package/kedro_viz/api/apps.py
@@ -2,6 +2,7 @@
 This data could either come from a real Kedro project or a file.
 """
 import json
+import secure
 import time
 from pathlib import Path
 
@@ -19,6 +20,8 @@ from .graphql.router import router as graphql_router
 from .rest.router import router as rest_router
 
 _HTML_DIR = Path(__file__).parent.parent.absolute() / "html"
+
+secure_headers = secure.Secure()
 
 
 def _create_etag() -> str:
@@ -55,6 +58,12 @@ def create_api_app_from_project(
     # everytime the server reloads, a new app with a new timestamp will be created.
     # this is used as an etag embedded in the frontend for client to use when making requests.
     app_etag = _create_etag()
+
+    @app.middleware("http")
+    async def set_secure_headers(request, call_next):
+        response = await call_next(request)
+        secure_headers.framework.fastapi(response)
+        return response
 
     @app.get("/")
     @app.get("/experiment-tracking")

--- a/package/requirements.txt
+++ b/package/requirements.txt
@@ -11,3 +11,4 @@ sqlalchemy>=1.4, <3
 strawberry-graphql>=0.99.0, <1.0
 networkx>=1.0
 orjson~=3.8
+secure>=0.3.0


### PR DESCRIPTION
## Description

Resolves #1348.

## Development notes

I've added and am using the [secure](https://pypi.org/project/secure/) package to add the necessary security headers infosec requested, those headers being:

- `Strict-Transport-Security`
- `X-Frame-Options`

## QA notes

You need to run the app locally or with Gitpod and view the main server response.

This is before the change:

![Screenshot 2023-05-12 at 09 07 33](https://github.com/kedro-org/kedro-viz/assets/16869061/acbab64b-695d-4f96-8d62-61e606b898f9)

This is after:

![Screenshot 2023-05-12 at 09 06 28](https://github.com/kedro-org/kedro-viz/assets/16869061/7941a2d2-070a-4594-9b89-9487957b4434)


## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro-viz/pull/1355"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

