### PR TITLE
Fix: Kedro-Viz doesn't work when hosted via a URL subpath

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -123,19 +123,21 @@ export const params = {
 };
 
 const activePipeline = `${params.pipeline}=:pipelineId`;
+const { pathname } = window.location;
+const sanitizedPathname = pathname.endsWith('/') ? pathname : `${pathname}/`; // the `pathname` will have a trailing slash if it didn't initially
 
 export const routes = {
   flowchart: {
-    main: '/',
-    focusedNode: `/?${activePipeline}&${params.focused}=:id`,
-    selectedNode: `/?${activePipeline}&${params.selected}=:id`,
-    selectedName: `/?${activePipeline}&${params.selectedName}=:fullName`,
-    selectedPipeline: `/?${activePipeline}`,
+    main: sanitizedPathname,
+    focusedNode: `${sanitizedPathname}?${activePipeline}&${params.focused}=:id`,
+    selectedNode: `${sanitizedPathname}?${activePipeline}&${params.selected}=:id`,
+    selectedName: `${sanitizedPathname}?${activePipeline}&${params.selectedName}=:fullName`,
+    selectedPipeline: `${sanitizedPathname}?${activePipeline}`,
   },
   experimentTracking: {
-    main: '/experiment-tracking',
-    selectedView: `/experiment-tracking?${params.view}=:view`,
-    selectedRuns: `/experiment-tracking?${params.run}=:ids&${params.view}=:view&${params.comparisonMode}=:isComparison`,
+    main: `${sanitizedPathname}experiment-tracking`,
+    selectedView: `${sanitizedPathname}experiment-tracking?${params.view}=:view`,
+    selectedRuns: `${sanitizedPathname}experiment-tracking?${params.run}=:ids&${params.view}=:view&${params.comparisonMode}=:isComparison`,
   },
 };
 


### PR DESCRIPTION
## Description

Resolves [#1610](https://github.com/kedro-org/kedro-viz/issues/1610) 

Kedro-Viz flowchar function properly when the app is hosted via a subpath.
This changes deployed on my github page [https://jitu5.github.io/kedro-viz/](https://jitu5.github.io/kedro-viz/)


## QA notes

<!-- How has the expected behaviour changed? What testing strategies have you used? -->

## Checklist

- [X] Read the [contributing](/CONTRIBUTING.md) guidelines
- [X] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes
