### PR TITLE
Fix shareable url click navigation

### DIFF
--- a/src/components/shareable-url-modal/shareable-url-modal.js
+++ b/src/components/shareable-url-modal/shareable-url-modal.js
@@ -250,7 +250,7 @@ const ShareableUrlModal = ({ onToggleModal, visible }) => {
             <div className="shareable-url-modal__url-wrapper">
               <a
                 className="shareable-url-modal__result-url"
-                href="/"
+                href={responseUrl}
                 target="_blank"
                 rel="noopener noreferrer"
               >


### PR DESCRIPTION
## Description

After the shareable link is created, user should be able to either click on the link or copy the link to navigate. The click link navigation was having an issue as it was redirected to "/". This PR fixes the bug.

## Development notes

* Link navigation reverted to responseUrl

## QA notes

* User should be able to click on the shareable url and get navigated to a different window with the destination pointing to AWS S3 hosted link

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes
