### PR TITLE
 Fix button for large pipeline warning

### DIFF
--- a/src/components/pipeline-warning/pipeline-warning.js
+++ b/src/components/pipeline-warning/pipeline-warning.js
@@ -70,14 +70,9 @@ export const PipelineWarning = ({
       )}
       {invalidUrl && componentLoaded && (
         <div
-          className={classnames(
-            'kedro',
-            'pipeline-warning',
-            'pipeline-warning--invalid-url',
-            {
-              'pipeline-warning--sidebar-visible': sidebarVisible,
-            }
-          )}
+          className={classnames('kedro', 'pipeline-warning', {
+            'pipeline-warning--sidebar-visible': sidebarVisible,
+          })}
         >
           <h2 className="pipeline-warning__title">
             Oops, this URL isn't valid

--- a/src/components/pipeline-warning/pipeline-warning.scss
+++ b/src/components/pipeline-warning/pipeline-warning.scss
@@ -74,8 +74,3 @@
 .pipeline-warning .button:first-of-type {
   margin-bottom: 1.2em;
 }
-
-.pipeline-warning--invalid-url .button {
-  display: flex;
-  justify-content: center;
-}

--- a/src/components/ui/button/button.scss
+++ b/src/components/ui/button/button.scss
@@ -35,7 +35,6 @@ $secondary-underline-offset-hover: 4px;
   box-shadow: none;
   color: var(--color-button__text);
   cursor: pointer;
-  display: flex;
   font-family: inherit;
   font-size: 1.6em;
   font-weight: 600;


### PR DESCRIPTION
## Description

This is to fix this issue 

<img width="1432" alt="Screenshot 2023-06-29 at 17 41 31" src="https://github.com/kedro-org/kedro-viz/assets/37628668/cf7dc487-c1a6-4a85-828f-ea9705001f40">

## Development notes

This bug was introduced due to changes on this ticket - #875 where display:flex is being added [here](https://github.com/kedro-org/kedro-viz/blob/main/src/components/ui/button/button.scss#L38). I have removed it for now. Removing this hasn't affected the Apply/Close buttons but @tynandebold can confirm. 


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro-viz/pull/1426"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

