### PR TITLE
Add html meta description for better browser search results

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -9,6 +9,10 @@
     <meta name="theme-color" content="#000000" />
     <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico" />
     <title>Kedro-Viz</title>
+    <meta
+      name="description"
+      content="Kedro-Viz is an interactive development tool for building data science pipelines with Kedro."
+    />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link


### PR DESCRIPTION
## Description

Fixes #1292.

## Development notes

I added a `meta` tag to our `index.html` page.

## QA notes

We won't see the result until Google re-index the page. I'm confident this will work, since [this meta tag](https://developers.google.com/search/docs/appearance/snippet) is what they use to pull the search result snippet.

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro-viz/pull/1413"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

