### PR TITLE
Issue #1548: Fix improper display of 'run command' text

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -9,7 +9,7 @@ Please follow the established format:
 # Next Release
 
 ## Bug fixes and other changes
-- Fix improper display of 'run-command' inside the metadata panel. (#1548)
+- Fix improper display of 'run-command' inside the metadata panel. (#1569)
 
 # Release 6.6.0
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,6 +6,11 @@ Please follow the established format:
 - Include the ID number for the related PR (or PRs) in parentheses
 -->
 
+# Next Release
+
+## Bug fixes and other changes
+- Fix improper display of 'run-command' inside the metadata panel. (#1548)
+
 # Release 6.6.0
 
 ## Major features and improvements

--- a/package/kedro_viz/models/flowchart.py
+++ b/package/kedro_viz/models/flowchart.py
@@ -411,6 +411,8 @@ class TaskNodeMetadata(GraphNodeMetadata):
         if kedro_node._name is not None:
             self.run_command = (
                 f"kedro run --to-nodes={task_node.namespace}.{kedro_node._name}"
+                if task_node.namespace is not None
+                else f"kedro run --to-nodes={kedro_node._name}"
             )
 
 

--- a/package/tests/test_models/test_flowchart.py
+++ b/package/tests/test_models/test_flowchart.py
@@ -304,6 +304,28 @@ class TestGraphNodeMetadata:
             == "kedro run --to-nodes=namespace.identity_node"
         )
 
+    def test_task_node_metadata_no_namespace(self):
+        kedro_node = node(
+            identity,
+            inputs="x",
+            outputs="y",
+            name="identity_node",
+            tags={"tag"},
+        )
+        task_node = GraphNode.create_task_node(kedro_node)
+        task_node_metadata = TaskNodeMetadata(task_node=task_node)
+        assert task_node_metadata.code == dedent(
+            """\
+            def identity(x):
+                return x
+            """
+        )
+        assert task_node_metadata.filepath == str(
+            Path(__file__).relative_to(Path.cwd().parent).expanduser()
+        )
+        assert task_node_metadata.parameters == {}
+        assert task_node_metadata.run_command == "kedro run --to-nodes=identity_node"
+
     def test_task_node_metadata_no_run_command(self):
         kedro_node = node(
             identity,


### PR DESCRIPTION
## Description
Resolves https://github.com/kedro-org/kedro-viz/issues/1548

Task nodes that have no namespace, but a name present, will display their run command as `...None.(Node_name)`.

The correct display should just be the `...(Node_name)` only

## Development notes

Purposely made changes very light to avoid unintentional bugs around the code (still unfamiliar with code base, so don't want to make large changes I can't predict the effects of).

Primary change for this PR is just to the text display; tells it to ignore 'None' values. 

## QA notes

- All tests run normally.
- Added new test case where a TaskNode is created w/ a name but no namespace, to check the namespace 'None' will not be included

## Image Example
_Before_
&nbsp;
<img width="935" alt="image" src="https://github.com/kedro-org/kedro-viz/assets/35583819/ec5ca193-d878-4d40-88db-b0bfdb350348">


_After_
&nbsp;
<img width="825" alt="image" src="https://github.com/kedro-org/kedro-viz/assets/35583819/96a30ae5-16a7-4be4-899e-dfe9d707cada">

