### PR TITLE
Fix for connection issue on shared servers

### DIFF
--- a/package/kedro_viz/launchers/utils.py
+++ b/package/kedro_viz/launchers/utils.py
@@ -66,7 +66,7 @@ def _check_viz_up(host: str, port: int):
         port: the port the webserver is listening
     """
 
-    url = f"http://{host}:{port}"
+    url = f"http://{host}:{port}/api/main"
     try:
         response = requests.get(url, timeout=10)
     except requests.ConnectionError:


### PR DESCRIPTION
## Description

Resolves #1277 and the intermittent blank page issue on shared server when the server is already responding on port 4141

## Development notes

* Updated _check_viz_up url to fetch data from /api/main

## QA notes

- Checkout branch `fix/connection-error-shared-server`
- Run frontend using `npm start` - This simulates localhost:4141 is running 
- Build backend using `pip install -e package`
- cd demo-project, execute command `kedro viz` or `kedro viz --autoreload`
- Browser window should open after server is started and the browser should not dispay a connection error/blank page

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes
