### PR TITLE
Inherit tags from nodes for modular pipelines

### DIFF
--- a/cypress/tests/ui/flowchart/menu.cy.js
+++ b/cypress/tests/ui/flowchart/menu.cy.js
@@ -64,7 +64,9 @@ describe('Flowchart Menu', () => {
     const nodeToClickText = 'Companies';
 
     // Action
-    cy.get(`[data-test=node-${nodeToClickText}]`)
+    cy.get(
+      `.MuiTreeItem-label > .pipeline-nodelist__row > [data-test=node-${nodeToClickText}]`
+    )
       .should('exist')
       .as('nodeToClick');
     cy.get('@nodeToClick').click();
@@ -81,7 +83,9 @@ describe('Flowchart Menu', () => {
     const nodeToHighlightText = 'Companies';
 
     // Action
-    cy.get(`[data-test=node-${nodeToHighlightText}]`)
+    cy.get(
+      `.MuiTreeItem-label > .pipeline-nodelist__row > [data-test=node-${nodeToHighlightText}]`
+    )
       .should('exist')
       .as('nodeToHighlight');
     cy.__hover__('@nodeToHighlight');

--- a/demo-project/src/demo_project/pipelines/data_ingestion/pipeline.py
+++ b/demo-project/src/demo_project/pipelines/data_ingestion/pipeline.py
@@ -27,19 +27,22 @@ def create_pipeline(**kwargs) -> Pipeline:
                 func=apply_types_to_companies,
                 inputs="companies",
                 outputs="int_typed_companies",
-                name='apply_types_to_companies'
+                name='apply_types_to_companies',
+                tags='companies'
             ),
             node(
                 func=apply_types_to_shuttles,
                 inputs="shuttles",
                 outputs="int_typed_shuttles@pandas1",
-                name='apply_types_to_shuttles'
+                name='apply_types_to_shuttles',
+                tags='shuttles'
             ),
             node(
                 func=apply_types_to_reviews,
                 inputs=["reviews", "params:typing.reviews.columns_as_floats"],
                 outputs="int_typed_reviews",
                 name='apply_types_to_reviews'
+                
             ),
             node(
                 func=aggregate_company_data,

--- a/demo-project/src/demo_project/pipelines/modelling/pipeline.py
+++ b/demo-project/src/demo_project/pipelines/modelling/pipeline.py
@@ -22,11 +22,13 @@ def new_train_eval_template() -> Pipeline:
                 func=train_model,
                 inputs=["X_train", "y_train", "params:dummy_model_options"],
                 outputs=["regressor", "experiment_params"],
+                tags="train"
             ),
             node(
                 func=evaluate_model,
                 inputs=["regressor", "X_test", "y_test"],
                 outputs="r2_score",
+                tags="evaluate"
             ),
         ]
     )

--- a/src/selectors/nodes.js
+++ b/src/selectors/nodes.js
@@ -45,7 +45,7 @@ export const getGraphNodes = createSelector(
 /**
  * Retrieves tags associated with both nodes and their corresponding modular pipelines.
  */
-export const getTaggedNodesAndModularPipelines = createSelector(
+export const getTagsforNodesAndModularPipelines = createSelector(
   [getNodeTags, getNodeModularPipelines],
   (nodeTags, nodeModularPipelines) => {
     const updatedNodeTags = { ...nodeTags };
@@ -78,7 +78,7 @@ export const getNodeActive = createSelector(
   [
     getPipelineNodeIDs,
     getHoveredNode,
-    getTaggedNodesAndModularPipelines,
+    getTagsforNodesAndModularPipelines,
     getTagActive,
     getNodeModularPipelines,
     getModularPipelineActive,

--- a/src/selectors/nodes.js
+++ b/src/selectors/nodes.js
@@ -42,7 +42,10 @@ export const getGraphNodes = createSelector(
     }, {})
 );
 
-export const getAllNodesWithTags = createSelector(
+/**
+ * Retrieves tags associated with both nodes and their corresponding modular pipelines.
+ */
+export const getTaggedNodesAndModularPipelines = createSelector(
   [getNodeTags, getNodeModularPipelines],
   (nodeTags, nodeModularPipelines) => {
     const updatedNodeTags = { ...nodeTags };
@@ -75,7 +78,7 @@ export const getNodeActive = createSelector(
   [
     getPipelineNodeIDs,
     getHoveredNode,
-    getAllNodesWithTags,
+    getTaggedNodesAndModularPipelines,
     getTagActive,
     getNodeModularPipelines,
     getModularPipelineActive,

--- a/src/selectors/nodes.js
+++ b/src/selectors/nodes.js
@@ -42,6 +42,32 @@ export const getGraphNodes = createSelector(
     }, {})
 );
 
+export const getAllNodesWithTags = createSelector(
+  [getNodeTags, getNodeModularPipelines],
+  (nodeTags, nodeModularPipelines) => {
+    const updatedNodeTags = { ...nodeTags };
+
+    Object.entries(nodeTags)
+      .filter(([, tags]) => tags.length > 0)
+      .forEach(([nodeID, tags]) => {
+        const modularPipelineIDs = nodeModularPipelines[nodeID] || [];
+        modularPipelineIDs.forEach((modularPipelineID) => {
+          if (!updatedNodeTags[modularPipelineID]) {
+            updatedNodeTags[modularPipelineID] = [];
+          }
+
+          tags.forEach((tag) => {
+            if (!updatedNodeTags[modularPipelineID].includes(tag)) {
+              updatedNodeTags[modularPipelineID].push(tag);
+            }
+          });
+        });
+      });
+
+    return updatedNodeTags;
+  }
+);
+
 /**
  * Set active status if the node is specifically highlighted, and/or via an associated tag or modular pipeline
  */
@@ -49,10 +75,11 @@ export const getNodeActive = createSelector(
   [
     getPipelineNodeIDs,
     getHoveredNode,
-    getNodeTags,
+    getAllNodesWithTags,
     getTagActive,
     getNodeModularPipelines,
     getModularPipelineActive,
+
     (state) => state.modularPipeline.tree,
   ],
   (

--- a/src/selectors/nodes.test.js
+++ b/src/selectors/nodes.test.js
@@ -3,7 +3,7 @@ import { getPipelineNodeIDs } from './pipeline';
 import {
   getNodeActive,
   getNodeSelected,
-  getTaggedNodesAndModularPipelines,
+  getTagsforNodesAndModularPipelines,
   getNodeData,
   getGroupedNodes,
   getNodeTextWidth,
@@ -39,8 +39,8 @@ const parameterNodesID = ['65d0d789'];
 const dataSetNode = ['f192326a'];
 
 describe('Selectors', () => {
-  describe('getTaggedNodesAndModularPipelines', () => {
-    const allNodesWithTags = getTaggedNodesAndModularPipelines(
+  describe('getTagsforNodesAndModularPipelines', () => {
+    const allNodesWithTags = getTagsforNodesAndModularPipelines(
       mockState.spaceflights
     );
 

--- a/src/selectors/nodes.test.js
+++ b/src/selectors/nodes.test.js
@@ -3,6 +3,7 @@ import { getPipelineNodeIDs } from './pipeline';
 import {
   getNodeActive,
   getNodeSelected,
+  getAllNodesWithTags,
   getNodeData,
   getGroupedNodes,
   getNodeTextWidth,
@@ -35,8 +36,31 @@ const getNodeType = (state) => state.node.type;
 const getNodePipelines = (state) => state.node.pipelines;
 
 const parameterNodesID = ['65d0d789'];
+const dataSetNode = ['f192326a'];
 
 describe('Selectors', () => {
+  describe('getAllNodesWithTags', () => {
+    const allNodesWithTags = getAllNodesWithTags(mockState.spaceflights);
+
+    it('returns an object', () => {
+      expect(allNodesWithTags).toEqual(expect.any(Object));
+    });
+
+    it('copies tags from node to associated modular pipelines', () => {
+      const nodeID = dataSetNode; // ID of the node you provided
+      const tagsForNode = allNodesWithTags[nodeID];
+      expect(tagsForNode).toEqual(expect.arrayContaining(['preprocessing']));
+
+      // Assert that the modular pipelines associated with the node also get the tags
+      const modularPipelines = ['data_processing'];
+      modularPipelines.forEach((modPipeline) => {
+        expect(allNodesWithTags[modPipeline]).toEqual(
+          expect.arrayContaining(['preprocessing'])
+        );
+      });
+    });
+  });
+
   describe('getNodeActive', () => {
     const nodeActive = getNodeActive(mockState.spaceflights);
 

--- a/src/selectors/nodes.test.js
+++ b/src/selectors/nodes.test.js
@@ -3,7 +3,7 @@ import { getPipelineNodeIDs } from './pipeline';
 import {
   getNodeActive,
   getNodeSelected,
-  getAllNodesWithTags,
+  getTaggedNodesAndModularPipelines,
   getNodeData,
   getGroupedNodes,
   getNodeTextWidth,
@@ -39,8 +39,10 @@ const parameterNodesID = ['65d0d789'];
 const dataSetNode = ['f192326a'];
 
 describe('Selectors', () => {
-  describe('getAllNodesWithTags', () => {
-    const allNodesWithTags = getAllNodesWithTags(mockState.spaceflights);
+  describe('getTaggedNodesAndModularPipelines', () => {
+    const allNodesWithTags = getTaggedNodesAndModularPipelines(
+      mockState.spaceflights
+    );
 
     it('returns an object', () => {
       expect(allNodesWithTags).toEqual(expect.any(Object));


### PR DESCRIPTION
## Description

Resolves #795 

## Development notes

We tried solving this issue in the backend but the way modular pipelines is computed in the backend is very complex. I thought maybe we can try solving it in the FE using selectors. 

In this PR, we have a new selector called getTagsforNodesAndModularPipelines.This selector identifies nodes associated with specific tags and then propagates these tags to the corresponding modular pipeline(s) (nested as well) for each node.

## QA notes

I have also added some tags to the demo project so we can test this. 

## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro-viz/pull/1542"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

