### PR TITLE
Fix: Sidebar search width fix for longer text query

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -5,11 +5,12 @@ Please follow the established format:
 - Use present tense (e.g. 'Add new feature')
 - Include the ID number for the related PR (or PRs) in parentheses
 -->
+
+# Release 6.3.5
+
 ## Major features and improvements
 
 - Add support for displaying dataset statistics in the metadata panel. (#1472)
-
-# Release 6.3.5
 
 ## Bug fixes and other changes
 

--- a/src/components/ui/search-bar/search-input/search-input.scss
+++ b/src/components/ui/search-bar/search-input/search-input.scss
@@ -95,6 +95,7 @@ $padding-top-bottom: 7px;
   &::before {
     content: attr(data-value);
     overflow: hidden;
+    word-break: break-all;
     background-color: transparent;
     color: transparent;
     transition: background-color $duration-input-transition;

--- a/src/components/ui/search-bar/search-input/search-input.scss
+++ b/src/components/ui/search-bar/search-input/search-input.scss
@@ -95,7 +95,6 @@ $padding-top-bottom: 7px;
   &::before {
     content: attr(data-value);
     overflow: hidden;
-    white-space: pre;
     background-color: transparent;
     color: transparent;
     transition: background-color $duration-input-transition;


### PR DESCRIPTION
## Description

Resolves below issue [No tickets]

Sidebar search input gets bigger as you type in longer text query.

<img width="827" alt="Screenshot 2023-08-15 at 4 32 59 p m" src="https://github.com/kedro-org/kedro-viz/assets/38945204/ccc4923d-0b92-4dfa-bbaf-9942df2ce242">


## QA notes

In sidebar search input, Type longer text (more then the current input width) to reproduce.

## Checklist

- [X] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro-viz/pull/1489"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

