### PR TITLE
Update Kedro requirement version

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,16 @@ There are two ways you can use Kedro-Viz:
 
 ## Usage
 
+#### Compatibility with Kedro
+
+Ensure that your Kedro-Viz version is compatible with your Kedro version by referencing the following table:
+
+| Kedro-Viz version | Kedro version     |
+| ----------------- | ----------------- |
+| >=4.7             | >=0.17.5          |
+| >=3.8.0, <4.7     | >=0.16.6, <0.17.5 |
+| <3.8.0            | <0.16.6           |
+
 ### CLI Usage
 
 To launch Kedro-Viz from the command line as a Kedro plugin, use the following command from the root folder of your Kedro project:

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ There are two ways you can use Kedro-Viz:
 
 #### Compatibility with Kedro
 
-Ensure that your Kedro-Viz version is compatible with your Kedro version by referencing the following table:
+Ensure your Kedro-Viz and Kedro versions are compatible by referencing the following table:
 
 | Kedro-Viz version | Kedro version     |
 | ----------------- | ----------------- |

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,16 +6,13 @@ Please follow the established format:
 - Include the ID number for the related PR (or PRs) in parentheses
 -->
 
-
 # Release 6.2.0
-
-
-
-# Release 6.1.1
 
 ## Major features and improvements
 
 - Enable collaborative experiment tracking on Kedro-viz. (#1286)
+
+# Release 6.1.1
 
 ## Bug fixes and other changes
 

--- a/package/requirements.txt
+++ b/package/requirements.txt
@@ -1,5 +1,5 @@
 semver~=2.13 # Needs to be at least 2.10.0 to get VersionInfo.match
-kedro>=0.17.0
+kedro>=0.17.5
 ipython>=7.0.0, <9.0
 fastapi>=0.73.0, <0.96.0
 fsspec>=2021.4, <2024.1 


### PR DESCRIPTION
## Description

Resolves #1361 

## Development notes

I've updated our Kedro requirement version and added a section in our README that indicates which versions of Viz work with which version of Kedro.

## QA notes

Based on our docs, I tried to discern what version of Viz work with Kedro. It might need to be expanded or tweaked.

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro-viz/pull/1366"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

