### PR TITLE
Revert "Bump pillow from 9.3.0 to 10.0.1 in /demo-project/src/demo_project/pipelines/reporting"

### DIFF
--- a/demo-project/src/demo_project/pipelines/reporting/requirements.txt
+++ b/demo-project/src/demo_project/pipelines/reporting/requirements.txt
@@ -1,4 +1,4 @@
 kedro==0.18.4
 kedro-datasets[plotly.PlotlyDataSet, plotly.JSONDataSet, matplotlib.MatplotlibWriter]==1.0.1
-pillow==10.0.1
+pillow==9.3.0
 seaborn==0.11.2


### PR DESCRIPTION
Reverts kedro-org/kedro-viz#1552

Reverting as release is currently planned, and hence this merge is unnecessary at the moment