### PR TITLE
Refactor visualize dataset stats from DataNodeMetadata to DataNode

### DIFF
--- a/package/kedro_viz/api/rest/responses.py
+++ b/package/kedro_viz/api/rest/responses.py
@@ -63,6 +63,7 @@ class TaskNodeAPIResponse(BaseGraphNodeAPIResponse):
 class DataNodeAPIResponse(BaseGraphNodeAPIResponse):
     layer: Optional[str]
     dataset_type: Optional[str]
+    stats: Optional[Dict]
 
     class Config:
         schema_extra = {
@@ -75,6 +76,7 @@ class DataNodeAPIResponse(BaseGraphNodeAPIResponse):
                 "type": "data",
                 "layer": "primary",
                 "dataset_type": "kedro.extras.datasets.pandas.csv_dataset.CSVDataSet",
+                "stats": {"rows": 10, "columns": 2, "file_size": 2300},
             }
         }
 

--- a/package/kedro_viz/api/rest/router.py
+++ b/package/kedro_viz/api/rest/router.py
@@ -49,12 +49,10 @@ async def get_single_node_metadata(node_id: str):
         return TaskNodeMetadata(node)
 
     if isinstance(node, DataNode):
-        dataset_stats = data_access_manager.get_stats_for_data_node(node)
-        return DataNodeMetadata(node, dataset_stats)
+        return DataNodeMetadata(node)
 
     if isinstance(node, TranscodedDataNode):
-        dataset_stats = data_access_manager.get_stats_for_data_node(node)
-        return TranscodedDataNodeMetadata(node, dataset_stats)
+        return TranscodedDataNodeMetadata(node)
 
     return ParametersNodeMetadata(node)
 

--- a/package/kedro_viz/data_access/managers.py
+++ b/package/kedro_viz/data_access/managers.py
@@ -102,17 +102,15 @@ class DataAccessManager:
 
         self.dataset_stats = stats_dict
 
-    def get_stats_for_data_node(
-        self, data_node: Union[DataNode, TranscodedDataNode]
-    ) -> Dict:
+    def get_stats_for_data_node(self, data_node_name: str) -> Dict:
         """Returns the dataset statistics for the data node if found else returns an
         empty dictionary
 
         Args:
-            The data node for which we need the statistics
+            The data node name for which we need the statistics
         """
 
-        return self.dataset_stats.get(data_node.name, {})
+        return self.dataset_stats.get(data_node_name, {})
 
     def add_pipeline(self, registered_pipeline_id: str, pipeline: KedroPipeline):
         """Iterate through all the nodes and datasets in a "registered" pipeline
@@ -278,6 +276,7 @@ class DataAccessManager:
                 layer=layer,
                 tags=set(),
                 dataset=obj,
+                stats=self.get_stats_for_data_node(dataset_name),
                 is_free_input=is_free_input,
             )
         graph_node = self.nodes.add_node(graph_node)

--- a/package/kedro_viz/data_access/managers.py
+++ b/package/kedro_viz/data_access/managers.py
@@ -102,15 +102,14 @@ class DataAccessManager:
 
         self.dataset_stats = stats_dict
 
-    def get_stats_for_data_node(self, data_node_name: str) -> Dict:
-        """Returns the dataset statistics for the data node if found else returns an
-        empty dictionary
+    def get_stats_for_data_node(self, data_node_name: str) -> Union[Dict, None]:
+        """Returns the dataset statistics for the data node if found
 
         Args:
             The data node name for which we need the statistics
         """
 
