### PR TITLE
[DON'T MERGE] PoC of recording stats during kedro run

### DIFF
--- a/demo-project/src/demo_project/settings.py
+++ b/demo-project/src/demo_project/settings.py
@@ -4,14 +4,49 @@
 
 from pathlib import Path
 
+from traitlets import default
+
 # Define where to store data from a KedroSession. Defaults to BaseSessionStore.
 # from kedro.framework.session.store import ShelveStore
 from kedro_viz.integrations.kedro.sqlite_store import SQLiteStore
 
+from kedro.framework.hooks import hook_impl
+from collections import defaultdict
+
+
+class DatasetStatsHook:
+    def __init__(self):
+        self._stats = defaultdict(dict)
+
+    @hook_impl
+    def after_context_created(self, context):
+        self._catalog = context.catalog
+
+    @hook_impl
+    def after_dataset_loaded(self, dataset_name, data):
+        import pandas as pd
+
+        if isinstance(data, pd.DataFrame):
+            self._stats[dataset_name] = {}
+            self._stats[dataset_name]["filesize"] = int(data.size)
+            self._stats[dataset_name]["columns"] = int(data.shape[1])
+            self._stats[dataset_name]["rows"] = int(data.shape[0])
+
+            print(data)
+    @hook_impl
+    def after_pipeline_run(self):
+        import json
+        with open("stats.json", "w") as f:
+            json.dump(self._stats, f)
+
+
+
+dataset_stats_hook = DatasetStatsHook()
+HOOKS = (dataset_stats_hook,)
 SESSION_STORE_CLASS = SQLiteStore
 SESSION_STORE_ARGS = {"path": str(Path(__file__).parents[2] / "data")}
 
-#Setup for collaborative experiment tracking. 
+# Setup for collaborative experiment tracking.
 # SESSION_STORE_ARGS = {"path": str(Path(__file__).parents[2] / "data"),
 #                       "remote_path": "s3://{path-to-session_store}" }
 


### PR DESCRIPTION
## Description

<!-- Why was this PR created? -->
#662

If you run

```py
cd demo_project
kedro run
```

You should see a `stats.json` created.
## Development notes
Pros:
- No extra cost to read data when users fire up viz to see the statistics.
- Need better way to manage the version, or maybe it is ok because the current pipeline view also only display the latest pipeline. If viz saw this file then it can optionally skip the read.

Cons:
- It can only show the stats for the last run, if it's the first time user fire up Viz it won't work.
- Requires an upgrade of kedro-viz & a new kedro run to generate this stats.json

Notes:
It's a PoC, if we actually want to implement this we need to be more careful about the type checking, maybe we can check the type of the `dataset` instead of `data`. We may also need to take care of the remote storage (or it could be a next step)
<!-- What have you changed? Consider adding a screenshot or GIF. -->

## QA notes

<!-- How has the expected behaviour changed? What testing strategies have you used? -->

## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro-viz/pull/1465"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

