### PR TITLE
Add forward compatibility with renames `_dataset` arguments.

### DIFF
--- a/package/kedro_viz/data_access/repositories/catalog.py
+++ b/package/kedro_viz/data_access/repositories/catalog.py
@@ -78,12 +78,16 @@ class CatalogRepository:
 
         self._layers_mapping = {}
 
+        try:
+            datasets = self._catalog._data_sets
+        except:
+            datasets = self._catalog._datasets
         # Maps layers according to the old format
         if KEDRO_VERSION < parse("0.19.0"):
             if self._catalog.layers is None:
                 self._layers_mapping = {
                     _strip_transcoding(dataset_name): None
-                    for dataset_name in self._catalog._datasets
+                    for dataset_name in datasets
                 }
             else:
                 for layer, dataset_names in self._catalog.layers.items():
@@ -94,7 +98,7 @@ class CatalogRepository:
                         self._layers_mapping[dataset_name] = layer
 
         # Maps layers according to the new format
-        for dataset_name in self._catalog._datasets:
+        for dataset_name in datasets:
             dataset = self._catalog._get_dataset(dataset_name)
             metadata = getattr(dataset, "metadata", None)
             if not metadata:

--- a/package/kedro_viz/data_access/repositories/catalog.py
+++ b/package/kedro_viz/data_access/repositories/catalog.py
@@ -52,6 +52,7 @@ class CatalogRepository:
 
     @property
     def layers_mapping(self):
+        # pylint: disable=too-many-branches
         """Return layer mapping: dataset_name -> layer it belongs to in the catalog
         From kedro-datasets 1.3.0 onwards, the 'layers' attribute is defined inside the 'metadata'
         under 'kedro-viz' plugin.
@@ -78,16 +79,18 @@ class CatalogRepository:
 
         self._layers_mapping = {}
 
+        # Temporary try/except block so the Kedro develop branch can work with Viz.
         try:
             datasets = self._catalog._data_sets
-        except:
+        # pylint: disable=broad-exception-caught
+        except Exception:  # pragma: no cover
             datasets = self._catalog._datasets
+
         # Maps layers according to the old format
         if KEDRO_VERSION < parse("0.19.0"):
             if self._catalog.layers is None:
                 self._layers_mapping = {
-                    _strip_transcoding(dataset_name): None
-                    for dataset_name in datasets
+                    _strip_transcoding(dataset_name): None for dataset_name in datasets
                 }
             else:
                 for layer, dataset_names in self._catalog.layers.items():

--- a/package/kedro_viz/data_access/repositories/catalog.py
+++ b/package/kedro_viz/data_access/repositories/catalog.py
@@ -83,7 +83,7 @@ class CatalogRepository:
             if self._catalog.layers is None:
                 self._layers_mapping = {
                     _strip_transcoding(dataset_name): None
-                    for dataset_name in self._catalog._data_sets
+                    for dataset_name in self._catalog._datasets
                 }
             else:
                 for layer, dataset_names in self._catalog.layers.items():
@@ -94,7 +94,7 @@ class CatalogRepository:
                         self._layers_mapping[dataset_name] = layer
 
         # Maps layers according to the new format
-        for dataset_name in self._catalog._data_sets:
+        for dataset_name in self._catalog._datasets:
             dataset = self._catalog._get_dataset(dataset_name)
             metadata = getattr(dataset, "metadata", None)
             if not metadata:

--- a/package/kedro_viz/integrations/kedro/hooks.py
+++ b/package/kedro_viz/integrations/kedro/hooks.py
@@ -30,10 +30,11 @@ class DatasetStatsHook:
         Args:
             catalog: The catalog that was created.
         """
+        # Temporary try/except block so the Kedro develop branch can work with Viz.
         try:
             self.datasets = catalog._data_sets
-        except:
-            self.datasets = catalog._datasets
+        except Exception:  # pragma: no cover
+            self.datasets = catalog._datasets  # type: ignore[attr-defined]
 
     @hook_impl
     def after_dataset_loaded(self, dataset_name: str, data: Any):

--- a/package/kedro_viz/integrations/kedro/hooks.py
+++ b/package/kedro_viz/integrations/kedro/hooks.py
@@ -31,7 +31,7 @@ class DatasetStatsHook:
             catalog: The catalog that was created.
         """
 
-        self.datasets = catalog._data_sets
+        self.datasets = catalog._datasets
 
     @hook_impl
     def after_dataset_loaded(self, dataset_name: str, data: Any):

--- a/package/kedro_viz/integrations/kedro/hooks.py
+++ b/package/kedro_viz/integrations/kedro/hooks.py
@@ -30,8 +30,10 @@ class DatasetStatsHook:
         Args:
             catalog: The catalog that was created.
         """
-
-        self.datasets = catalog._datasets
+        try:
+            self.datasets = catalog._data_sets
+        except:
+            self.datasets = catalog._datasets
 
     @hook_impl
     def after_dataset_loaded(self, dataset_name: str, data: Any):

--- a/package/tests/test_integrations/test_hooks.py
+++ b/package/tests/test_integrations/test_hooks.py
@@ -23,7 +23,7 @@ def test_after_catalog_created(example_dataset_stats_hook_obj, example_catalog):
 
     # Assert for catalog creation
     assert hasattr(example_dataset_stats_hook_obj, "datasets")
-    assert example_dataset_stats_hook_obj.datasets == example_catalog._datasets
+    assert example_dataset_stats_hook_obj.datasets == example_catalog._data_sets
 
 
 @pytest.mark.parametrize(

--- a/package/tests/test_integrations/test_hooks.py
+++ b/package/tests/test_integrations/test_hooks.py
@@ -23,7 +23,7 @@ def test_after_catalog_created(example_dataset_stats_hook_obj, example_catalog):
 
     # Assert for catalog creation
     assert hasattr(example_dataset_stats_hook_obj, "datasets")
-    assert example_dataset_stats_hook_obj.datasets == example_catalog._data_sets
+    assert example_dataset_stats_hook_obj.datasets == example_catalog._datasets
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description
In https://github.com/kedro-org/kedro/issues/3041 we renamed any mentions of `data_set`/`_data_set` to `dataset` and `_dataset` respectively. This was merged to the `develop` branch, because it's a breaking change. For the new add_ons work we need to build new code inside the starters against the Kedro `develop` branch, but the starters also rely on Kedro-Viz and so the change in this PR makes sure that the starters can use Kedro `develop` as well as viz with a "forward compatible" mention of the renamed arguments. 

## Development notes
It's not possible yet to just rename the arguments inside of Kedro-Viz, because that requires a release of the Kedro `develop` branch. 

## QA notes



## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes
