### PR TITLE
Fix shareable viz issue with dataclass refactor

### DIFF
--- a/package/features/viz.feature
+++ b/package/features/viz.feature
@@ -3,7 +3,7 @@ Feature: Viz plugin in new project
         Given I have prepared a config file with example code
 
     Scenario: Execute viz with the earliest Kedro version that it supports 
-        Given I have installed kedro version "0.18.2"
+        Given I have installed kedro version "0.18.3"
         And I have run a non-interactive kedro new with pandas-iris starter
         And I have installed the project's requirements
         When I execute the kedro viz command

--- a/package/kedro_viz/models/flowchart.py
+++ b/package/kedro_viz/models/flowchart.py
@@ -115,7 +115,9 @@ class GraphNode(BaseModel, abc.ABC):
     type: str
     tags: Set[str] = Field(set(), description="The tags associated with this node")
     kedro_obj: Optional[Union[KedroNode, AbstractDataset]] = Field(
-        None, description="The underlying Kedro object for each graph node, if any"
+        None,
+        description="The underlying Kedro object for each graph node, if any",
+        exclude=True,
     )
     pipelines: Set[str] = Field(
         set(), description="The set of registered pipeline IDs this node belongs to"
@@ -429,7 +431,7 @@ class TaskNodeMetadata(GraphNodeMetadata):
         AssertionError: If task_node is not supplied during instantiation
     """
 
-    task_node: TaskNode
+    task_node: TaskNode = Field(..., exclude=True)
 
     # Source code of the node's function
     code: Optional[str]
@@ -712,7 +714,7 @@ class DataNodeMetadata(GraphNodeMetadata):
         AssertionError: If data_node is not supplied during instantiation
     """
 
-    data_node: DataNode
+    data_node: DataNode = Field(..., exclude=True)
 
     # The type of the data node
     type: Optional[str]
@@ -821,7 +823,7 @@ class TranscodedDataNodeMetadata(GraphNodeMetadata):
         AssertionError: If transcoded_data_node is not supplied during instantiation
     """
 
-    transcoded_data_node: TranscodedDataNode
+    transcoded_data_node: TranscodedDataNode = Field(..., exclude=True)
 
     # The path to the actual data file for the underlying dataset.
     # Only available if the dataset has filepath set.
@@ -957,7 +959,7 @@ class ParametersNodeMetadata(GraphNodeMetadata):
         AssertionError: If parameters_node is not supplied during instantiation
     """
 
-    parameters_node: ParametersNode
+    parameters_node: ParametersNode = Field(..., exclude=True)
     parameters: Optional[Dict] = Field(
         None, description="The parameters dictionary for the parameters metadata node"
     )


### PR DESCRIPTION
## Description

This is a quick fix for the issue with shareable viz due to dataclass refactor

## Development notes

- Exclude Node object from metadata class as it is not json serializable

## QA notes

- Test shareable viz 
- All test cases must pass

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes
