### PR TITLE
Relax `semver` requirement bound, add back comment

### DIFF
--- a/package/requirements.txt
+++ b/package/requirements.txt
@@ -1,4 +1,4 @@
-semver~=3.0
+semver>=2.10  # Needs to be at least 2.10.0 to make use of `VersionInfo.match`.
 kedro>=0.17.5
 ipython>=7.0.0, <9.0
 fastapi>=0.73.0, <0.96.0


### PR DESCRIPTION
## Description

<!-- Why was this PR created? -->
Related to https://github.com/kedro-org/kedro-plugins/issues/269

Don't want to break compatibility for people using `kedro-airflow` (or other libraries depending on older versions of `semver`) for no reason.

## Development notes

<!-- What have you changed? Consider adding a screenshot or GIF. -->

## QA notes

<!-- How has the expected behaviour changed? What testing strategies have you used? -->

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro-viz/pull/1452"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

