### PR TITLE
Fix modular pipelines breaking when collapsed. 

### DIFF
--- a/package/kedro_viz/models/flowchart.py
+++ b/package/kedro_viz/models/flowchart.py
@@ -407,18 +407,13 @@ class ModularPipelineNode(GraphNode):
         Intuitively, the set of inputs for this modular pipeline is the set of all
         external and internal inputs, excluding the ones also serving as outputs.
         """
-        return (self.external_inputs | self.internal_inputs) - (
-            self.external_outputs | self.internal_outputs
-        )
-
+        return self.external_inputs| (self.internal_inputs - self.internal_outputs)     
     @property
     def outputs(self) -> Set[str]:
         """Return a set of inputs for this modular pipeline.
         Follow the same logic as the inputs calculation.
         """
-        return (self.external_outputs | self.internal_outputs) - (
-            self.external_inputs | self.internal_inputs
-        )
+        return self.external_outputs | (self.internal_outputs - self.internal_inputs)
 
 
 class TaskNodeMetadata(GraphNodeMetadata):

--- a/package/kedro_viz/models/flowchart.py
+++ b/package/kedro_viz/models/flowchart.py
@@ -407,7 +407,7 @@ class ModularPipelineNode(GraphNode):
         Intuitively, the set of inputs for this modular pipeline is the set of all
         external and internal inputs, excluding the ones also serving as outputs.
         """
-        return self.external_inputs | (self.internal_inputs - self.internal_outputs)
+        return (self.external_inputs | self.internal_inputs) - self.internal_outputs
 
     @property
     def outputs(self) -> Set[str]:

--- a/package/kedro_viz/models/flowchart.py
+++ b/package/kedro_viz/models/flowchart.py
@@ -407,7 +407,8 @@ class ModularPipelineNode(GraphNode):
         Intuitively, the set of inputs for this modular pipeline is the set of all
         external and internal inputs, excluding the ones also serving as outputs.
         """
-        return self.external_inputs| (self.internal_inputs - self.internal_outputs)     
+        return self.external_inputs | (self.internal_inputs - self.internal_outputs)
+
     @property
     def outputs(self) -> Set[str]:
         """Return a set of inputs for this modular pipeline.

--- a/package/tests/test_api/test_rest/test_responses.py
+++ b/package/tests/test_api/test_rest/test_responses.py
@@ -96,6 +96,7 @@ def assert_example_data(response_data):
         {"source": "uk.data_science", "target": "d5a8b994"},
         {"source": "0ecea0de", "target": "uk.data_science"},
         {"source": "uk", "target": "d5a8b994"},
+        {"source": "uk", "target": "0ecea0de"},
     ]
     assert_dict_list_equal(
         response_data.pop("edges"), expected_edges, sort_keys=("source", "target")
@@ -234,9 +235,9 @@ def assert_example_data(response_data):
                 {"id": "uk.data_processing", "type": "modularPipeline"},
             ],
             "id": "uk",
-            "inputs": ["f0ebef01", "13399a82", "f1f1425b"],
+            "inputs": ["f0ebef01", "13399a82", "f1f1425b", "0ecea0de"],
             "name": "uk",
-            "outputs": ["d5a8b994"],
+            "outputs": ["d5a8b994", "0ecea0de"],
         },
         "uk.data_processing": {
             "children": [


### PR DESCRIPTION
## Description

Resolves #1105 

## Development notes

In modular pipelines, a bug was identified when the pipelines were in collapsed mode. This issue was related to the incorrect handling of datasets due to a flawed logic in defining inputs and outputs. Here's the explanation:

### Inputs of a Modular Pipeline:
- An input can either be an external source or an internal one, provided it's not also used internally as an output.
If an internal input is simultaneously an internal output, it implies it's part of a sub-pipeline within the modular pipeline. Therefore, it should remain hidden in the collapsed view of the modular pipeline and not be displayed as an input.

### Outputs of a Modular Pipeline:
- An output is typically any external dataset used by other pipelines.
- In the Kedro framework, an external output must be explicitly defined as an output of the modular pipeline. It doesn't have a namespace.
- Internal outputs that also function as internal inputs are treated as components of the modular pipeline. These are not visible as outputs in the collapsed view but become visible when the pipeline is expanded.

This improved handling ensures a more accurate representation and functionality of modular pipelines, particularly in their collapsed state.

## QA notes

Tested this solution on below 4 edge cases :- 

1.  ### When a modular pipeline (external) output is used as an input to another pipeline and as an (internal) input to another function of the same modular pipeline. 
```python 
def create_pipeline(**kwargs) -> Pipeline:
    new_pipeline = pipeline(
        [
            node(lambda x: x,
                 inputs="dataset_in",
                 outputs="dataset_1",
                 name="step1"),
            node(lambda x: x,
                 inputs="dataset_1",
                 outputs="dataset_2",
                 name="step2"),
            node(lambda x: x,
                 inputs="dataset_2",
                 outputs="dataset_3",
                 name="step3"),
            node(lambda x: x,
                 inputs="dataset_3",
                 outputs="dataset_out",
                 name="step4"
            )
        ],
            namespace="main_pipeline",
        inputs=None,
        outputs={"dataset_out", "dataset_3"}
    )
    return new_pipeline
```
### Before 
<img width="1085" alt="Screenshot 2023-11-21 at 11 38 09" src="https://github.com/kedro-org/kedro-viz/assets/37628668/58a0dc99-ca95-4abf-8e38-71b3c36dd7fc">

### After 
<img width="927" alt="Screenshot 2023-11-21 at 11 32 48" src="https://github.com/kedro-org/kedro-viz/assets/37628668/01710b70-7bf7-4898-80ba-c58d3bc8ba4c">


2. ### When a nested modular pipeline output is used as an input to the outer modular pipeline and also used as an input to another external modular pipeline 
```python 
def create_pipeline(**kwargs) -> Pipeline:

    sub_pipeline = pipeline(
        [
            node(lambda x: x,
                 inputs="dataset_1",
                 outputs="dataset_2",
                 name="step2"),
            node(lambda x: x,
                 inputs="dataset_2",
                 outputs="dataset_3",
                 name="step3"),
        ],
        inputs={"dataset_1"},
        outputs={"dataset_3"},
        namespace="sub_pipeline"
    )
    new_pipeline = pipeline(
        [
            node(lambda x: x,
                 inputs="dataset_in",
                 outputs="dataset_1",
                 name="step1"),
            sub_pipeline,
            node(lambda x: x,
                 inputs="dataset_1",
                 outputs="dataset_1_2",
                 name="step1_2"),
            node(lambda x: x,
                 inputs="dataset_3",
                 outputs="dataset_4",
                 name="step4"
            )
        ],
            namespace="main_pipeline",
        inputs=None,
        outputs={"dataset_3","dataset_4"}
    )
    return new_pipeline
```

### Before 
<img width="990" alt="Screenshot 2023-11-21 at 11 37 23" src="https://github.com/kedro-org/kedro-viz/assets/37628668/ea027b5b-d11b-45cd-883b-94f5edef6ccf">

### After 
<img width="1386" alt="Screenshot 2023-11-21 at 11 33 46" src="https://github.com/kedro-org/kedro-viz/assets/37628668/e50c4ca4-11f2-4c71-84da-623805850db4">


3. ### When an output of a namespace function (using node namespaces) is an input to another function in the same namespace 

```python 
def create_pipeline(**kwargs) -> Pipeline:
    return pipeline(
        [
            node(
                func=lambda dataset_1, dataset_2: (dataset_1, dataset_2),
                inputs=["dataset_1", "dataset_2"],
                outputs="dataset_3",
                name="first_node",
            ),
            node(
                func=lambda dataset_1, dataset_2: (dataset_1, dataset_2),
                inputs=["dataset_3", "dataset_4"],
                outputs="dataset_5",
                name="second_node",
            ),
            node(
                func=lambda dataset_1, dataset_2: (dataset_1, dataset_2),
                inputs=["dataset_5", "dataset_6"],
                outputs="dataset_7", 
                name="third_node",
                namespace="namespace_prefix_1",
            ),
            node(
                func=lambda dataset_1, dataset_2: (dataset_1, dataset_2),
                inputs=["dataset_7", "dataset_8"],
                outputs="dataset_9",
                name="fourth_node",
                namespace="namespace_prefix_1",
            ),
            node(
                func=lambda dataset_1, dataset_2: (dataset_1, dataset_2),
                inputs=["dataset_9", "dataset_10"],
                outputs="dataset_11",
                name="fifth_node",
                namespace="namespace_prefix_1",
            ),
        ]
    )
```
### Before 
<img width="918" alt="Screenshot 2023-11-21 at 11 28 40" src="https://github.com/kedro-org/kedro-viz/assets/37628668/940e8b62-f992-4d2c-9657-a6fc978e6c1d">

### After 
<img width="1037" alt="Screenshot 2023-11-21 at 11 29 59" src="https://github.com/kedro-org/kedro-viz/assets/37628668/2312e35d-8c6e-4df0-a080-18d84ddaea9d">



4. ### When an output of a nested modular pipeline is an input to another nested modular pipeline 
```python 
def create_pipeline(**kwargs) -> Pipeline:
    data_processing_pipeline = pipeline(
        [
            node(
                lambda x: x,
                inputs=["raw_data"],
                outputs="model_inputs",
                name="process_data",
                tags=["split"],
            )
        ],
        namespace="uk.data_processing",
        outputs="model_inputs",
    )
    data_science_pipeline = pipeline(
        [
            node(
                lambda x: x,
                inputs=["model_inputs"],
                outputs="model",
                name="train_model",
                tags=["train"],
            )
        ],
        namespace="uk.data_science",
        inputs="model_inputs",
    )
    return data_processing_pipeline + data_science_pipeline
```
### Before
<img width="1235" alt="Screenshot 2023-11-21 at 11 36 14" src="https://github.com/kedro-org/kedro-viz/assets/37628668/75d9740a-5df2-4235-8167-3557e232ad45">

### After 
<img width="1254" alt="Screenshot 2023-11-21 at 11 35 23" src="https://github.com/kedro-org/kedro-viz/assets/37628668/7ffd5b21-f1b8-436d-bed9-8e0b740a709c">



## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes
