### PR TITLE
Remove old variable in `conf.py` now CSS has moved

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -46,7 +46,6 @@ extensions = [
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
-html_static_path = ["_static"]
 
 exclude_patterns = []
 source_suffix = {".rst": "restructuredtext", ".md": "markdown"}


### PR DESCRIPTION
## Description

The variable definition in `conf.py` is causing a build warning in RTD builds. We no longer need it.

## Development notes

Removed line of code.


## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes
