### PR TITLE
Add Inter font family

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -12,7 +12,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Titillium+Web:wght@400;600&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap"
       rel="stylesheet"
     />
   </head>

--- a/src/components/export-modal/export-graph.js
+++ b/src/components/export-modal/export-graph.js
@@ -49,7 +49,7 @@ const exportGraph = ({ format, theme, graphSize, mockFn }) => {
   if (format === 'svg') {
     // Add webfont
     style.innerHTML =
-      '@import url(https://fonts.googleapis.com/css?family=Titillium+Web:400);';
+      '@import url(https://fonts.googleapis.com/css?family=Inter:400);';
   } else {
     // Add websafe fallback font
     style.innerHTML = `.kedro {

--- a/src/components/ui/button/button.scss
+++ b/src/components/ui/button/button.scss
@@ -52,7 +52,7 @@ $secondary-underline-offset-hover: 4px;
   font-size: 1.4em;
   letter-spacing: 0.1px;
   line-height: 1.4;
-  padding: 0.6em 0.85em 0.7em;
+  padding: 0.7em 0.85em;
 }
 
 .button__btn--primary {


### PR DESCRIPTION
## Description

With the rebrand, we updated our font family to Inter, except we never actually updated the Google font import. This PR does that.

## Development notes

I've swapped Titillium for Inter.

## QA notes

On the demo site, you can see that even though we include Inter as the font [in the family property](https://github.com/kedro-org/kedro-viz/blob/b8da8fea8033839a2b5c34890348600ad27b15a9/src/components/app/app.scss#L92) the import itself wasn't updated, so what's being rendered is actually Helvetica (or whatever the standard sans-serif font is on the user's machine is).

![Screenshot 2023-06-22 at 20 53 08](https://github.com/kedro-org/kedro-viz/assets/16869061/1bc4b5d9-6e7e-40d5-8e2f-a50afd0bbc95)

Look at the Gitpod link and you'll see clearly that now Inter is being rendered.

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro-viz/pull/1414"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

