### PR TITLE
Add kedro viz deprecation warning for CLI

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -11,9 +11,10 @@ Please follow the established format:
 ## Bug fixes and other changes
 
 - Fix dataset factory patterns in Experiment Tracking. (#1588)
-- Improved feedback for copy to clipboard feature. (#1614)
+- Improve feedback for copy to clipboard feature. (#1614)
 - Ensure Kedro-Viz works when hosted on a URL subpath. (#1621)
 - Refactor flowchart dataclasses to pydantic base models. (#1565)
+- Add kedro viz CLI command deprecation warning. (#1641)
 
 # Release 6.6.1
 

--- a/docs/source/kedro-viz_visualisation.md
+++ b/docs/source/kedro-viz_visualisation.md
@@ -32,6 +32,11 @@ To start Kedro-Viz, type the following into your terminal from the project direc
 kedro viz
 ```
 
+```{important}
+The `kedro viz` command will be deprecated with the release of Kedro-Viz 7.0.0. 
+`kedro viz run` will be the new way to run the tool.
+```
+
 The command opens a browser tab to serve the visualisation at `http://127.0.0.1:4141/`.
 
 You should see the following:

--- a/package/kedro_viz/launchers/cli.py
+++ b/package/kedro_viz/launchers/cli.py
@@ -122,7 +122,7 @@ def viz(
     click.echo(
         click.style(
             "WARNING: The `kedro viz` command will be deprecated with the release of "
-            "Kedro-Viz 7.0.0. `kedro viz run` will be the new way to run the tool. ",
+            "Kedro-Viz 7.0.0. `kedro viz run` will be the new way to run the tool.",
             fg="yellow",
         ),
     )

--- a/package/kedro_viz/launchers/cli.py
+++ b/package/kedro_viz/launchers/cli.py
@@ -119,6 +119,14 @@ def viz(
             ),
         )
 
+    click.echo(
+        click.style(
+            "WARNING: The `kedro viz` command will be deprecated with the release of "
+            "Kedro-Viz 7.0.0. `kedro viz run` will be the new way to run the tool. ",
+            fg="yellow",
+        ),
+    )
+
     try:
         if port in _VIZ_PROCESSES and _VIZ_PROCESSES[port].is_alive():
             _VIZ_PROCESSES[port].terminate()

--- a/package/tests/test_launchers/test_cli.py
+++ b/package/tests/test_launchers/test_cli.py
@@ -1,3 +1,5 @@
+from unittest.mock import call
+
 import pytest
 import requests
 from click.testing import CliRunner
@@ -134,14 +136,22 @@ def test_kedro_viz_command_should_log_outdated_version(mocker, mock_http_respons
     with runner.isolated_filesystem():
         runner.invoke(cli.commands, ["viz"])
 
-    mock_click_echo.assert_called_once_with(
-        "\x1b[33mWARNING: You are using an old version of Kedro Viz. "
-        f"You are using version {installed_version}; "
-        f"however, version {mock_version} is now available.\n"
-        "You should consider upgrading via the `pip install -U kedro-viz` command.\n"
-        "You can view the complete changelog at "
-        "https://github.com/kedro-org/kedro-viz/releases.\x1b[0m"
-    )
+    mock_click_echo_calls = [
+        call(
+            "\x1b[33mWARNING: You are using an old version of Kedro Viz. "
+            f"You are using version {installed_version}; "
+            f"however, version {mock_version} is now available.\n"
+            "You should consider upgrading via the `pip install -U kedro-viz` command.\n"
+            "You can view the complete changelog at "
+            "https://github.com/kedro-org/kedro-viz/releases.\x1b[0m"
+        ),
+        call(
+            "\x1b[33mWARNING: The `kedro viz` command will be deprecated with the release of "
+            "Kedro-Viz 7.0.0. `kedro viz run` will be the new way to run the tool.\x1b[0m",
+        ),
+    ]
+
+    mock_click_echo.assert_has_calls(mock_click_echo_calls)
 
 
 def test_kedro_viz_command_should_not_log_latest_version(mocker, mock_http_response):
@@ -156,7 +166,14 @@ def test_kedro_viz_command_should_not_log_latest_version(mocker, mock_http_respo
     with runner.isolated_filesystem():
         runner.invoke(cli.commands, ["viz"])
 
-    mock_click_echo.assert_not_called()
+    mock_click_echo_calls = [
+        call(
+            "\x1b[33mWARNING: The `kedro viz` command will be deprecated with the release of "
+            "Kedro-Viz 7.0.0. `kedro viz run` will be the new way to run the tool.\x1b[0m",
+        )
+    ]
+
+    mock_click_echo.assert_has_calls(mock_click_echo_calls)
 
 
 def test_kedro_viz_command_should_not_log_if_pypi_is_down(mocker, mock_http_response):
@@ -169,7 +186,14 @@ def test_kedro_viz_command_should_not_log_if_pypi_is_down(mocker, mock_http_resp
     with runner.isolated_filesystem():
         runner.invoke(cli.commands, ["viz"])
 
-    mock_click_echo.assert_not_called()
+    mock_click_echo_calls = [
+        call(
+            "\x1b[33mWARNING: The `kedro viz` command will be deprecated with the release of "
+            "Kedro-Viz 7.0.0. `kedro viz run` will be the new way to run the tool.\x1b[0m",
+        )
+    ]
+
+    mock_click_echo.assert_has_calls(mock_click_echo_calls)
 
 
 def test_kedro_viz_command_with_autoreload(


### PR DESCRIPTION
## Description

Resolves #1625 

## Development notes

- Added a deprecation warning, when users run `kedro viz`
- Update pytests to reflect new warning message

## QA notes

- Install editable kedro viz by executing `pip install -e package`
- `cd demo-project`
- Run `kedro viz`
- You should see the below warning message -

![image](https://github.com/kedro-org/kedro-viz/assets/87735534/3c07b058-30b6-468a-8aa9-7f0dac13bb80)


## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [x] Added new entries to the `RELEASE.md` file
- [x] Added tests to cover my changes
