### PR TITLE
Remove source maps from the Kedro-viz package

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "proxy": "http://localhost:4142/",
   "scripts": {
-    "build": "react-scripts build",
+    "build": "GENERATE_SOURCEMAP=false react-scripts build",
     "postbuild": "rm -rf build/api",
     "start": "REACT_APP_DATA_SOURCE=$DATA npm-run-all -p start:app start:lib",
     "start:app": "PORT=4141 react-scripts start",


### PR DESCRIPTION
## Description

Resolves [#1526](https://github.com/kedro-org/kedro-viz/issues/1526) 

Kedro-viz package has html folder which has source map files which are not really required in production. These files are also big so removing it will make our package smaller.

## Development notes

After this changes build folder size reduced from ~19MB to ~5MB.

## QA notes

<!-- How has the expected behaviour changed? What testing strategies have you used? -->

## Checklist

- [X] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro-viz/pull/1534"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

