### PR TITLE
Hot fix for backward compatiblity of kedro datasets

### DIFF
--- a/package/features/steps/lower_requirements.txt
+++ b/package/features/steps/lower_requirements.txt
@@ -4,7 +4,7 @@ fsspec==2021.4
 aiofiles==22.1.0
 uvicorn[standard]==0.22.0
 watchgod==0.8.2
-plotly==4.0
+plotly==5.0
 packaging==23.0
 pandas==1.3; python_version < '3.10'
 pandas==1.5; python_version >= '3.10'

--- a/package/features/steps/lower_requirements.txt
+++ b/package/features/steps/lower_requirements.txt
@@ -4,7 +4,7 @@ fsspec==2021.4
 aiofiles==22.1.0
 uvicorn[standard]==0.22.0
 watchgod==0.8.2
-plotly==5.0
+plotly==4.8
 packaging==23.0
 pandas==1.3; python_version < '3.10'
 pandas==1.5; python_version >= '3.10'

--- a/package/kedro_viz/integrations/kedro/data_loader.py
+++ b/package/kedro_viz/integrations/kedro/data_loader.py
@@ -212,22 +212,27 @@ try:
     getattr(plotly, "JSONDataset")  # Trigger import
     plotly.JSONDataset._load = json_dataset.JSONDataset._load
 except (ImportError, AttributeError):
-    pass
+    getattr(plotly, "JSONDataSet")  # Trigger import
+    plotly.JSONDataSet._load = json_dataset.JSONDataSet._load
+
 
 try:
     getattr(plotly, "PlotlyDataset")  # Trigger import
     plotly.PlotlyDataset._load = json_dataset.JSONDataset._load
 except (ImportError, AttributeError):
-    pass
+    getattr(plotly, "PlotlyDataSet")  # Trigger import
+    plotly.PlotlyDataSet._load = json_dataset.JSONDataSet._load
 
 try:
     getattr(tracking, "JSONDataset")  # Trigger import
     tracking.JSONDataset._load = json_dataset.JSONDataset._load
 except (ImportError, AttributeError):
-    pass
+    getattr(tracking, "JSONDataSet")  # Trigger import
+    tracking.JSONDataSet._load = json_dataset.JSONDataSet._load
 
 try:
     getattr(tracking, "MetricsDataset")  # Trigger import
     tracking.MetricsDataset._load = json_dataset.JSONDataset._load
 except (ImportError, AttributeError):
-    pass
+    getattr(tracking, "MetricsDataSet")  # Trigger import
+    tracking.MetricsDataSet._load = json_dataset.JSONDataSet._load

--- a/package/kedro_viz/models/experiment_tracking.py
+++ b/package/kedro_viz/models/experiment_tracking.py
@@ -68,6 +68,10 @@ TRACKING_DATASET_GROUPS = {
     "matplotlib.matplotlib_writer.MatplotlibWriter": TrackingDatasetGroup.PLOT,
     "tracking.metrics_dataset.MetricsDataset": TrackingDatasetGroup.METRIC,
     "tracking.json_dataset.JSONDataset": TrackingDatasetGroup.JSON,
+    "plotly.plotly_dataset.PlotlyDataSet": TrackingDatasetGroup.PLOT,
+    "plotly.json_dataset.JSONDataSet": TrackingDatasetGroup.PLOT,
+    "tracking.metrics_dataset.MetricsDataSet": TrackingDatasetGroup.METRIC,
+    "tracking.json_dataset.JSONDataSet": TrackingDatasetGroup.JSON,
 }
 
 

--- a/package/kedro_viz/models/flowchart.py
+++ b/package/kedro_viz/models/flowchart.py
@@ -468,6 +468,8 @@ class DataNode(GraphNode):
         return self.dataset_type in (
             "plotly.plotly_dataset.PlotlyDataset",
             "plotly.json_dataset.JSONDataset",
+            "plotly.plotly_dataset.PlotlyDataSet",
+            "plotly.json_dataset.JSONDataSet",
         )
 
     def is_image_node(self):
@@ -476,11 +478,17 @@ class DataNode(GraphNode):
 
     def is_metric_node(self):
         """Check if the current node is a metrics node."""
-        return self.dataset_type in ("tracking.metrics_dataset.MetricsDataset",)
+        return self.dataset_type in (
+            "tracking.metrics_dataset.MetricsDataset",
+            "tracking.metrics_dataset.MetricsDataSet",
+        )
 
     def is_json_node(self):
         """Check if the current node is a JSONDataset node."""
-        return self.dataset_type in ("tracking.json_dataset.JSONDataset",)
+        return self.dataset_type in (
+            "tracking.json_dataset.JSONDataset",
+            "tracking.json_dataset.JSONDataSet",
+        )
 
     def is_tracking_node(self):
         """Checks if the current node is a tracking data node"""

--- a/src/config.js
+++ b/src/config.js
@@ -103,6 +103,10 @@ export const shortTypeMapping = {
   'matplotlib.matplotlib_writer.MatplotlibWriter': 'image',
   'tracking.json_dataset.JSONDataset': 'JSONTracking',
   'tracking.metrics_dataset.MetricsDataset': 'metricsTracking',
+  'plotly.plotly_dataset.PlotlyDataSet': 'plotly',
+  'plotly.json_dataset.JSONDataSet': 'plotly',
+  'tracking.json_dataset.JSONDataSet': 'JSONTracking',
+  'tracking.metrics_dataset.MetricsDataSet': 'metricsTracking',
 };
 
 export const tabLabels = ['Overview', 'Metrics', 'Plots'];


### PR DESCRIPTION
## Description

Fixes the experiment tracking issue when user is on kedro viz > 6.6.0 and kedro-datasets >= 1.7.0

## Development notes

**NOTE**: This is a hot fix and needs to be pushed before 6.6.1 release to support kedro-datasets >= 1.7.0

## QA notes

* Experiment Tracking should work with kedro-datasets < 1.7.1 and kedro-datasets >= 1.7.1

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes
