### PR TITLE
Update demo project to use OmegaConfigLoader

### DIFF
--- a/demo-project/README.md
+++ b/demo-project/README.md
@@ -4,7 +4,7 @@ This project is designed to be a realistic example of what Kedro looks like when
 
 ## Setup
 
-1. Run `pip install kedro==0.18.4`
-2. Run `kedro install --build-reqs`
+1. Run `pip install kedro~=0.18.0`
+2. Run `pip install -r src/demo_project/requirements.in`
 3. Run `kedro run`
 4. Run `kedro viz`

--- a/demo-project/conf/base/catalog_01_raw.yml
+++ b/demo-project/conf/base/catalog_01_raw.yml
@@ -1,6 +1,6 @@
 companies:
   type: pandas.CSVDataSet
-  filepath: ${base_location}/01_raw/companies.csv
+  filepath: ${_base_location}/01_raw/companies.csv
   metadata:
     kedro-viz:
       layer: raw
@@ -9,21 +9,19 @@ companies:
 
 reviews:
   type: pandas.CSVDataSet
-  filepath: ${base_location}/01_raw/reviews.csv
+  filepath: ${_base_location}/01_raw/reviews.csv
   metadata:
     kedro-viz:
       layer: raw
-      preview_args: 
+      preview_args:
         nrows: 10
 
 
 shuttles:
   type: pandas.ExcelDataSet
-  filepath: ${base_location}/01_raw/shuttles.xlsx
+  filepath: ${_base_location}/01_raw/shuttles.xlsx
   metadata:
     kedro-viz:
       layer: raw
       preview_args:
-        nrows: 15 
-
-
+        nrows: 15

--- a/demo-project/conf/base/catalog_02_int.yml
+++ b/demo-project/conf/base/catalog_02_int.yml
@@ -1,27 +1,27 @@
 ingestion.int_typed_companies:
   type: pandas.ParquetDataSet
-  filepath: ${base_location}/02_intermediate/typed_companies.pq
+  filepath: ${_base_location}/02_intermediate/typed_companies.pq
   metadata:
     kedro-viz:
       layer: intermediate
 
 ingestion.int_typed_shuttles@pandas1:
   type: pandas.ParquetDataSet
-  filepath: ${base_location}/02_intermediate/typed_shuttles.pq
+  filepath: ${_base_location}/02_intermediate/typed_shuttles.pq
   metadata:
     kedro-viz:
       layer: intermediate
 
 ingestion.int_typed_shuttles@pandas2:
   type: pandas.ParquetDataSet
-  filepath: ${base_location}/02_intermediate/typed_shuttles.pq
+  filepath: ${_base_location}/02_intermediate/typed_shuttles.pq
   metadata:
     kedro-viz:
       layer: intermediate
 
 ingestion.int_typed_reviews:
   type: pandas.ParquetDataSet
-  filepath: ${base_location}/02_intermediate/typed_reviews.pq
+  filepath: ${_base_location}/02_intermediate/typed_reviews.pq
   metadata:
     kedro-viz:
       layer: intermediate

--- a/demo-project/conf/base/catalog_03_prm.yml
+++ b/demo-project/conf/base/catalog_03_prm.yml
@@ -1,14 +1,13 @@
 prm_shuttle_company_reviews:
   type: pandas.ParquetDataSet
-  filepath: ${base_location}/03_primary/prm_shuttle_company_reviews.pq
+  filepath: ${_base_location}/03_primary/prm_shuttle_company_reviews.pq
   metadata:
     kedro-viz:
       layer: primary
 
 prm_spine_table:
   type: pandas.ParquetDataSet
-  filepath: ${base_location}/03_primary/prm_spine_table.pq
+  filepath: ${_base_location}/03_primary/prm_spine_table.pq
   metadata:
     kedro-viz:
       layer: primary
-

