### PR TITLE
Fix Safari blank page when clicking on modular pipelines

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -18,7 +18,7 @@ Please follow the established format:
 - Fix broken SVG/PNG exports in light theme. (#1463)
 - Fix dataset and global toolbar error with standalone React component (#1351)
 - Fix `ImportError` as kedro-datasets is now lazily loaded (#1481).
-- Fix the issue of encountering a blank page in Safari when interacting with the modular pipeline. (#1462)
+- Fix the issue of encountering a blank page in Safari when interacting with the modular pipeline. (#1488)
 
 # Release 6.3.4
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -5,6 +5,7 @@ Please follow the established format:
 - Use present tense (e.g. 'Add new feature')
 - Include the ID number for the related PR (or PRs) in parentheses
 -->
+
 ## Major features and improvements
 
 - Add support for displaying dataset statistics in the metadata panel. (#1472)
@@ -17,6 +18,7 @@ Please follow the established format:
 - Fix broken SVG/PNG exports in light theme. (#1463)
 - Fix dataset and global toolbar error with standalone React component (#1351)
 - Fix `ImportError` as kedro-datasets is now lazily loaded (#1481).
+- Fix the issue of encountering a blank page in Safari when interacting with the modular pipeline. (#1462)
 
 # Release 6.3.4
 

--- a/src/components/flowchart/draw.js
+++ b/src/components/flowchart/draw.js
@@ -351,7 +351,10 @@ export const drawEdges = function (changed) {
   const updateEdges = this.el.edges;
   const enterEdges = this.el.edges.enter().append('g');
   const exitEdges = this.el.edges.exit();
-  const allEdges = this.el.edges.merge(enterEdges).merge(exitEdges);
+  const allEdges = this.el.edges
+    .merge(enterEdges)
+    .merge(exitEdges)
+    .filter((edge) => edge);
 
   if (changed('edges', 'focusMode', 'inputOutputDataNodes')) {
     enterEdges.append('path');


### PR DESCRIPTION
## Description

Resolves [1462](https://github.com/kedro-org/kedro-viz/issues/1462)

## Development notes

This issue specifically happens on Safari when interacting with modular pipelines in the sidebar or flowchart. The problem seems to arise during edge redraws. For some reason Safari has several `undefined` values in the edges array so I filtered them out when creating new edges.

This is the error Safari throws:
<img width="922" alt="Screenshot 2023-08-15 at 12 57 48" src="https://github.com/kedro-org/kedro-viz/assets/106236933/24078373-77cf-456c-a393-20eae7e084b2">

And this is the error when I manually catch it in a try / catch block
<img width="553" alt="Screenshot 2023-08-15 at 12 57 59" src="https://github.com/kedro-org/kedro-viz/assets/106236933/b5edc09e-f84b-430c-9e85-83f8c2764ab3">


## QA notes

- Checkout branch
- Build & deploy 
- Open in Safari and start clicking modular pipelines in the sidebar or flowchart

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [x] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro-viz/pull/1488"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

