### PR TITLE
Adjust Dependabot versioning strategy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,7 @@ updates:
     directory: "/package" # Location of package manifests
     schedule:
       interval: "monthly"
+    versioning-strategy: increase-if-necessary
     ignore:
       - dependency-name: "types-*"
     labels:


### PR DESCRIPTION
## Description

Currently dependabot uses `auto` as its versioning strategy (which effectively becomes `increase` for us), which is a too aggressive for our liking for a component like Kedro-Viz. 

This PR adjusts it to use `increase-if-necessary` to reduce the aggressiveness and ensure dependancies are only increased if necessary. Makes dependency management a more relaxing task for us going forward.


> **All of the possible versioning strategies available, regardless of package ecosystem**

![image](https://github.com/kedro-org/kedro-viz/assets/35583819/1df5c378-6cdc-4ab8-9ff5-22abcec8243a)

> **Ideally we would've used `widen`, however this strategy is unavailable for `pip`:**

![image](https://github.com/kedro-org/kedro-viz/assets/35583819/d20dcb79-2fea-4b62-9f99-78826d3f159c)

> **Hence the decision to go forward with increase-if-necessary, as it behaves the closest and works with pip. Example of how each strategy works below**

<img width="1031" alt="image" src="https://github.com/kedro-org/kedro-viz/assets/35583819/2edb183e-cb3e-40cb-b19c-0e31c0f985c9">

## Development notes

Added `versioning strategy: increase-if-necessary` to dependabot's .yml configuration. Without this line, dependabot would have defaulted to `auto` if no versioning strategy was specified to it.

## QA notes

No major behavioural changes - however going forward, dependabot should try to not be as aggressive when it comes to upgrading dependencies. 