### PR TITLE
Fix exp. tracking back button and metadata panel position

### DIFF
--- a/src/components/flowchart-wrapper/flowchart-wrapper.scss
+++ b/src/components/flowchart-wrapper/flowchart-wrapper.scss
@@ -42,7 +42,7 @@ $sidebar-toolbar-width-open: variables.$sidebar-width-open +
     border-radius: 40px;
     border: none;
     color: black;
-    width: 280px;
+    width: 300px;
   }
 }
 
@@ -62,7 +62,7 @@ $sidebar-toolbar-width-open: variables.$sidebar-width-open +
     display: flex;
     justify-content: center;
     padding: 8px 8px 8px 0;
-    width: 280px;
+    width: 300px;
   }
 }
 

--- a/src/components/metadata/styles/metadata.scss
+++ b/src/components/metadata/styles/metadata.scss
@@ -25,7 +25,7 @@
   @extend %sidebar;
   position: absolute;
   top: -1px; /* Avoids pixel rounding gaps */
-  right: 0;
+  right: -1px;
   bottom: -1px;
   z-index: 2;
   display: flex;
@@ -34,6 +34,7 @@
   max-width: variables.$metadata-sidebar-width-open;
   padding: 6px 0 0 0;
   overflow-y: auto;
+  overflow-x: hidden;
   background: var(--color-metadata-bg);
   border-left: 1px solid var(--color-border-line);
   transform: translateX(100%);


### PR DESCRIPTION
## Description

There was a small style discrepancy here after the rebrand.

## Development notes

I made the width of the button larger. I also moved the metadata panel over 1px to remove a very small amount of whitespace.

## QA notes

Before:

<img width="393" alt="Screenshot 2023-06-08 at 08 50 46" src="https://github.com/kedro-org/kedro-viz/assets/16869061/2fe2f8e0-5d4f-46c3-8f3b-818e45d42036">

After:

<img width="379" alt="Screenshot 2023-06-08 at 08 51 18" src="https://github.com/kedro-org/kedro-viz/assets/16869061/ab65a8bb-58ce-4023-9a64-15ab8a47123d">

Metadata panel changes fixes this (tiny slice of white on the right side):

<img width="413" alt="image" src="https://github.com/kedro-org/kedro-viz/assets/16869061/db6f8bb5-b77f-429d-a9f9-8613d873f61c">


## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro-viz/pull/1385"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