--- a/demo-project/conf/base/catalog_04_feature.yml
+++ b/demo-project/conf/base/catalog_04_feature.yml
@@ -1,36 +1,12 @@
-# Jinja is super powerful, but does come at the cost of readability
-# Set your IDE to Jinja YAML to ensure this is highlighted correctly
+# Use dataset factories to reduce duplication
+"feature_engineering.feat_{metric_type}_metrics":
+ type: pandas.ParquetDataSet
+ filepath: ${_base_location}/04_feature/feat_{metric_type}_metrics.pq
+ layer: feature
 
-{% set namespace = 'feature_engineering' %}
-{% set metric_types = ['weighting', 'scaling'] %}
-{% for metric_type in metric_types %}
-{{ namespace }}.feat_{{ metric_type }}_metrics:
-  type: pandas.ParquetDataSet
-  filepath: ${base_location}/04_feature/feat_{{ metric_type }}_metrics.pq
+feature_importance_output:
+  type: pandas.CSVDataSet
+  filepath: ${_base_location}/04_feature/feature_importance_output.csv
   metadata:
     kedro-viz:
       layer: feature
-
-{% endfor %}
-
-# This will render to generate the records below...
-#
-# feature_engineering.feat_weighting_metrics:
-#  type: pandas.ParquetDataSet
-#  filepath: ${base_location}/04_feature/feat_weighting_metrics.pq
-#  layer: feature
-#
-# feature_engineering.feat_scaling_metrics:
-#  type: pandas.ParquetDataSet
-#  filepath: ${base_location}/04_feature/feat_scaling_metrics.pq
-#  layer: feature
-
-
-feature_importance_output: 
-  type: pandas.CSVDataSet
-  filepath: ${base_location}/04_feature/feature_importance_output.csv
-  metadata:
-    kedro-viz:
-      layer: feature 
-
-

--- a/demo-project/conf/base/catalog_05_model_input.yml
+++ b/demo-project/conf/base/catalog_05_model_input.yml
@@ -1,7 +1,6 @@
 model_input_table:
   type: pandas.ParquetDataSet
-  filepath: ${base_location}/05_model_input/model_input_table.pq
+  filepath: ${_base_location}/05_model_input/model_input_table.pq
   metadata:
     kedro-viz:
       layer: model_input
-

--- a/demo-project/conf/base/catalog_06_models.yml
+++ b/demo-project/conf/base/catalog_06_models.yml
@@ -1,9 +1,9 @@
 train_evaluation.linear_regression.regressor:
   type: pickle.PickleDataSet
-  filepath: ${base_location}/06_models/linear_regression.pkl
+  filepath: ${_base_location}/06_models/linear_regression.pkl
   versioned: True
 
 train_evaluation.random_forest.regressor:
   type: pickle.PickleDataSet
-  filepath: ${base_location}/06_models/random_forest.pkl
+  filepath: ${_base_location}/06_models/random_forest.pkl
   versioned: True

--- a/demo-project/conf/base/catalog_08_reporting.yml
+++ b/demo-project/conf/base/catalog_08_reporting.yml
@@ -1,6 +1,6 @@
 reporting.cancellation_policy_breakdown:
   type: plotly.PlotlyDataSet # Constructed via plotly_args below
-  filepath: ${base_location}/08_reporting/cancellation_breakdown.json
+  filepath: ${_base_location}/08_reporting/cancellation_breakdown.json
   metadata:
     kedro-viz:
       layer: reporting
@@ -16,7 +16,7 @@ reporting.cancellation_policy_breakdown:
 
 reporting.price_histogram:
   type: plotly.JSONDataSet # Constructed via Python API
-  filepath: ${base_location}/08_reporting/price_histogram.json
+  filepath: ${_base_location}/08_reporting/price_histogram.json
   metadata:
     kedro-viz:
       layer: reporting
@@ -24,7 +24,7 @@ reporting.price_histogram:
 
 reporting.feature_importance:
   type: plotly.JSONDataSet # Constructed via Python API
-  filepath: ${base_location}/08_reporting/feature_importance_plot.json
+  filepath: ${_base_location}/08_reporting/feature_importance_plot.json
   metadata:
     kedro-viz:
       layer: reporting
@@ -32,10 +32,9 @@ reporting.feature_importance:
 
 reporting.cancellation_policy_grid:
   type: demo_project.extras.datasets.image_dataset.ImageDataSet
-  filepath: ${base_location}/08_reporting/cancellation_policy_grid.png
+  filepath: ${_base_location}/08_reporting/cancellation_policy_grid.png
 
 reporting.confusion_matrix:
   type: matplotlib.MatplotlibWriter
-  filepath: ${base_location}/08_reporting/confusion_matrix.png
+  filepath: ${_base_location}/08_reporting/confusion_matrix.png
   versioned: true
-

--- a/demo-project/conf/base/catalog_09_tracking.yml
+++ b/demo-project/conf/base/catalog_09_tracking.yml
@@ -1,19 +1,19 @@
 train_evaluation.linear_regression.r2_score:
   type: tracking.MetricsDataSet
-  filepath: ${base_location}/09_tracking/linear_score.json
+  filepath: ${_base_location}/09_tracking/linear_score.json
   versioned: True
 
 train_evaluation.random_forest.r2_score:
   type: tracking.MetricsDataSet
-  filepath: ${base_location}/09_tracking/rf_score.json
+  filepath: ${_base_location}/09_tracking/rf_score.json
   versioned: True
 
 train_evaluation.linear_regression.experiment_params:
   type: tracking.JSONDataSet
-  filepath: ${base_location}/09_tracking/linear_params.json
+  filepath: ${_base_location}/09_tracking/linear_params.json
   versioned: True
 
 train_evaluation.random_forest.experiment_params:
   type: tracking.JSONDataSet
-  filepath: ${base_location}/09_tracking/rf_params.json
+  filepath: ${_base_location}/09_tracking/rf_params.json
   versioned: True

--- a/demo-project/conf/base/catalog_globals.yml
+++ b/demo-project/conf/base/catalog_globals.yml
@@ -1,0 +1,1 @@
+_base_location: data/

--- a/demo-project/conf/base/globals.yml
+++ b/demo-project/conf/base/globals.yml
@@ -1,1 +1,0 @@
-base_location: data/

--- a/demo-project/conf/base/parameters/feature_engineering.yml
+++ b/demo-project/conf/base/parameters/feature_engineering.yml
@@ -1,8 +1,3 @@
-# This is a boilerplate parameters config generated for pipeline 'feature_engineering'
-# using Kedro 0.18.1.
-#
-# Documentation for this file format can be found in "Parameters"
-# Link: https://kedro.readthedocs.io/en/0.18.1/kedro_project_setup/configuration.html#parameters
 feature_engineering:
   feature:
     static:

--- a/demo-project/conf/base/parameters/modelling.yml
+++ b/demo-project/conf/base/parameters/modelling.yml
@@ -21,7 +21,7 @@ train_evaluation:
         min_samples_split: 2
         min_samples_leaf: 1
         min_weight_fraction_leaf: 0
-        max_features: 'auto'
+        max_features: 1.0
         min_impurity_decrease: 0
         bootstrap: True
         oob_score: False

--- a/demo-project/conf/prod/catalog_globals.yml
+++ b/demo-project/conf/prod/catalog_globals.yml
@@ -1,0 +1,1 @@
+_base_location: s3://my_bucket/production/

--- a/demo-project/conf/prod/globals.yml
+++ b/demo-project/conf/prod/globals.yml
@@ -1,1 +1,0 @@
-base_location: s3://my_bucket/production/

--- a/demo-project/pyproject.toml
+++ b/demo-project/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.kedro]
 package_name = "demo_project"
 project_name = "modular-spaceflights"
-project_version = "0.18.4"
+kedro_init_version = "0.18.14"
 
 [tool.isort]
 multi_line_output = 3

