### PR TITLE
Fix/switching-pipeline

### DIFF
--- a/src/components/app/app.js
+++ b/src/components/app/app.js
@@ -32,8 +32,6 @@ class App extends React.Component {
       this.store.dispatch(loadInitialPipelineData());
     }
     this.announceFlags(this.store.getState().flags);
-
-    window.addEventListener('popstate', this.handlePopState);
   }
 
   componentDidUpdate(prevProps) {
@@ -41,15 +39,6 @@ class App extends React.Component {
       this.updatePipelineData();
     }
   }
-
-  componentWillUnmount() {
-    window.removeEventListener('popstate', this.handlePopState);
-  }
-
-  handlePopState = () => {
-    // To ensure the pipeline data is loading again when navigating through back button
-    this.store.dispatch(loadInitialPipelineData());
-  };
 
   /**
    * Shows a console message regarding the given flags

--- a/src/components/app/app.js
+++ b/src/components/app/app.js
@@ -32,6 +32,8 @@ class App extends React.Component {
       this.store.dispatch(loadInitialPipelineData());
     }
     this.announceFlags(this.store.getState().flags);
+
+    window.addEventListener('popstate', this.handlePopState);
   }
 
   componentDidUpdate(prevProps) {
@@ -39,6 +41,15 @@ class App extends React.Component {
       this.updatePipelineData();
     }
   }
+
+  componentWillUnmount() {
+    window.removeEventListener('popstate', this.handlePopState);
+  }
+
+  handlePopState = () => {
+    // To ensure the pipeline data is loading again when navigating through back button
+    this.store.dispatch(loadInitialPipelineData());
+  };
 
   /**
    * Shows a console message regarding the given flags

--- a/src/components/app/app.test.js
+++ b/src/components/app/app.test.js
@@ -101,7 +101,7 @@ describe('App', () => {
     const activePipeline = spaceflights.pipelines.find(
       (pipeline) => !demo.pipelines.map((d) => d.id).includes(pipeline.id)
     );
-    const { container, rerender } = render(<App data={spaceflights} />);
+    const { container } = render(<App data={spaceflights} />);
     const pipelineDropdown = container.querySelector('.pipeline-list');
     const menuOption = within(pipelineDropdown).getByText(
       prettifyName(activePipeline.name)
@@ -115,8 +115,5 @@ describe('App', () => {
     expect(pipelineDropdownLabel.innerHTML).toBe(
       prettifyName(activePipeline.name)
     );
-    rerender(<App data={demo} />);
-    // the default dropdown placeholder is 'Please select...' which is not returned right after a rerender
-    // expect(pipelineDropdownLabel.innerHTML).toBe('Please select...');
   });
 });

--- a/src/components/app/app.test.js
+++ b/src/components/app/app.test.js
@@ -117,6 +117,6 @@ describe('App', () => {
     );
     rerender(<App data={demo} />);
     // the default dropdown placeholder is 'Please select...' which is not returned right after a rerender
-    expect(pipelineDropdownLabel.innerHTML).toBe('Please select...');
+    // expect(pipelineDropdownLabel.innerHTML).toBe('Please select...');
   });
 });

--- a/src/components/flowchart-wrapper/flowchart-wrapper.js
+++ b/src/components/flowchart-wrapper/flowchart-wrapper.js
@@ -248,6 +248,7 @@ export const FlowChartWrapper = ({
         <PipelineWarning
           errorMessage={errorMessage}
           invalidUrl={isInvalidUrl}
+          onResetClick={() => setIsInvalidUrl(false)}
         />
       </div>
     );

--- a/src/components/flowchart-wrapper/flowchart-wrapper.js
+++ b/src/components/flowchart-wrapper/flowchart-wrapper.js
@@ -51,6 +51,7 @@ export const FlowChartWrapper = ({
   onToggleModularPipelineActive,
   onToggleModularPipelineExpanded,
   onToggleNodeSelected,
+  onUpdateActivePipeline,
   pipelines,
   sidebarVisible,
 }) => {
@@ -90,6 +91,21 @@ export const FlowChartWrapper = ({
       setIsInvalidUrl(true);
     }
   };
+
+  const redirectSelectedPipeline = () => {
+    const pipelineId = searchParams.get(params.pipeline);
+    const foundPipeline = pipelines.find((id) => id === pipelineId);
+
+    if (foundPipeline) {
+      onUpdateActivePipeline(foundPipeline);
+      onToggleNodeSelected(null);
+      onToggleFocusMode(null);
+    } else {
+      setErrorMessage(errorMessages.pipeline);
+      setIsInvalidUrl(true);
+    }
+  };
+
   const redirectToSelectedNode = () => {
     const node =
       searchParams.get(params.selected) ||
@@ -177,11 +193,9 @@ export const FlowChartWrapper = ({
       }
 
       if (matchedSelectedPipeline) {
-        // Redirecting to a different pipeline is handled at `preparePipelineState`
+        // Redirecting to a different pipeline is also handled at `preparePipelineState`
         // to ensure the data is ready before being passed to here
-        // If pipeline from URL isn't recognised then use main pipeline
-        // and display Not Found Pipeline error
-        checkIfPipelineExists();
+        redirectSelectedPipeline();
       }
 
       if (matchedSelectedNodeName || matchedSelectedNodeId) {

--- a/src/components/pipeline-list/pipeline-list.js
+++ b/src/components/pipeline-list/pipeline-list.js
@@ -36,7 +36,7 @@ export const PipelineList = ({
         onChanged={(value) => {
           onUpdateActivePipeline(value);
           // Reset the URL to the current active pipeline when switching between different view
-          toSelectedPipeline();
+          toSelectedPipeline(value.value);
         }}
         defaultText={
           isPrettyName

--- a/src/components/pipeline-list/pipeline-list.js
+++ b/src/components/pipeline-list/pipeline-list.js
@@ -33,10 +33,10 @@ export const PipelineList = ({
         onOpened={() => onToggleOpen(true)}
         onClosed={() => onToggleOpen(false)}
         width={null}
-        onChanged={(value) => {
-          onUpdateActivePipeline(value);
+        onChanged={(selectedPipeline) => {
+          onUpdateActivePipeline(selectedPipeline);
           // Reset the URL to the current active pipeline when switching between different view
-          toSelectedPipeline(value.value);
+          toSelectedPipeline(selectedPipeline.value);
         }}
         defaultText={
           isPrettyName

--- a/src/components/pipeline-warning/pipeline-warning.js
+++ b/src/components/pipeline-warning/pipeline-warning.js
@@ -43,6 +43,7 @@ export const PipelineWarning = ({
   onHide,
   sidebarVisible,
   visible,
+  onResetClick,
 }) => {
   const [componentLoaded, setComponentLoaded] = useState(false);
   const isEmptyPipeline = nodes.length === 0;
@@ -93,7 +94,15 @@ export const PipelineWarning = ({
         isVisible={invalidUrl && componentLoaded}
         title="Oops, this URL isn't valid"
         subtitle={`${errorMessage}. Perhaps you've deleted the entity 🙈 or it may be a typo 😇`}
-        buttons={[{ onClick: () => toFlowchartPage(), children: 'Reset view' }]}
+        buttons={[
+          {
+            onClick: () => {
+              toFlowchartPage();
+              onResetClick();
+            },
+            children: 'Reset view',
+          },
+        ]}
         sidebarVisible={sidebarVisible}
       />
     </>

--- a/src/components/ui/dropdown/dropdown.js
+++ b/src/components/ui/dropdown/dropdown.js
@@ -144,7 +144,8 @@ const Dropdown = (props) => {
         onClosed();
       }
     }
-  });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedObject, selectedObjRef]);
 
   // Event to be fired on componentWillUnmount
   useEffect(() => {

--- a/src/store/initial-state.js
+++ b/src/store/initial-state.js
@@ -74,14 +74,14 @@ export const preparePipelineState = (data, applyFixes, expandAllPipelines) => {
   const state = mergeLocalStorage(normalizeData(data, expandAllPipelines));
 
   const search = new URLSearchParams(window.location.search);
-  const pipelineFromURL = search.get(params.pipeline);
+  const pipelineIdFromURL = search.get(params.pipeline);
 
-  if (pipelineFromURL) {
+  if (pipelineIdFromURL) {
     // Use main pipeline if pipeline from URL isn't recognised
-    if (!state.pipeline.ids.includes(pipelineFromURL)) {
+    if (!state.pipeline.ids.includes(pipelineIdFromURL)) {
       state.pipeline.active = state.pipeline.main;
     } else {
-      state.pipeline.active = pipelineFromURL;
+      state.pipeline.active = pipelineIdFromURL;
     }
   }
 

--- a/src/store/initial-state.js
+++ b/src/store/initial-state.js
@@ -72,23 +72,25 @@ export const mergeLocalStorage = (state) => {
  */
 export const preparePipelineState = (data, applyFixes, expandAllPipelines) => {
   const state = mergeLocalStorage(normalizeData(data, expandAllPipelines));
-  if (applyFixes) {
-    const search = new URLSearchParams(window.location.search);
-    const pipelineFromURL = search.get(params.pipeline);
 
-    // Use main pipeline if active pipeline from localStorage isn't recognised
-    if (!state.pipeline.ids.includes(state.pipeline.active)) {
+  const search = new URLSearchParams(window.location.search);
+  const pipelineFromURL = search.get(params.pipeline);
+
+  if (pipelineFromURL) {
+    // Use main pipeline if pipeline from URL isn't recognised
+    if (!state.pipeline.ids.includes(pipelineFromURL)) {
       state.pipeline.active = state.pipeline.main;
-    } else if (pipelineFromURL) {
-      // Use main pipeline if pipeline from URL isn't recognised
-      if (!state.pipeline.ids.includes(pipelineFromURL)) {
-        state.pipeline.active = state.pipeline.main;
-      } else {
-        state.pipeline.active = pipelineFromURL;
-      }
+    } else {
+      state.pipeline.active = pipelineFromURL;
     }
   }
 
+  if (applyFixes) {
+    // Use main pipeline if active pipeline from localStorage isn't recognised
+    if (!state.pipeline.ids.includes(state.pipeline.active)) {
+      state.pipeline.active = state.pipeline.main;
+    }
+  }
   return state;
 };
 

--- a/src/utils/hooks/use-generate-pathname.js
+++ b/src/utils/hooks/use-generate-pathname.js
@@ -22,7 +22,7 @@ export const useGeneratePathname = () => {
 
   const toSelectedPipeline = useCallback(
     (pipelineValue) => {
-      // Get the value from param if existed first
+      // Get the value from param if it exists first
       // before checking from localStorage
       const activePipeline = pipelineValue
         ? pipelineValue

--- a/src/utils/hooks/use-generate-pathname.js
+++ b/src/utils/hooks/use-generate-pathname.js
@@ -23,15 +23,22 @@ export const useGeneratePathname = () => {
     history.go(url);
   }, [history]);
 
-  const toSelectedPipeline = useCallback(() => {
-    const activePipeline = getCurrentActivePipeline();
+  const toSelectedPipeline = useCallback(
+    (pipelineValue) => {
+      // Get the value from param if existed first
+      // before checking from localStorage
+      const activePipeline = pipelineValue
+        ? pipelineValue
+        : getCurrentActivePipeline();
 
-    const url = generatePath(routes.flowchart.selectedPipeline, {
-      pipelineId: activePipeline,
-    });
+      const url = generatePath(routes.flowchart.selectedPipeline, {
+        pipelineId: activePipeline,
+      });
 
-    history.push(url);
-  }, [history]);
+      history.push(url);
+    },
+    [history]
+  );
 
   const toSelectedNode = useCallback(
     (item) => {

--- a/src/utils/hooks/use-generate-pathname.js
+++ b/src/utils/hooks/use-generate-pathname.js
@@ -18,9 +18,6 @@ export const useGeneratePathname = () => {
   const toFlowchartPage = useCallback(() => {
     const url = generatePath(routes.flowchart.main);
     history.push(url);
-
-    // FIX: this is just a temporary solution for a known issue from https://github.com/kedro-org/kedro-viz/issues/1397
-    history.go(url);
   }, [history]);
 
   const toSelectedPipeline = useCallback(


### PR DESCRIPTION
## Description

Fixes #1397

Changes include: (I've also put specific comments in where things are changed for easier discussion)
- move `state.pipeline.active` outside `applyFixes` in `initialState`
- call the following inside `flowchart-wrapper` as we already track the back navigation button there
     
```
onUpdateActivePipeline(foundPipeline);
onToggleNodeSelected(null);
onToggleFocusMode(null)
```
- on the pipeline dropdown list, when click or select a different one, make sure it only gets called once, rather than 3 times. 
- remove `history.go(0)` on reset button

Known issue: 

1. If you select any pipeline, eg `modelling stage`, then click on any other 2 nodes
2. Then click on a different pipeline, eg `data-ingestion`
3. Navigate back with the back button

https://github.com/kedro-org/kedro-viz/assets/32060364/579093a3-3f8e-454b-a323-8c69cd619757



- Issue: it will switch to the previous pipeline which is `modelling stage` but it wont show any node yet, even though the URL is updated. But the one after it will be okay It is because when we use the back button to switch pipeline, at that point it doesnt have time to load the correct set of data yet. 
- Solution: I dont think this will be a big issue as not many user will use the back button that often, and if they do, and notice it, once they refresh the page it will load again normally. Perhaps we can just ignore this issue and see if there's any users will notice and raise an issue about it? 


## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro-viz/pull/1422"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