-        return self.dataset_stats.get(data_node_name, {})
+        return self.dataset_stats.get(data_node_name, None)
 
     def add_pipeline(self, registered_pipeline_id: str, pipeline: KedroPipeline):
         """Iterate through all the nodes and datasets in a "registered" pipeline

--- a/package/kedro_viz/data_access/managers.py
+++ b/package/kedro_viz/data_access/managers.py
@@ -9,6 +9,7 @@ import networkx as nx
 from kedro.io import DataCatalog
 from kedro.pipeline import Pipeline as KedroPipeline
 from kedro.pipeline.node import Node as KedroNode
+from kedro.pipeline.pipeline import _strip_transcoding
 from sqlalchemy.orm import sessionmaker
 
 from kedro_viz.constants import DEFAULT_REGISTERED_PIPELINE_ID, ROOT_MODULAR_PIPELINE_ID
@@ -275,7 +276,7 @@ class DataAccessManager:
                 layer=layer,
                 tags=set(),
                 dataset=obj,
-                stats=self.get_stats_for_data_node(dataset_name),
+                stats=self.get_stats_for_data_node(_strip_transcoding(dataset_name)),
                 is_free_input=is_free_input,
             )
         graph_node = self.nodes.add_node(graph_node)

--- a/package/kedro_viz/server.py
+++ b/package/kedro_viz/server.py
@@ -44,8 +44,11 @@ def populate_data(
         data_access_manager.set_db_session(session_class)
 
     data_access_manager.add_catalog(catalog)
-    data_access_manager.add_pipelines(pipelines)
+
+    # add dataset stats before adding pipelines
     data_access_manager.add_dataset_stats(stats_dict)
+
+    data_access_manager.add_pipelines(pipelines)
 
 
 def run_server(

--- a/package/tests/test_api/test_rest/test_responses.py
+++ b/package/tests/test_api/test_rest/test_responses.py
@@ -108,6 +108,7 @@ def assert_example_data(response_data):
             "type": "data",
             "layer": "raw",
             "dataset_type": "pandas.csv_dataset.CSVDataSet",
+            "stats": None,
         },
         {
             "id": "f0ebef01",
@@ -118,6 +119,7 @@ def assert_example_data(response_data):
             "type": "parameters",
             "layer": None,
             "dataset_type": None,
+            "stats": None,
         },
         {
             "id": "0ecea0de",
@@ -128,6 +130,7 @@ def assert_example_data(response_data):
             "type": "data",
             "layer": "model_inputs",
             "dataset_type": "pandas.csv_dataset.CSVDataSet",
+            "stats": {"columns": 12, "rows": 29768},
         },
         {
             "id": "7b140b3f",
@@ -150,6 +153,7 @@ def assert_example_data(response_data):
             "type": "parameters",
             "layer": None,
             "dataset_type": None,
+            "stats": None,
         },
         {
             "id": "d5a8b994",
@@ -160,6 +164,7 @@ def assert_example_data(response_data):
             "type": "data",
             "layer": None,
             "dataset_type": "io.memory_dataset.MemoryDataset",
+            "stats": None,
         },
         {
             "id": "uk.data_processing",
@@ -170,6 +175,7 @@ def assert_example_data(response_data):
             "modular_pipelines": None,
             "layer": None,
             "dataset_type": None,
+            "stats": None,
         },
         {
             "id": "uk.data_science",
@@ -180,6 +186,7 @@ def assert_example_data(response_data):
             "modular_pipelines": None,
             "layer": None,
             "dataset_type": None,
+            "stats": None,
         },
         {
             "id": "uk",
@@ -190,6 +197,7 @@ def assert_example_data(response_data):
             "modular_pipelines": None,
             "layer": None,
             "dataset_type": None,
+            "stats": None,
         },
     ]
     assert_nodes_equal(response_data.pop("nodes"), expected_nodes)
@@ -480,6 +488,7 @@ def assert_example_transcoded_data(response_data):
             "modular_pipelines": [],
             "layer": None,
             "dataset_type": "io.memory_dataset.MemoryDataset",
+            "stats": None,
         },
         {
             "id": "f0ebef01",
@@ -490,6 +499,7 @@ def assert_example_transcoded_data(response_data):
             "modular_pipelines": ["uk", "uk.data_processing"],
             "layer": None,
             "dataset_type": None,
+            "stats": None,
         },
         {
             "id": "0ecea0de",
@@ -500,6 +510,7 @@ def assert_example_transcoded_data(response_data):
             "modular_pipelines": [],
             "layer": None,
             "dataset_type": None,
+            "stats": None,
         },
         {
             "id": "2302ea78",
@@ -519,6 +530,7 @@ def assert_example_transcoded_data(response_data):
             "modular_pipelines": [],
             "layer": None,
             "dataset_type": None,
+            "stats": None,
         },
         {
             "id": "1d06a0d7",
@@ -529,6 +541,7 @@ def assert_example_transcoded_data(response_data):
             "modular_pipelines": [],
             "layer": None,
             "dataset_type": "io.memory_dataset.MemoryDataset",
+            "stats": None,
         },
     ]
 
@@ -572,7 +585,6 @@ class TestTranscodedDataset:
                 "pandas.parquet_dataset.ParquetDataSet",
             ],
             "run_command": "kedro run --to-outputs=model_inputs@pandas2",
-            "stats": {},
         }
 
 
@@ -614,7 +626,6 @@ class TestNodeMetadataEndpoint:
         assert response.json() == {
             "filepath": "raw_data.csv",
             "type": "pandas.csv_dataset.CSVDataSet",
-            "stats": {},
         }
 
     def test_parameters_node_metadata(self, client):
@@ -664,6 +675,7 @@ class TestSinglePipelineEndpoint:
                 "type": "data",
                 "layer": "model_inputs",
                 "dataset_type": "pandas.csv_dataset.CSVDataSet",
+                "stats": {"columns": 12, "rows": 29768},
             },
             {
                 "id": "7b140b3f",
@@ -686,6 +698,7 @@ class TestSinglePipelineEndpoint:
                 "type": "parameters",
                 "layer": None,
                 "dataset_type": None,
+                "stats": None,
             },
             {
                 "id": "d5a8b994",
@@ -696,6 +709,7 @@ class TestSinglePipelineEndpoint:
                 "type": "data",
                 "layer": None,
                 "dataset_type": "io.memory_dataset.MemoryDataset",
+                "stats": None,
             },
             {
                 "id": "uk",
@@ -706,6 +720,7 @@ class TestSinglePipelineEndpoint:
                 "modular_pipelines": None,
                 "layer": None,
                 "dataset_type": None,
+                "stats": None,
             },
             {
                 "id": "uk.data_science",
@@ -716,6 +731,7 @@ class TestSinglePipelineEndpoint:
                 "modular_pipelines": None,
                 "layer": None,
                 "dataset_type": None,
+                "stats": None,
             },
         ]
         assert_nodes_equal(response_data.pop("nodes"), expected_nodes)

--- a/package/tests/test_data_access/test_repositories/test_modular_pipelines.py
+++ b/package/tests/test_data_access/test_repositories/test_modular_pipelines.py
@@ -47,6 +47,7 @@ class TestModularPipelinesRepository:
             layer="model",
             tags=set(),
             dataset=kedro_dataset,
+            stats=None,
         )
         modular_pipelines.add_input("data_science", data_node)
         assert data_node.id in data_science_pipeline.inputs
@@ -62,6 +63,7 @@ class TestModularPipelinesRepository:
             layer="model",
             tags=set(),
             dataset=kedro_dataset,
+            stats=None,
         )
         modular_pipelines.add_output("data_science", data_node)
         assert data_node.id in data_science_pipeline.outputs

--- a/package/tests/test_services/test_layers.py
+++ b/package/tests/test_services/test_layers.py
@@ -163,6 +163,7 @@ def test_sort_layers(graph_schema, nodes, node_dependencies, expected):
             layer=node_dict.get("layer"),
             tags=None,
             dataset=None,
+            stats=None,
         )
         for node_id, node_dict in nodes.items()
     }
@@ -183,6 +184,7 @@ def test_sort_layers_should_return_empty_list_on_cyclic_layers(mocker):
             layer=node_dict.get("layer"),
             tags=None,
             dataset=None,
+            stats=None,
         )
         for node_id, node_dict in data.items()
     }

--- a/src/components/metadata/metadata-stats.js
+++ b/src/components/metadata/metadata-stats.js
@@ -1,6 +1,6 @@
 import React, { useState, useRef, useLayoutEffect } from 'react';
 import { formatFileSize, formatNumberWithCommas } from '../../utils';
-import { datasetStatLabels } from '../../config';
+import { datasetStatLabels, statsRowLen } from '../../config';
 import './styles/metadata-stats.css';
 
 const MetaDataStats = ({ stats }) => {
@@ -14,14 +14,13 @@ const MetaDataStats = ({ stats }) => {
       return;
     }
 
-    const containerWidth = statsContainer.clientWidth;
-    const totalItemsWidth = Array.from(statsContainer.children).reduce(
-      (total, item) => total + item.offsetWidth,
+    const statsLen = Array.from(statsContainer.children).reduce(
+      (total, item) => total + item.outerText?.length,
       0
     );
 
-    setHasOverflow(totalItemsWidth > containerWidth);
-  }, []);
+    setHasOverflow(statsLen > statsRowLen);
+  }, [stats]);
 
   return (
     <ul

--- a/src/components/metadata/metadata-stats.js
+++ b/src/components/metadata/metadata-stats.js
@@ -33,7 +33,7 @@ const MetaDataStats = ({ stats }) => {
             className="pipeline-metadata__value pipeline-metadata-value__stats"
             data-test={`stats-value-${statLabel}`}
           >
-            {stats.hasOwnProperty(statLabel)
+            {stats?.hasOwnProperty(statLabel)
               ? statLabel !== 'file_size'
                 ? formatNumberWithCommas(stats[statLabel])
                 : formatFileSize(stats[statLabel])

--- a/src/components/metadata/metadata.js
+++ b/src/components/metadata/metadata.js
@@ -59,7 +59,6 @@ const MetaData = ({
   const hasImage = Boolean(metadata?.image);
   const hasTrackingData = Boolean(metadata?.trackingData);
   const hasPreviewData = Boolean(metadata?.preview);
-  const hasStatsData = Boolean(metadata?.stats);
   const isMetricsTrackingDataset = nodeTypeIcon === 'metricsTracking';
   const hasCode = Boolean(metadata?.code);
   const isTranscoded = Boolean(metadata?.originalType);
@@ -234,7 +233,7 @@ const MetaData = ({
                     isCommand={metadata?.runCommand}
                   />
                 </MetaDataRow>
-                {hasStatsData && (
+                {isDataNode && (
                   <>
                     <span
                       className="pipeline-metadata__label"

--- a/src/config.js
+++ b/src/config.js
@@ -143,3 +143,5 @@ export const errorMessages = {
 };
 
 export const datasetStatLabels = ['rows', 'columns', 'file_size'];
+
+export const statsRowLen = 33;


### PR DESCRIPTION
## Description

Resolves #1482 

## Development notes

1. Remove stats field from DataNodeMetadata class
2. Update the DataNodeMetadata call from router
3. Add the stats field inside the data access manager (add_datasets method)
4. Access the stats field via the DataNode object in DataNodeMetadata class
5. Update the DataNodeAPI response to return stats field
5. Modify the unit tests accordingly

## QA notes

1. Checkout the branch chore/refactor-stats
2. In the metadata panel, find the Dataset Statistics row displaying stats for DataNode (no change from previous release)
3. Open developer tools and find the /main network call response. The node object contains stats field

**Note**: This field is currently not used in the flowchart, but this ticket helps in getting closer to our goal of displaying stats in a debug view

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [x] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro-viz/pull/1499"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

