### PR TITLE
bug: fix command '--autoreload' by uptating strawberry union annotation

### DIFF
--- a/package/kedro_viz/api/graphql/types.py
+++ b/package/kedro_viz/api/graphql/types.py
@@ -3,7 +3,7 @@
 # pylint: disable=too-few-public-methods,missing-class-docstring
 from __future__ import annotations
 
-from typing import List, Optional
+from typing import Annotated, List, Optional, Union
 
 import strawberry
 from strawberry import ID
@@ -62,11 +62,13 @@ class UpdateRunDetailsFailure:
     error_message: str
 
 
-UpdateRunDetailsResponse = strawberry.union(
-    "UpdateRunDetailsResponse",
-    (UpdateRunDetailsSuccess, UpdateRunDetailsFailure),
-    description="Response for update of run metadata",
-)
+UpdateRunDetailsResponse = Annotated[
+    Union[UpdateRunDetailsSuccess, UpdateRunDetailsFailure],
+    strawberry.union(
+        "UpdateRunDetailsResponse",
+        description="Response for update of run metadata",
+    ),
+]
 
 
 @strawberry.type(description="Installed and latest Kedro-Viz versions")


### PR DESCRIPTION
## Description

<!-- Why was this PR created? -->
The command `--autoreload` is currently not working correctly and the reason for this is that the type annotation in the graphql framework `starwberry` has updated their union annotation

https://github.com/strawberry-graphql/strawberry/blob/main/CHANGELOG.md#01910---2023-06-28

<img width="1156" alt="Screenshot 2023-06-30 at 14 20 09" src="https://github.com/kedro-org/kedro-viz/assets/20767068/41c26754-8367-4e39-a312-4094a4cf13e3">


## Development notes

This changes the annotation for unions according to the strawberry change logs 
https://github.com/strawberry-graphql/strawberry/blob/main/CHANGELOG.md#01910---2023-06-28

## QA notes

<!-- How has the expected behaviour changed? What testing strategies have you used? -->

## Checklist

- [X] Read the [contributing](/CONTRIBUTING.md) guidelines
- [X] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [X] Updated the documentation to reflect the code changes
- [X] Added new entries to the `RELEASE.md` file
- [X] Added tests to cover my changes
