### PR TITLE
Attempt to fix CI due to lazy-loading

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -11,6 +11,7 @@ Please follow the established format:
 - Fix incorrect rendering of datasets in modular pipelines. (#1439)
 - Fix broken SVG/PNG exports in light theme. (#1463)
 - Fix dataset and global toolbar error with standalone React component (#1351)
+- Fix ImportError as kedro-datasets is now lazily loaded.
 
 # Release 6.3.4
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -11,7 +11,7 @@ Please follow the established format:
 - Fix incorrect rendering of datasets in modular pipelines. (#1439)
 - Fix broken SVG/PNG exports in light theme. (#1463)
 - Fix dataset and global toolbar error with standalone React component (#1351)
-- Fix ImportError as kedro-datasets is now lazily loaded.
+- Fix `ImportError` as kedro-datasets is now lazily loaded (#1481).
 
 # Release 6.3.4
 

--- a/package/kedro_viz/integrations/kedro/data_loader.py
+++ b/package/kedro_viz/integrations/kedro/data_loader.py
@@ -177,24 +177,24 @@ except (ImportError, AttributeError):
 
 try:
     getattr(plotly, "JSONDataSet")  # Trigger import
-    plotly.JSONDataSet._load = json.JSONDataSet._load
+    plotly.JSONDataSet._load = json_dataset.JSONDataSet._load
 except (ImportError, AttributeError):
     pass
 
 try:
     getattr(plotly, "PlotlyDataSet")  # Trigger import
-    plotly.PlotlyDataSet._load = json.JSONDataSet._load
+    plotly.PlotlyDataSet._load = json_dataset.JSONDataSet._load
 except (ImportError, AttributeError):
     pass
 
 try:
     getattr(tracking, "JSONDataSet")  # Trigger import
-    tracking.JSONDataSet._load = json.JSONDataSet._load
+    tracking.JSONDataSet._load = json_dataset.JSONDataSet._load
 except (ImportError, AttributeError):
     pass
 
 try:
     getattr(tracking, "MetricsDataSet")  # Trigger import
-    tracking.MetricsDataSet._load = json.JSONDataSet._load
+    tracking.MetricsDataSet._load = json_dataset.JSONDataSet._load
 except (ImportError, AttributeError):
     pass

--- a/package/kedro_viz/integrations/kedro/data_loader.py
+++ b/package/kedro_viz/integrations/kedro/data_loader.py
@@ -129,7 +129,7 @@ def load_data(
 # These datasets do not have _load methods defined (tracking and matplotlib) or do not
 # load to json (plotly), hence the need to define _load here.
 try:
-    hasattr(matplotlib, "MatplotlibWriter")
+    getattr(matplotlib, "MatplotlibWriter")  # Trigger the lazy import
 
     def matplotlib_writer_load(dataset: matplotlib.MatplotlibWriter) -> str:
         load_path = get_filepath_str(dataset._get_load_path(), dataset._protocol)
@@ -142,24 +142,24 @@ except ImportError:
     pass
 
 try:
-    hasattr(plotly, "JSONDataSet")
+    getattr(plotly, "JSONDataSet")  # Trigger import
     plotly.JSONDataSet._load = json.JSONDataSet._load
 except ImportError:
     pass
 
 try:
-    hasattr(plotly, "PlotlyDataSet")
+    getattr(plotly, "PlotlyDataSet")  # Trigger import
     plotly.PlotlyDataSet._load = json.JSONDataSet._load
 except ImportError:
     pass
 
 try:
-    hasattr(tracking, "JSONDataSet")
+    getattr(tracking, "JSONDataSet")  # Trigger import
     tracking.JSONDataSet._load = json.JSONDataSet._load
 except ImportError:
     pass
 try:
-    hasattr(tracking, "MetricsDataSet")
+    getattr(tracking, "MetricsDataSet")  # Trigger import
     tracking.MetricsDataSet._load = json.JSONDataSet._load
 except ImportError:
     pass

--- a/package/kedro_viz/integrations/kedro/data_loader.py
+++ b/package/kedro_viz/integrations/kedro/data_loader.py
@@ -19,7 +19,7 @@ try:
         plotly,
         tracking,
     )
-except ImportError:
+except ImportError:  # kedro_datasets is not installed.
     from kedro.extras.datasets import (  # Safe since ImportErrors are suppressed within kedro.
         json,
         matplotlib,

--- a/package/kedro_viz/integrations/kedro/data_loader.py
+++ b/package/kedro_viz/integrations/kedro/data_loader.py
@@ -124,12 +124,12 @@ def load_data(
         return context.catalog, context.pipelines, session_store
 
 
-# The dataset type is available as an attribute if and only if the import from kedro
-# did not suppress an ImportError. i.e. hasattr(matplotlib, "MatplotlibWriter") is True
-# when matplotlib dependencies are installed.
+# Try to access the attribute to trigger the import of dependencies, only modify the _load
+# if dependencies are installed.
 # These datasets do not have _load methods defined (tracking and matplotlib) or do not
 # load to json (plotly), hence the need to define _load here.
-if hasattr(matplotlib, "MatplotlibWriter"):
+try:
+    hasattr(matplotlib, "MatplotlibWriter")
 
     def matplotlib_writer_load(dataset: matplotlib.MatplotlibWriter) -> str:
         load_path = get_filepath_str(dataset._get_load_path(), dataset._protocol)
@@ -138,15 +138,28 @@ if hasattr(matplotlib, "MatplotlibWriter"):
         return base64_bytes.decode("utf-8")
 
     matplotlib.MatplotlibWriter._load = matplotlib_writer_load
+except ImportError:
+    pass
 
-if hasattr(plotly, "JSONDataSet"):
+try:
+    hasattr(plotly, "JSONDataSet")
     plotly.JSONDataSet._load = json.JSONDataSet._load
+except ImportError:
+    pass
 
-if hasattr(plotly, "PlotlyDataSet"):
+try:
+    hasattr(plotly, "PlotlyDataSet")
     plotly.PlotlyDataSet._load = json.JSONDataSet._load
+except ImportError:
+    pass
 
-if hasattr(tracking, "JSONDataSet"):
+try:
+    hasattr(tracking, "JSONDataSet")
     tracking.JSONDataSet._load = json.JSONDataSet._load
-
-if hasattr(tracking, "MetricsDataSet"):
+except ImportError:
+    pass
+try:
+    hasattr(tracking, "MetricsDataSet")
     tracking.MetricsDataSet._load = json.JSONDataSet._load
+except ImportError:
+    pass

--- a/package/kedro_viz/integrations/kedro/data_loader.py
+++ b/package/kedro_viz/integrations/kedro/data_loader.py
@@ -130,7 +130,6 @@ def load_data(
 # load to json (plotly), hence the need to define _load here.
 try:
     getattr(matplotlib, "MatplotlibWriter")  # Trigger the lazy import
-
     def matplotlib_writer_load(dataset: matplotlib.MatplotlibWriter) -> str:
         load_path = get_filepath_str(dataset._get_load_path(), dataset._protocol)
         with dataset._fs.open(load_path, mode="rb") as img_file:
@@ -138,28 +137,29 @@ try:
         return base64_bytes.decode("utf-8")
 
     matplotlib.MatplotlibWriter._load = matplotlib_writer_load
-except ImportError:
+except (ImportError, AttributeError):
     pass
 
 try:
     getattr(plotly, "JSONDataSet")  # Trigger import
     plotly.JSONDataSet._load = json.JSONDataSet._load
-except ImportError:
+except (ImportError, AttributeError):
     pass
 
 try:
     getattr(plotly, "PlotlyDataSet")  # Trigger import
     plotly.PlotlyDataSet._load = json.JSONDataSet._load
-except ImportError:
+except (ImportError, AttributeError):
     pass
 
 try:
     getattr(tracking, "JSONDataSet")  # Trigger import
     tracking.JSONDataSet._load = json.JSONDataSet._load
-except ImportError:
+except (ImportError, AttributeError):
     pass
+
 try:
     getattr(tracking, "MetricsDataSet")  # Trigger import
     tracking.MetricsDataSet._load = json.JSONDataSet._load
-except ImportError:
+except (ImportError, AttributeError):
     pass

--- a/package/kedro_viz/integrations/kedro/data_loader.py
+++ b/package/kedro_viz/integrations/kedro/data_loader.py
@@ -130,6 +130,7 @@ def load_data(
 # load to json (plotly), hence the need to define _load here.
 try:
     getattr(matplotlib, "MatplotlibWriter")  # Trigger the lazy import
+
     def matplotlib_writer_load(dataset: matplotlib.MatplotlibWriter) -> str:
         load_path = get_filepath_str(dataset._get_load_path(), dataset._protocol)
         with dataset._fs.open(load_path, mode="rb") as img_file:

--- a/package/kedro_viz/models/flowchart.py
+++ b/package/kedro_viz/models/flowchart.py
@@ -595,7 +595,9 @@ class DataNodeMetadata(GraphNodeMetadata):
             self.tracking_data = dataset.load()
         elif data_node.is_preview_node():
             try:
-                self.preview = dataset._preview(**data_node.get_preview_args())
+                if hasattr(dataset, "_preview"):
+                    self.preview = dataset._preview(**data_node.get_preview_args())
+
             except Exception as exc:  # pylint: disable=broad-except # pragma: no cover
                 logger.warning(
                     "'%s' could not be previewed. Full exception: %s: %s",


### PR DESCRIPTION
## Description

<!-- Why was this PR created? -->
https://github.com/kedro-org/kedro-viz/blob/6e1d127fb85349ca7244e76719b756cc5001784f/package/kedro_viz/integrations/kedro/data_loader.py#L15-L32

This is no longer valid because `kedro-datasets` is lazily load and ImportError is not produce immediately.

The original code is slightly confusing, because `ImportError` can happens in 2 situations
- When a specific dependency is missing
- When `kedro-datasets` is not installed (This is what the original code intend to catch and have nothing to do with whether dependencies (i.e. `pandas`, `matplotlib`) is installed or not.


This is the comments in the code base
```
# The dataset type is available as an attribute if and only if the import from kedro
# did not suppress an ImportError. i.e. hasattr(matplotlib, "MatplotlibWriter") is True
# when matplotlib dependencies are installed.
```

This is no longer True. Previously, if the dependencies is not installed, `MatplotlibWriter` won't be available due to the suppression of `ImportError`.
## Development notes
- Catch `ImportError` for lazy-evaluation (kedro_datasets), catch `AttributeError` for eager evaluation (kedro.extras)
<!-- What have you changed? Consider adding a screenshot or GIF. -->

## QA notes

<!-- How has the expected behaviour changed? What testing strategies have you used? -->

## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro-viz/pull/1481"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

