### PR TITLE
Docs: Update the table of Kedro-viz compatibility with Kedro

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ Ensure your Kedro-Viz and Kedro versions are compatible by referencing the follo
 | >=3.8.0, <4.7     | >=0.16.6, <0.17.5 |
 | <3.8.0            | <0.16.6           |
 
+For Python 3.6 users, the last supported version of kedro-viz is 3.16
+
 ### CLI Usage
 
 To launch Kedro-Viz from the command line as a Kedro plugin, use the following command from the root folder of your Kedro project:


### PR DESCRIPTION
## Description

Kedro-viz dropped Python 3.6 support at 3.17.0, the last support version is 3.16.0. However, it is not updated properly until 4.2.0. adding a comment after the compatibility table "For Python 3.6 users, the last supported version of kedro-viz is 3.16".

## Development notes

<img width="954" alt="Screenshot 2023-08-23 at 6 51 36 p m" src="https://github.com/kedro-org/kedro-viz/assets/38945204/4e64b83a-736b-4ee2-a15d-22d2a5761e0f">


## QA notes

<!-- How has the expected behaviour changed? What testing strategies have you used? -->

## Checklist

- [X] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes
