### PR TITLE
Fix UTC timezone in deploy viz metadata

### DIFF
--- a/package/kedro_viz/integrations/deployment/s3_deployer.py
+++ b/package/kedro_viz/integrations/deployment/s3_deployer.py
@@ -96,10 +96,9 @@ class S3Deployer:
             self._bucket_path,
         )
 
-        utc_timestamp = datetime.utcnow().strftime("%d.%m.%Y %H:%M:%S")
         try:
             metadata = {
-                "timestamp": f"{utc_timestamp} UTC",
+                "timestamp": datetime.utcnow().strftime("%d.%m.%Y %H:%M:%S"),
                 "version": str(VersionInfo.parse(__version__)),
             }
             with self._remote_fs.open(

--- a/src/components/shareable-url-modal/shareable-url-metadata.js
+++ b/src/components/shareable-url-modal/shareable-url-metadata.js
@@ -33,7 +33,7 @@ const ShareableUrlMetadata = () => {
     <div className="shareable-url-timestamp">
       <p>{`Kedro-Viz ${metadata.version} – ${metadata.timestamp
         .split(' ')
-        .join(' – ')}`}</p>
+        .join(' – ')} UTC`}</p>
     </div>
   );
 };


### PR DESCRIPTION
## Description

Resolves #1556 

## Development notes

* Modified timezone to UTC and added UTC label 

![image](https://github.com/kedro-org/kedro-viz/assets/87735534/96046ea0-d4d4-42ac-8aaf-e7fcd76a0a45)


## QA notes
* Test shareable viz and find UTC timezone in the metadata as in image above

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes
