### PR TITLE
Fix to search for a '<lambda' Python function in the sidebar

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,6 +6,13 @@ Please follow the established format:
 - Include the ID number for the related PR (or PRs) in parentheses
 -->
 
+# Release 6.4.1
+
+## Major features and improvements
+
+## Bug fixes and other changes
+
+- Fix to search for a '<lambda' Python function in the sidebar. (#854)
 
 # Release 6.3.5
 

--- a/src/components/node-list/node-list-row.js
+++ b/src/components/node-list/node-list-row.js
@@ -12,12 +12,6 @@ import { toggleHoveredFocusMode } from '../../actions';
 // The exact fixed height of a row as measured by getBoundingClientRect()
 export const nodeListRowHeight = 32;
 
-// This allows lambda and partial Python functions to render via dangerouslySetInnerHTML
-const replaceTagsWithEntities = {
-  '<lambda>': '&lt;lambda&gt;',
-  '<partial>': '&lt;partial&gt;',
-};
-
 /**
  * Returns `true` if there are no props changes, therefore the last render can be reused.
  * Performance: Checks only the minimal set of props known to change after first render.
@@ -134,7 +128,7 @@ const NodeListRow = memo(
               }
             )}
             dangerouslySetInnerHTML={{
-              __html: replaceMatches(label, replaceTagsWithEntities),
+              __html: replaceMatches(label),
             }}
           />
         </TextButton>

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -61,18 +61,27 @@ export const changed = (props, objectA, objectB) => {
 };
 
 /**
- * Replace any parts of a string that match the keys in the toReplace object
+ * Replace any parts of a string that match the '<' & '>' except '<b>' & '</b>'
  * @param {String} str The string to check
- * @param {Object} toReplace The object of strings to replace and their replacements
  * @returns {String} The string with or without replaced values
  */
-export const replaceMatches = (str, toReplace) => {
+export const replaceMatches = (str) => {
   if (str?.length > 0) {
-    const regex = new RegExp(Object.keys(toReplace).join('|'), 'gi');
+    // Handling string like '<lambda>' or '<partial>' in 3 steps
+    // 1. replacing all '<b>' & '</b>' with unique '@$1$@' & '@$2$@' respectively
+    // 2. replacing all '<' & '>' with '&lt;' & '&gt;' respectively
+    // 3. replacing back all '@$1$@' & '@$2$@' with <b> & </b> respectively
+    const stgWithoutBTag = str
+      .replaceAll('<b>', '@$1$@')
+      .replaceAll('</b>', '@$2$@');
+    const replacedWithAngleBracket = stgWithoutBTag
+      .replaceAll('<', '&lt;')
+      .replaceAll('>', '&gt;');
+    const result = replacedWithAngleBracket
+      .replaceAll('@$1$@', '<b>')
+      .replaceAll('@$2$@', '</b>');
 
-    return str.replace(regex, (matched) => {
-      return toReplace[matched];
-    });
+    return result;
   } else {
     return str;
   }

--- a/src/utils/utils.test.js
+++ b/src/utils/utils.test.js
@@ -48,15 +48,14 @@ describe('utils', () => {
   });
 
   describe('replaceMatches', () => {
-    const entitiesToReplace = {
-      '&lt;': '<',
-      '&gt;': '>',
-    };
-
     it('replaces matched characters from a string', () => {
-      expect(replaceMatches('&lt;lambda&gt;', entitiesToReplace)).toEqual(
-        '<lambda>'
+      expect(replaceMatches('<b><lam</b>bda>')).toEqual(
+        '<b>&lt;lam</b>bda&gt;'
       );
+      expect(replaceMatches('<b><lambda></b>')).toEqual(
+        '<b>&lt;lambda&gt;</b>'
+      );
+      expect(replaceMatches('<lambda>')).toEqual('&lt;lambda&gt;');
     });
   });
 });


### PR DESCRIPTION
## Description

Searching for lambda or partial functions in the sidebar doesn't work when including the < or > character, as those interfere with either the search matching or element rendering.

## QA notes

After this PR if your search query contains "<" or ">" it list result with correct highlighting. As show below.
<img width="501" alt="Screenshot 2023-08-21 at 1 34 54 p m" src="https://github.com/kedro-org/kedro-viz/assets/38945204/8f5e939a-6d42-432f-af8c-295f809696c0">


## Checklist

- [X] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [X] Added new entries to the `RELEASE.md` file
- [X] Added tests to cover my changes
