### PR TITLE
E2E cypress test for Shareable URL modal

### DIFF
--- a/cypress/fixtures/mock/deploySuccessResponse.json
+++ b/cypress/fixtures/mock/deploySuccessResponse.json
@@ -1,0 +1,4 @@
+{
+  "message": "Website deployed on S3",
+  "url": "http://myBucketName.s3-website.us-east-1.amazonaws.com"
+}

--- a/cypress/tests/ui/flowchart/shareable-urls.cy.js
+++ b/cypress/tests/ui/flowchart/shareable-urls.cy.js
@@ -63,9 +63,9 @@ describe('Shareable URLs', () => {
     );
   });
 
-  it('verifies that deploy button should be disabled when region is not selected and bucket name is empty #TC-56', () => {
+  it('verifies that publish button should be disabled when region is not selected and bucket name is empty #TC-56', () => {
     const selectedRegion = 'Choose a region...';
-    const primaryButtonNodeText = 'Deploy';
+    const primaryButtonNodeText = 'Publish';
 
     // Action
     cy.get('.pipeline-menu-button--deploy').click();
@@ -80,8 +80,8 @@ describe('Shareable URLs', () => {
       .should('be.disabled');
   });
 
-  it('verifies that deploy button should be disabled when region is not selected or bucket name is empty #TC-57', () => {
-    const primaryButtonNodeText = 'Deploy';
+  it('verifies that publish button should be disabled when region is not selected or bucket name is empty #TC-57', () => {
+    const primaryButtonNodeText = 'Publish';
 
     // Action
     cy.get('.pipeline-menu-button--deploy').click();
@@ -97,9 +97,9 @@ describe('Shareable URLs', () => {
       .should('be.disabled');
   });
 
-  it('verifies that deploy button should be enabled when region is selected and bucket name is not empty #TC-58', () => {
+  it('verifies that publish button should be enabled when region is selected and bucket name is not empty #TC-58', () => {
     const bucketName = 'myBucketName';
-    const primaryButtonNodeText = 'Deploy';
+    const primaryButtonNodeText = 'Publish';
 
     // Action
     cy.get('.pipeline-menu-button--deploy').click();
@@ -115,9 +115,9 @@ describe('Shareable URLs', () => {
       .should('be.enabled');
   });
 
-  it('verifies that error message appears with wrong inputs on deploy button click #TC-59', () => {
+  it('verifies that error message appears with wrong inputs on publish button click #TC-59', () => {
     const bucketName = 'myBucketName';
-    const primaryButtonNodeText = 'Deploy';
+    const primaryButtonNodeText = 'Publish';
 
     // Action
     cy.get('.pipeline-menu-button--deploy').click();
@@ -136,16 +136,16 @@ describe('Shareable URLs', () => {
     );
   });
 
-  it('verifies that AWS link is generated with correct inputs on deploy button click #TC-60', () => {
+  it('verifies that AWS link is generated with correct inputs on publish button click #TC-60', () => {
     const bucketName = 'myBucketName';
-    const primaryButtonNodeText = 'Deploy';
+    const primaryButtonNodeText = 'Publish';
 
     // Intercept the network request to mock with a fixture
     cy.__interceptRest__(
       '/api/deploy',
       'POST',
       '/mock/deploySuccessResponse.json'
-    ).as('deployRequest');
+    ).as('publishRequest');
 
     // Action
     cy.reload();
@@ -160,7 +160,7 @@ describe('Shareable URLs', () => {
       .click();
 
     // Wait for the POST request to complete and check the mocked response
-    cy.wait('@deployRequest').then((interception) => {
+    cy.wait('@publishRequest').then((interception) => {
       // Assert after action
       cy.get('.shareable-url-modal__result-url').contains(
         interception.response.body.url
@@ -168,10 +168,10 @@ describe('Shareable URLs', () => {
     });
   });
 
-  it('verifies that AWS link is generated with correct inputs on re-deploy button click #TC-61', () => {
+  it('verifies that AWS link is generated with correct inputs on Republish button click #TC-61', () => {
     const bucketName = 'myBucketName';
-    const primaryButtonNodeText = 'Deploy';
-    const primaryButtonNodeTextVariant = 'Re-Deploy';
+    const primaryButtonNodeText = 'Publish';
+    const primaryButtonNodeTextVariant = 'Republish';
     const secondaryButtonNodeText = 'Link Settings';
 
     // Intercept the network request to mock with a fixture
@@ -179,7 +179,7 @@ describe('Shareable URLs', () => {
       '/api/deploy',
       'POST',
       '/mock/deploySuccessResponse.json'
-    ).as('deployRequest');
+    ).as('publishRequest');
 
     // Action
     cy.reload();
@@ -194,7 +194,7 @@ describe('Shareable URLs', () => {
       .click();
 
     // Wait for the POST request to complete
-    cy.wait('@deployRequest');
+    cy.wait('@publishRequest');
 
     // Action
     cy.get('.shareable-url-modal__button-wrapper button')
@@ -205,7 +205,7 @@ describe('Shareable URLs', () => {
       .click();
 
     // Wait for the POST request to complete and check the mocked response
-    cy.wait('@deployRequest').then((interception) => {
+    cy.wait('@publishRequest').then((interception) => {
       // Assert after action
       cy.get('.shareable-url-modal__result-url').contains(
         interception.response.body.url

--- a/cypress/tests/ui/flowchart/shareable-urls.cy.js
+++ b/cypress/tests/ui/flowchart/shareable-urls.cy.js
@@ -34,4 +34,182 @@ describe('Shareable URLs', () => {
       `Deploying and hosting Kedro-Viz is only supported with fsspec >=2023.9.0. You are currently on version 2023.8.1.`
     );
   });
+
+  it('verifies that shareable url modal closes on close button click #TC-54', () => {
+    // Action
+    cy.get('.pipeline-menu-button--deploy').click();
+    cy.get('.shareable-url-modal__button-wrapper button')
+      .contains('Cancel')
+      .click();
+
+    // Assert after action
+    cy.get('.modal.shareable-url-modal').should(
+      'not.have.class',
+      'modal--visible'
+    );
+  });
+
+  it('verifies that users can click on region dropdown and see all region options #TC-55', () => {
+    const regionCount = 30;
+
+    // Action
+    cy.get('.pipeline-menu-button--deploy').click();
+    cy.get('.shareable-url-modal [data-test=kedro-pipeline-selector]').click();
+
+    // Assert after action
+    cy.get('.shareable-url-modal .menu-option').should(
+      'have.length',
+      regionCount
+    );
+  });
+
+  it('verifies that deploy button should be disabled when region is not selected and bucket name is empty #TC-56', () => {
+    const selectedRegion = 'Choose a region...';
+    const primaryButtonNodeText = 'Deploy';
+
+    // Action
+    cy.get('.pipeline-menu-button--deploy').click();
+
+    // Assert after action
+    cy.get(
+      '.shareable-url-modal [data-test=kedro-pipeline-selector] .dropdown__label span'
+    ).contains(selectedRegion);
+    cy.get('.shareable-url-modal textarea').should('have.value', '');
+    cy.get('.shareable-url-modal__button-wrapper button')
+      .contains(primaryButtonNodeText)
+      .should('be.disabled');
+  });
+
+  it('verifies that deploy button should be disabled when region is not selected or bucket name is empty #TC-57', () => {
+    const primaryButtonNodeText = 'Deploy';
+
+    // Action
+    cy.get('.pipeline-menu-button--deploy').click();
+    cy.get('.shareable-url-modal [data-test=kedro-pipeline-selector]').click();
+    cy.get('.shareable-url-modal .dropdown__options section div')
+      .first()
+      .click();
+
+    // Assert after action
+    cy.get('.shareable-url-modal textarea').should('have.value', '');
+    cy.get('.shareable-url-modal__button-wrapper button')
+      .contains(primaryButtonNodeText)
+      .should('be.disabled');
+  });
+
+  it('verifies that deploy button should be enabled when region is selected and bucket name is not empty #TC-58', () => {
+    const bucketName = 'myBucketName';
+    const primaryButtonNodeText = 'Deploy';
+
+    // Action
+    cy.get('.pipeline-menu-button--deploy').click();
+    cy.get('.shareable-url-modal [data-test=kedro-pipeline-selector]').click();
+    cy.get('.shareable-url-modal .dropdown__options section div')
+      .first()
+      .click();
+    cy.get('.shareable-url-modal textarea').type(bucketName);
+
+    // Assert after action
+    cy.get('.shareable-url-modal__button-wrapper button')
+      .contains(primaryButtonNodeText)
+      .should('be.enabled');
+  });
+
+  it('verifies that error message appears with wrong inputs on deploy button click #TC-59', () => {
+    const bucketName = 'myBucketName';
+    const primaryButtonNodeText = 'Deploy';
+
+    // Action
+    cy.get('.pipeline-menu-button--deploy').click();
+    cy.get('.shareable-url-modal [data-test=kedro-pipeline-selector]').click();
+    cy.get('.shareable-url-modal .dropdown__options section div')
+      .first()
+      .click();
+    cy.get('.shareable-url-modal textarea').type(bucketName);
+    cy.get('.shareable-url-modal__button-wrapper button')
+      .contains(primaryButtonNodeText)
+      .click();
+
+    // Assert after action
+    cy.get('.shareable-url-modal .modal__wrapper').contains(
+      'Something went wrong. Please try again later.'
+    );
+  });
+
+  it('verifies that AWS link is generated with correct inputs on deploy button click #TC-60', () => {
+    const bucketName = 'myBucketName';
+    const primaryButtonNodeText = 'Deploy';
+
+    // Intercept the network request to mock with a fixture
+    cy.__interceptRest__(
+      '/api/deploy',
+      'POST',
+      '/mock/deploySuccessResponse.json'
+    ).as('deployRequest');
+
+    // Action
+    cy.reload();
+    cy.get('.pipeline-menu-button--deploy').click();
+    cy.get('.shareable-url-modal [data-test=kedro-pipeline-selector]').click();
+    cy.get('.shareable-url-modal .dropdown__options section div')
+      .first()
+      .click();
+    cy.get('.shareable-url-modal textarea').type(bucketName);
+    cy.get('.shareable-url-modal__button-wrapper button')
+      .contains(primaryButtonNodeText)
+      .click();
+
+    // Wait for the POST request to complete and check the mocked response
+    cy.wait('@deployRequest').then((interception) => {
+      // Assert after action
+      cy.get('.shareable-url-modal__result-url').contains(
+        interception.response.body.url
+      );
+    });
+  });
+
+  it('verifies that AWS link is generated with correct inputs on re-deploy button click #TC-61', () => {
+    const bucketName = 'myBucketName';
+    const primaryButtonNodeText = 'Deploy';
+    const primaryButtonNodeTextVariant = 'Re-Deploy';
+    const secondaryButtonNodeText = 'Link Settings';
+
+    // Intercept the network request to mock with a fixture
+    cy.__interceptRest__(
+      '/api/deploy',
+      'POST',
+      '/mock/deploySuccessResponse.json'
+    ).as('deployRequest');
+
+    // Action
+    cy.reload();
+    cy.get('.pipeline-menu-button--deploy').click();
+    cy.get('.shareable-url-modal [data-test=kedro-pipeline-selector]').click();
+    cy.get('.shareable-url-modal .dropdown__options section div')
+      .first()
+      .click();
+    cy.get('.shareable-url-modal textarea').type(bucketName);
+    cy.get('.shareable-url-modal__button-wrapper button')
+      .contains(primaryButtonNodeText)
+      .click();
+
+    // Wait for the POST request to complete
+    cy.wait('@deployRequest');
+
+    // Action
+    cy.get('.shareable-url-modal__button-wrapper button')
+      .contains(secondaryButtonNodeText)
+      .click();
+    cy.get('.shareable-url-modal__button-wrapper button')
+      .contains(primaryButtonNodeTextVariant)
+      .click();
+
+    // Wait for the POST request to complete and check the mocked response
+    cy.wait('@deployRequest').then((interception) => {
+      // Assert after action
+      cy.get('.shareable-url-modal__result-url').contains(
+        interception.response.body.url
+      );
+    });
+  });
 });

--- a/cypress/tests/ui/flowchart/shareable-urls.cy.js
+++ b/cypress/tests/ui/flowchart/shareable-urls.cy.js
@@ -80,7 +80,7 @@ describe('Shareable URLs', () => {
       .should('be.disabled');
   });
 
-  it('verifies that publish button should be disabled when region is not selected or bucket name is empty #TC-57', () => {
+  it('verifies that publish button should be disabled when a bucket region is selected and bucket name is empty #TC-57', () => {
     const primaryButtonNodeText = 'Publish';
 
     // Action
@@ -118,6 +118,7 @@ describe('Shareable URLs', () => {
   it('verifies that error message appears with wrong inputs on publish button click #TC-59', () => {
     const bucketName = 'myBucketName';
     const primaryButtonNodeText = 'Publish';
+    const errorButtonNodeText = 'Go back';
 
     // Action
     cy.get('.pipeline-menu-button--deploy').click();
@@ -134,6 +135,7 @@ describe('Shareable URLs', () => {
     cy.get('.shareable-url-modal .modal__wrapper').contains(
       'Something went wrong. Please try again later.'
     );
+    cy.get('.shareable-url-modal__error button').contains(errorButtonNodeText);
   });
 
   it('verifies that AWS link is generated with correct inputs on publish button click #TC-60', () => {


### PR DESCRIPTION
## Description

10 E2E cypress tests added for Shareable URL modal.

## Checklist

- [X] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [X] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro-viz/pull/1543"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

