### PR TITLE
Issue #1521: Add 'preview' mechanism for Data Nodes

### DIFF
--- a/demo-project/conf/base/catalog_01_raw.yml
+++ b/demo-project/conf/base/catalog_01_raw.yml
@@ -7,6 +7,14 @@ companies:
       preview_args:
         nrows: 5
 
+SQL_Query_Dataset_Example:
+  type: pandas.SQLQueryDataSet
+  sql: "SELECT shuttle, shuttle_id FROM spaceflights.shuttles;"
+  credentials: db_credentials
+  metadata:
+    kedro-viz:
+      layer: raw
+
 reviews:
   type: pandas.CSVDataSet
   filepath: ${base_location}/01_raw/reviews.csv

--- a/demo-project/src/demo_project/pipelines/data_ingestion/nodes.py
+++ b/demo-project/src/demo_project/pipelines/data_ingestion/nodes.py
@@ -116,3 +116,8 @@ def combine_shuttle_level_information(
     working_table = combined_table.dropna(how="any")
     id_columns = [x for x in working_table.columns if x.endswith("id")]
     return working_table, working_table[id_columns]
+
+def apply_basic_logic_to_sql_example_data(
+    sqlExampleParam
+) -> Tuple[pd.DataFrame, pd.DataFrame]:
+    return sqlExampleParam

--- a/demo-project/src/demo_project/pipelines/data_ingestion/pipeline.py
+++ b/demo-project/src/demo_project/pipelines/data_ingestion/pipeline.py
@@ -30,6 +30,12 @@ def create_pipeline(**kwargs) -> Pipeline:
                 name='apply_types_to_companies'
             ),
             node(
+                func=apply_basic_logic_to_sql_example_data,
+                inputs="SQL_Query_Dataset_Example",
+                outputs="result_sql_example_data",
+                name='apply_basic_logic_to_sql_example_data'
+            ),
+            node(
                 func=apply_types_to_shuttles,
                 inputs="shuttles",
                 outputs="int_typed_shuttles@pandas1",
@@ -64,7 +70,7 @@ def create_pipeline(**kwargs) -> Pipeline:
             ),
         ],
         namespace="ingestion",  # provide inputs
