### PR TITLE
Disable GraphQL introspection

### DIFF
--- a/package/kedro_viz/api/graphql/schema.py
+++ b/package/kedro_viz/api/graphql/schema.py
@@ -10,8 +10,10 @@ import logging
 from typing import AsyncGenerator, List, Optional
 
 import strawberry
+from graphql.validation import NoSchemaIntrospectionCustomRule
 from semver import VersionInfo
 from strawberry import ID
+from strawberry.extensions import AddValidationRules
 from strawberry.tools import merge_types
 
 from kedro_viz import __version__
@@ -196,4 +198,7 @@ schema = strawberry.Schema(
     query=(merge_types("Query", (RunsQuery, VersionQuery))),
     mutation=Mutation,
     subscription=Subscription,
+    extensions=[
+        AddValidationRules([NoSchemaIntrospectionCustomRule]),
+    ],
 )


### PR DESCRIPTION
## Description

This is to remedy something in the PenTest report.

## Development notes

I've followed the [Strawberry docs](https://strawberry.rocks/docs/operations/deployment#introspection) to turn this off.

## QA notes

You need to use Postman or something similar to test this. After this change, this is the response:

<img width="960" alt="image" src="https://github.com/kedro-org/kedro-viz/assets/16869061/2d67aa4c-a0c0-4636-ad71-40f92bab2d1a">


## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro-viz/pull/1363"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