--- a/demo-project/src/demo_project/pipelines/reporting/nodes.py
+++ b/demo-project/src/demo_project/pipelines/reporting/nodes.py
@@ -57,7 +57,7 @@ def make_price_histogram(model_input_data: pd.DataFrame) -> go.Figure:
     Returns:
         BaseFigure: Plotly object which is serialised as JSON for rendering
     """
-    price_data_df = model_input_data[["price", "engine_type"]]
+    price_data_df = model_input_data.loc[:, ["price", "engine_type"]]
     p = np.random.dirichlet([1, 1, 1])
     price_data_df["engine_type"] = np.random.choice(
         ["Quantum", "Plasma", "Nuclear"], len(price_data_df), p=p

--- a/demo-project/src/demo_project/requirements.in
+++ b/demo-project/src/demo_project/requirements.in
@@ -16,3 +16,4 @@ wheel>=0.35, <0.37
 pillow~=9.0
 matplotlib==3.5.0
 pre-commit~=1.17
+seaborn~=0.11.2

--- a/demo-project/src/demo_project/settings.py
+++ b/demo-project/src/demo_project/settings.py
@@ -24,4 +24,3 @@ SESSION_STORE_ARGS = {"path": str(Path(__file__).parents[2] / "data")}
 from kedro.config import OmegaConfigLoader  # NOQA
 
 CONFIG_LOADER_CLASS = OmegaConfigLoader
-CONFIG_LOADER_ARGS = {"globals_pattern": "*globals.yml", "globals_dict": {}}

--- a/demo-project/src/demo_project/settings.py
+++ b/demo-project/src/demo_project/settings.py
@@ -11,7 +11,7 @@ from kedro_viz.integrations.kedro.sqlite_store import SQLiteStore
 SESSION_STORE_CLASS = SQLiteStore
 SESSION_STORE_ARGS = {"path": str(Path(__file__).parents[2] / "data")}
 
-#Setup for collaborative experiment tracking. 
+# Setup for collaborative experiment tracking.
 # SESSION_STORE_ARGS = {"path": str(Path(__file__).parents[2] / "data"),
 #                       "remote_path": "s3://{path-to-session_store}" }
 
@@ -21,7 +21,7 @@ SESSION_STORE_ARGS = {"path": str(Path(__file__).parents[2] / "data")}
 # Define the configuration folder. Defaults to `conf`
 # CONF_ROOT = "conf"
 
-from kedro.config import TemplatedConfigLoader  # NOQA
+from kedro.config import OmegaConfigLoader  # NOQA
 
-CONFIG_LOADER_CLASS = TemplatedConfigLoader
+CONFIG_LOADER_CLASS = OmegaConfigLoader
 CONFIG_LOADER_ARGS = {"globals_pattern": "*globals.yml", "globals_dict": {}}


### PR DESCRIPTION
## Description

Resolves https://github.com/kedro-org/kedro/issues/3172

## Development notes

To migrate the project to use `OmegaConfigLoader`, the [migration guide](https://docs.kedro.org/en/stable/configuration/config_loader_migration.html#templatedconfigloader-to-omegaconfigloader) was followed. During this migration, I encountered some small issues that I have fixed:

* A deprecated parameter of the machine learning model in the pipeline. This was changed to the new default.
* Several warnings about `DataSet` to be renamed `Dataset` fixed by the renaming.
* Fix a `Pandas` warning, `SettingWithCopyWarning`. This was fixed using `loc` to slice a subset of the DataFrame in the pipeline.

Note: I have renamed `demo-project/src/demo_project/requirements.in` to  `demo-project/src/dev_requirements.txt` but this is optional and could be reverted

## QA notes
To test my changes, the following steps were performed:

* Making sure I could install the dependencies, following `Makefile` and instructions in `README`
* Run pipeline with `kedro run`
* Run existing tests with `pytest`

## Checklist

- [X] Read the [contributing](/CONTRIBUTING.md) guidelines
- [X] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Screenshot

![kedro-pipeline](https://github.com/kedro-org/kedro-viz/assets/38346044/75a5c704-7361-4bcb-aa1f-a059cd4047b9)