-        inputs={"reviews", "shuttles", "companies"},  # map inputs outside of namespace
+        inputs={"reviews", "shuttles", "companies", "SQL_Query_Dataset_Example"},  # map inputs outside of namespace
         outputs={
             "prm_spine_table",
             "prm_shuttle_company_reviews",

--- a/demo-project/src/demo_project/pipelines/data_ingestion/pipeline.py
+++ b/demo-project/src/demo_project/pipelines/data_ingestion/pipeline.py
@@ -4,6 +4,7 @@ from kedro.pipeline.modular_pipeline import pipeline
 from .nodes import (
     aggregate_company_data,
     apply_types_to_companies,
+    apply_basic_logic_to_sql_example_data,
     apply_types_to_reviews,
     apply_types_to_shuttles,
     combine_shuttle_level_information,

--- a/package/kedro_viz/api/rest/responses.py
+++ b/package/kedro_viz/api/rest/responses.py
@@ -109,6 +109,8 @@ class TaskNodeMetadataAPIResponse(BaseAPIResponse):
 
 
 class DataNodeMetadataAPIResponse(BaseAPIResponse):
+    code: Optional[str]
+    type: str
     filepath: Optional[str]
     type: str
     plot: Optional[Dict]
@@ -121,6 +123,7 @@ class DataNodeMetadataAPIResponse(BaseAPIResponse):
     class Config:
         schema_extra = {
             "example": {
+                "code": "SELECT * FROM test",
                 "filepath": "/my-kedro-project/data/03_primary/master_table.csv",
                 "type": "pandas.csv_dataset.CSVDataSet",
                 "run_command": "kedro run --to-outputs=master_table",

--- a/package/kedro_viz/models/flowchart.py
+++ b/package/kedro_viz/models/flowchart.py
@@ -13,7 +13,7 @@ from typing import Any, Dict, List, Optional, Set, Union, cast
 from kedro.pipeline.node import Node as KedroNode
 from kedro.pipeline.pipeline import TRANSCODING_SEPARATOR, _strip_transcoding
 
-from kedro_viz.models.utils import get_dataset_type, extract_data_source
+from kedro_viz.models.utils import extract_data_source, get_dataset_type
 
 try:
     # kedro 0.18.11 onwards
@@ -308,6 +308,7 @@ def _extract_wrapped_func(func: FunctionType) -> FunctionType:
     wrapped_func = next((c for c in closure if isinstance(c, FunctionType)), None)
     # return the original function if it's not a decorated function
     return func if wrapped_func is None else wrapped_func
+
 
 @dataclass
 class ModularPipelineNode(GraphNode):

--- a/package/kedro_viz/models/flowchart.py
+++ b/package/kedro_viz/models/flowchart.py
@@ -13,7 +13,7 @@ from typing import Any, Dict, List, Optional, Set, Union, cast
 from kedro.pipeline.node import Node as KedroNode
 from kedro.pipeline.pipeline import TRANSCODING_SEPARATOR, _strip_transcoding
 
-from kedro_viz.models.utils import get_dataset_type
+from kedro_viz.models.utils import get_dataset_type, extract_data_source
 
 try:
     # kedro 0.18.11 onwards
@@ -308,28 +308,6 @@ def _extract_wrapped_func(func: FunctionType) -> FunctionType:
     wrapped_func = next((c for c in closure if isinstance(c, FunctionType)), None)
     # return the original function if it's not a decorated function
     return func if wrapped_func is None else wrapped_func
-
-def extract_data_source(node_type, data_desc):
-    extracted_format_type = node_type.split(".")[-1]
-
-    match extracted_format_type:
-        case "SQLQueryDataSet" | "GBQQueryDataSet":
-            return data_desc["sql"]
-        case "APIDataSet":
-            source = f'Derived from {data_desc["url"]} using {data_desc["method"]} method.'
-            return source
-        case "SparkHiveDataSet" | "SnowparkTableDataSet":
-            extracted_table = data_desc["table_name"] if extracted_format_type == "SnowparkTableDataSet" else data_desc["table"]
-            source = f'Derived from {extracted_table} table, within {data_desc["database"]} database.'
-            return source
-        case "SparkJDBCDataSet":
-            source = f'Derived from {data_desc["table"]} table, from {data_desc["url"]} url.'
-            return source
-        case "PickleDataSet":
-            source = f'Derived from {data_desc["url"]} url.'
-            return source
-        case "_": # Default case
-            return None
 
 @dataclass
 class ModularPipelineNode(GraphNode):

--- a/package/kedro_viz/models/utils.py
+++ b/package/kedro_viz/models/utils.py
@@ -1,6 +1,6 @@
 """`kedro_viz.models.utils` contains utility functions used in the `kedro_viz.models` package"""
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Dict
 
 logger = logging.getLogger(__name__)
 
@@ -44,24 +44,43 @@ def get_dataset_type(dataset: "AbstractDataset") -> str:
     class_name = f"{dataset.__class__.__qualname__}"
     return f"{abbreviated_module_name}.{class_name}"
 
-def extract_data_source(node_type, data_desc):
+
+def extract_data_source(node_type: str, data_desc: Dict) -> str:
+    """Get the relevant source logic used in generating this node's data, based
+    on dataset type
+
+    Args:
+        node_type: The dataset object to get the type of
+        data_desc: Dict whose values store useful contextual information about the dataset
+
+    Returns:
+        String to display to user as the node source code
+    """
     extracted_format_type = node_type.split(".")[-1]
 
     match extracted_format_type:
         case "SQLQueryDataSet" | "GBQQueryDataSet":
             return data_desc["sql"]
         case "APIDataSet":
-            source = f'Derived from {data_desc["url"]} using {data_desc["method"]} method.'
+            source = (
+                f'Derived from {data_desc["url"]} using {data_desc["method"]} method.'
+            )
             return source
         case "SparkHiveDataSet" | "SnowparkTableDataSet":
-            extracted_table = data_desc["table_name"] if extracted_format_type == "SnowparkTableDataSet" else data_desc["table"]
-            source = f'Derived from {extracted_table} table, within {data_desc["database"]} database.'
+            extracted_table = (
+                data_desc["table_name"]
+                if extracted_format_type == "SnowparkTableDataSet"
+                else data_desc["table"]
+            )
+            source = f'Derived from {extracted_table} table, in {data_desc["database"]} database.'
             return source
         case "SparkJDBCDataSet":
-            source = f'Derived from {data_desc["table"]} table, from {data_desc["url"]} url.'
+            source = (
+                f'Derived from {data_desc["table"]} table, from {data_desc["url"]} url.'
+            )
             return source
         case "PickleDataSet":
             source = f'Derived from {data_desc["url"]} url.'
             return source
-        case "_": # Default case
+        case "_":  # Default case
             return None

--- a/package/kedro_viz/models/utils.py
+++ b/package/kedro_viz/models/utils.py
@@ -43,3 +43,25 @@ def get_dataset_type(dataset: "AbstractDataset") -> str:
     abbreviated_module_name = ".".join(dataset.__class__.__module__.split(".")[-2:])
     class_name = f"{dataset.__class__.__qualname__}"
     return f"{abbreviated_module_name}.{class_name}"
+
+def extract_data_source(node_type, data_desc):
+    extracted_format_type = node_type.split(".")[-1]
+
+    match extracted_format_type:
+        case "SQLQueryDataSet" | "GBQQueryDataSet":
+            return data_desc["sql"]
+        case "APIDataSet":
+            source = f'Derived from {data_desc["url"]} using {data_desc["method"]} method.'
+            return source
+        case "SparkHiveDataSet" | "SnowparkTableDataSet":
+            extracted_table = data_desc["table_name"] if extracted_format_type == "SnowparkTableDataSet" else data_desc["table"]
+            source = f'Derived from {extracted_table} table, within {data_desc["database"]} database.'
+            return source
+        case "SparkJDBCDataSet":
+            source = f'Derived from {data_desc["table"]} table, from {data_desc["url"]} url.'
+            return source
+        case "PickleDataSet":
+            source = f'Derived from {data_desc["url"]} url.'
+            return source
+        case "_": # Default case
+            return None

--- a/package/tests/test_models/test_flowchart.py
+++ b/package/tests/test_models/test_flowchart.py
@@ -19,7 +19,7 @@ from kedro_viz.models.flowchart import (
     TaskNode,
     TaskNodeMetadata,
     TranscodedDataNode,
-    TranscodedDataNodeMetadata
+    TranscodedDataNodeMetadata,
 )
 
 try:
@@ -368,24 +368,30 @@ class TestGraphNodeMetadata:
         data_node_metadata = DataNodeMetadata(data_node=data_node)
         assert data_node_metadata.type == "pandas.csv_dataset.CSVDataSet"
         assert data_node_metadata.filepath == "/tmp/dataset.csv"
-        assert data_node_metadata.code == None
+        assert data_node_metadata.code is None
         assert data_node_metadata.run_command == "kedro run --to-outputs=dataset"
         assert data_node_metadata.stats["rows"] == 10
         assert data_node_metadata.stats["columns"] == 2
 
     def test_data_node_metadata_with_sql_source(self):
-        dataset = SQLQueryDataSet("SELECT * FROM test_data_node_metadata_with_sql_source", {"con": "postgresql://test_test@localhost/test"})
+        dataset = SQLQueryDataSet(
+            "SELECT * FROM test_data_node_metadata_with_sql_source",
+            {"con": "postgresql://test_test@localhost/test"},
+        )
         data_node = GraphNode.create_data_node(
             dataset_name="sql_dataset",
             layer="raw",
             tags=set(),
             dataset=dataset,
-            stats={}
+            stats={},
         )
         data_node_metadata = DataNodeMetadata(data_node=data_node)
         assert data_node_metadata.type == "pandas.sql_dataset.SQLQueryDataSet"
         assert data_node_metadata.filepath == "None"
-        assert data_node_metadata.code == "SELECT * FROM test_data_node_metadata_with_sql_source"
+        assert (
+            data_node_metadata.code
+            == "SELECT * FROM test_data_node_metadata_with_sql_source"
+        )
 
     def test_preview_args_not_exist(self):
         metadata = {"kedro-viz": {"something": 3}}

--- a/package/tests/test_models/test_flowchart.py
+++ b/package/tests/test_models/test_flowchart.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, call, patch
 
 import pytest
 from kedro.pipeline.node import node
-from kedro_datasets.pandas import CSVDataSet, ParquetDataSet, SQLQueryDataSet, GBQQueryDataSet
+from kedro_datasets.pandas import CSVDataSet, ParquetDataSet, SQLQueryDataSet
 
 from kedro_viz.models.flowchart import (
     DataNode,
@@ -19,7 +19,7 @@ from kedro_viz.models.flowchart import (
     TaskNode,
     TaskNodeMetadata,
     TranscodedDataNode,
-    TranscodedDataNodeMetadata,
+    TranscodedDataNodeMetadata
 )
 
 try:
@@ -373,31 +373,19 @@ class TestGraphNodeMetadata:
         assert data_node_metadata.stats["rows"] == 10
         assert data_node_metadata.stats["columns"] == 2
 
-    data_node_metadata_sources = [
-         (
-            SQLQueryDataSet("SELECT * FROM test_data_node_metadata_with_sql_source", {"con": "postgresql://test_test@localhost/test"}),
-            "sql_dataset",
-            "pandas.sql_dataset.SQLQueryDataSet",
-            "SELECT * FROM test_data_node_metadata_with_source"
-         ),
-         (
-            DataNode()
-         )
-
-     ]
-    @pytest.mark.parametrize("dataset,dataset_name,expected_type,expected_code", data_node_metadata_sources)
-    def test_data_node_metadata_with_different_source(self, dataset, dataset_name, expected_type, expected_code):
+    def test_data_node_metadata_with_sql_source(self):
+        dataset = SQLQueryDataSet("SELECT * FROM test_data_node_metadata_with_sql_source", {"con": "postgresql://test_test@localhost/test"})
         data_node = GraphNode.create_data_node(
-            dataset_name=dataset_name,
+            dataset_name="sql_dataset",
             layer="raw",
             tags=set(),
             dataset=dataset,
             stats={}
         )
         data_node_metadata = DataNodeMetadata(data_node=data_node)
-        assert data_node_metadata.type == expected_type
+        assert data_node_metadata.type == "pandas.sql_dataset.SQLQueryDataSet"
         assert data_node_metadata.filepath == "None"
-        assert data_node_metadata.code == expected_code
+        assert data_node_metadata.code == "SELECT * FROM test_data_node_metadata_with_sql_source"
 
     def test_preview_args_not_exist(self):
         metadata = {"kedro-viz": {"something": 3}}

--- a/package/tests/test_models/test_utils.py
+++ b/package/tests/test_models/test_utils.py
@@ -1,6 +1,6 @@
 import pytest
 
-from kedro_viz.models.utils import get_dataset_type, extract_data_source
+from kedro_viz.models.utils import extract_data_source, get_dataset_type
 
 try:
     # kedro 0.18.11 onwards
@@ -17,68 +17,52 @@ except ImportError:
 def test_get_dataset_type(dataset, expected_type):
     assert get_dataset_type(dataset) == expected_type
 
+
 data_node_inputs = [
-     (
+    (
         "pandas.sql_dataset.SQLQueryDataSet",
         {"sql": "SELECT * FROM test_data_node_metadata_with_sql_source"},
-        "SELECT * FROM test_data_node_metadata_with_sql_source"
-     ),
-     (
+        "SELECT * FROM test_data_node_metadata_with_sql_source",
+    ),
+    (
         "pandas.gbq_dataset.GBQQueryDataSet",
         {"sql": "SELECT * FROM test_data_node_metadata_with_gbq_source"},
-        "SELECT * FROM test_data_node_metadata_with_gbq_source"
-     ),
-     (
+        "SELECT * FROM test_data_node_metadata_with_gbq_source",
+    ),
+    (
         "api.api_dataset.APIDataSet",
-        {"url": "www.test.com", "method":"GET"},
-        "Derived from www.test.com using GET method."
-     ),
-     (
+        {"url": "www.test.com", "method": "GET"},
+        "Derived from www.test.com using GET method.",
+    ),
+    (
         "spark.spark_hive_dataset.SparkHiveDataSet",
-        {"table": "test_spark_hive_table", "database":"test_spark_hive_db"},
-        "Derived from test_spark_hive_table table, within test_spark_hive_db database."
-     ),
-     (
+        {"table": "test_spark_hive_table", "database": "test_spark_hive_db"},
+        "Derived from test_spark_hive_table table, in test_spark_hive_db database.",
+    ),
+    (
         "snow.snowpark_dataset.SnowparkTableDataSet",
-        {"table_name": "test_snowpark_table", "database":"test_snowpark_db"},
-        "Derived from test_snowpark_table table, within test_snowpark_db database."
-     ),
-     (
-        "spark.spark_hive_dataset.SparkHiveDataSet",
-        {"table": "test_spark_hive_table", "database":"test_spark_hive_db"},
-        "Derived from test_spark_hive_table table, within test_spark_hive_db database."
-     ),
-     (
-        "snow.snowpark_dataset.SnowparkTableDataSet",
-        {"table_name": "test_snowpark_table", "database":"test_snowpark_db"},
-        "Derived from test_snowpark_table table, within test_snowpark_db database."
-     ),
-     (
+        {"table_name": "test_snowpark_table", "database": "test_snowpark_db"},
+        "Derived from test_snowpark_table table, in test_snowpark_db database.",
+    ),
+    (
         "spark.spark_jdbc_dataset.SparkJDBCDataSet",
-        {"table": "test_spark_hive_table", "url":"www.test_spark_jdbc_dataset_url.com"},
-        "Derived from test_spark_hive_table table, from www.test_spark_jdbc_dataset_url.com url."
-     ),
-     (
+        {
+            "table": "test_spark_hive_table",
+            "url": "www.test_spark_jdbc_dataset_url.com",
+        },
+        "Derived from test_spark_hive_table table, from www.test_spark_jdbc_dataset_url.com url.",
+    ),
+    (
         "redis.pickle_dataset.PickleDataSet",
         {"url": "www.test_redis_pickle_dataset_url.com"},
-        "Derived from www.test_redis_pickle_dataset_url.com url."
-     ),
-     (
-        "unrecognised_dataset_type",
-        {},
-        None
-     ),
-     (
-        "_",
-        {},
-        None
-     ),
-     (
-        "",
-        {},
-        None
-     ),
- ]
+        "Derived from www.test_redis_pickle_dataset_url.com url.",
+    ),
+    ("unrecognised_dataset_type", {}, None),
+    ("_", {}, None),
+    ("", {}, None),
+]
+
+
 @pytest.mark.parametrize("node_type,data_desc,expected_source", data_node_inputs)
 def test_source_data_extraction(node_type, data_desc, expected_source):
     extractedSource = extract_data_source(node_type, data_desc)

--- a/package/tests/test_models/test_utils.py
+++ b/package/tests/test_models/test_utils.py
@@ -1,6 +1,6 @@
 import pytest
 
-from kedro_viz.models.utils import get_dataset_type
+from kedro_viz.models.utils import get_dataset_type, extract_data_source
 
 try:
     # kedro 0.18.11 onwards
@@ -16,3 +16,70 @@ except ImportError:
 )
 def test_get_dataset_type(dataset, expected_type):
     assert get_dataset_type(dataset) == expected_type
+
+data_node_inputs = [
+     (
+        "pandas.sql_dataset.SQLQueryDataSet",
+        {"sql": "SELECT * FROM test_data_node_metadata_with_sql_source"},
+        "SELECT * FROM test_data_node_metadata_with_sql_source"
+     ),
+     (
+        "pandas.gbq_dataset.GBQQueryDataSet",
+        {"sql": "SELECT * FROM test_data_node_metadata_with_gbq_source"},
+        "SELECT * FROM test_data_node_metadata_with_gbq_source"
+     ),
+     (
+        "api.api_dataset.APIDataSet",
+        {"url": "www.test.com", "method":"GET"},
+        "Derived from www.test.com using GET method."
+     ),
+     (
+        "spark.spark_hive_dataset.SparkHiveDataSet",
+        {"table": "test_spark_hive_table", "database":"test_spark_hive_db"},
+        "Derived from test_spark_hive_table table, within test_spark_hive_db database."
+     ),
+     (
+        "snow.snowpark_dataset.SnowparkTableDataSet",
+        {"table_name": "test_snowpark_table", "database":"test_snowpark_db"},
+        "Derived from test_snowpark_table table, within test_snowpark_db database."
+     ),
+     (
+        "spark.spark_hive_dataset.SparkHiveDataSet",
+        {"table": "test_spark_hive_table", "database":"test_spark_hive_db"},
+        "Derived from test_spark_hive_table table, within test_spark_hive_db database."
+     ),
+     (
+        "snow.snowpark_dataset.SnowparkTableDataSet",
+        {"table_name": "test_snowpark_table", "database":"test_snowpark_db"},
+        "Derived from test_snowpark_table table, within test_snowpark_db database."
+     ),
+     (
+        "spark.spark_jdbc_dataset.SparkJDBCDataSet",
+        {"table": "test_spark_hive_table", "url":"www.test_spark_jdbc_dataset_url.com"},
+        "Derived from test_spark_hive_table table, from www.test_spark_jdbc_dataset_url.com url."
+     ),
+     (
+        "redis.pickle_dataset.PickleDataSet",
+        {"url": "www.test_redis_pickle_dataset_url.com"},
+        "Derived from www.test_redis_pickle_dataset_url.com url."
+     ),
+     (
+        "unrecognised_dataset_type",
+        {},
+        None
+     ),
+     (
+        "_",
+        {},
+        None
+     ),
+     (
+        "",
+        {},
+        None
+     ),
+ ]
+@pytest.mark.parametrize("node_type,data_desc,expected_source", data_node_inputs)
+def test_source_data_extraction(node_type, data_desc, expected_source):
+    extractedSource = extract_data_source(node_type, data_desc)
+    assert extractedSource == expected_source

--- a/src/components/metadata/metadata-code.js
+++ b/src/components/metadata/metadata-code.js
@@ -35,7 +35,7 @@ export const MetaDataCode = ({
         'kedro'
       )}
     >
-      <h2 className="pipeline-metadata-code__title">Code block</h2>
+      <h2 className="pipeline-metadata-code__title">Source block</h2>
       <code className="pipeline-metadata-code__code">
         <pre ref={codeRef} dangerouslySetInnerHTML={{ __html: highlighted }} />
       </code>

--- a/src/components/metadata/metadata.js
+++ b/src/components/metadata/metadata.js
@@ -136,7 +136,7 @@ const MetaData = ({
                   id="code"
                   checked={visibleCode}
                   enabled={hasCode}
-                  title="Show Code"
+                  title="Show Source"
                   onChange={(event) => {
                     onToggleCode(event.target.checked);
                   }}

--- a/src/components/metadata/metadata.js
+++ b/src/components/metadata/metadata.js
@@ -25,6 +25,7 @@ import {
 
 import './styles/metadata.scss';
 import MetaDataStats from './metadata-stats';
+import Switch from '../ui/switch';
 
 /**
  * Shows node meta data
@@ -145,6 +146,10 @@ const MetaData = ({
             </div>
             <div className="pipeline-metadata__list">
               <dl className="pipeline-metadata__properties">
+                <MetaDataRow
+                  label="Preview original code:"
+                  children={<Switch defaultChecked={false} />}
+                />
                 {isPrettyName ? (
                   <MetaDataRow
                     label="Original node name:"

--- a/src/components/metadata/metadata.js
+++ b/src/components/metadata/metadata.js
@@ -25,7 +25,6 @@ import {
 
 import './styles/metadata.scss';
 import MetaDataStats from './metadata-stats';
-import Switch from '../ui/switch';
 
 /**
  * Shows node meta data
@@ -146,10 +145,6 @@ const MetaData = ({
             </div>
             <div className="pipeline-metadata__list">
               <dl className="pipeline-metadata__properties">
-                <MetaDataRow
-                  label="Preview original code:"
-                  children={<Switch defaultChecked={false} />}
-                />
                 {isPrettyName ? (
                   <MetaDataRow
                     label="Original node name:"


### PR DESCRIPTION
## Description
If a data node relies on a file, then the user has the ability to see where that file is and have a preview into its data.

The same is not true for non-file sources, like SQL Query Datasets or API sources; data flows in, but user has no 'preview' mechanism.

This adds one in for those non-file sources. Essentially, a `filepath` attribute for datasets that have no files.

## Development notes

Modifies DataNodeMetadata to have a 'code' attribute, which stores some context-data behind that node. For example, if the node's data was generated from SQL, the 'code' would store that SQL command. 

If the node was generated from an external API (e.g. at xyz address), then 'code' would store the address to indicate to the user where the source of the data is from. 

## What's left?
Polishing this PR and adding images to make it clearer.

## QA notes

All tests run normally, added new test cases in `kedro_viz`-`test_models`-`test_utils.py` file to achieve 100% test coverage.

## Image Example

TBC