### PR TITLE
Fix for broken svg/png exports in light theme

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -9,7 +9,8 @@ Please follow the established format:
 
 ## Bug fixes and other changes
 
-- Fix incorrect rendering of datasets in modular pipelines. (#1439) 
+- Fix incorrect rendering of datasets in modular pipelines. (#1439)
+- Fix broken svg/png exports in light theme. (#1463)
 
 # Release 6.3.4
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -10,7 +10,7 @@ Please follow the established format:
 ## Bug fixes and other changes
 
 - Fix incorrect rendering of datasets in modular pipelines. (#1439)
-- Fix broken svg/png exports in light theme. (#1463)
+- Fix broken SVG/PNG exports in light theme. (#1463)
 
 # Release 6.3.4
 

--- a/src/components/flowchart/styles/_variables.scss
+++ b/src/components/flowchart/styles/_variables.scss
@@ -26,7 +26,7 @@
   @mixin export {
     --node-fill-default: #{colors.$white-200};
     --node-stroke-default: #{colors.$white-900};
-    --edge-stroke: colors.$white-900;
+    --edge-stroke: #{colors.$black-100};
     --edge-arrowhead-fill: colors.$white-900;
   }
 

--- a/src/components/flowchart/styles/_variables.scss
+++ b/src/components/flowchart/styles/_variables.scss
@@ -27,7 +27,6 @@
     --node-fill-default: #{colors.$white-200};
     --node-stroke-default: #{colors.$white-900};
     --edge-stroke: #{colors.$black-100};
-    --edge-arrowhead-fill: colors.$white-900;
   }
 
   &.pipeline-graph--export {


### PR DESCRIPTION
## Description

Resolves #1290 

## Development notes

- Modified the --edge-stroke value of export mixin inside .kui-theme--light from white to black

**Downloaded SVG Image**
![kedro-pipeline_light](https://github.com/kedro-org/kedro-viz/assets/87735534/fb301a7e-16c8-43d7-b093-075af9feee42)

**Downloaded PNG Image**

<img width="1123" alt="image" src="https://github.com/kedro-org/kedro-viz/assets/87735534/93567110-f740-4a26-8f0a-e6f183925087">


## QA notes

- Export the flowchart using the Download SVG/PNG button and the edges should appear in black when light theme is enabled

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro-viz/pull/1463"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

