### PR TITLE
Add demo.kedro.org to Shareable URLs hosts list

### DIFF
--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -189,8 +189,8 @@ export const formatNumberWithCommas = (number) => {
  * @returns {Boolean} True if the app is running locally.
  */
 export const isRunningLocally = () => {
-  const localHosts = ['localhost', '127.0.0.1'];
-  const itemFoundIndex = localHosts.indexOf(window.location.hostname);
+  const hosts = ['localhost', '127.0.0.1', 'demo.kedro.org'];
+  const itemFoundIndex = hosts.indexOf(window.location.hostname);
 
   if (itemFoundIndex === -1) {
     return false; // The hostname isn't in our list of local hosts


### PR DESCRIPTION
## Description

When I deployed the new 6.6.0 release to our demo website last week, the experiment tracking icon and link was missing. That's because there's a check to see if the app is running locally, and if it isn't, we hide that link item.

We should actually show it on the demo site, so this fixes that.

## Development notes

Adds `demo.kedro.org` to the list of hosts in order to show the experiment tracking and shareable URLs icon buttons.


## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes
