### PR TITLE
Fix Kedro-viz embedded as an IFrame

### DIFF
--- a/demo-project/Dockerfile
+++ b/demo-project/Dockerfile
@@ -8,3 +8,5 @@ COPY . /code
 RUN pip install --no-cache-dir --upgrade -r /code/src/docker_requirements.txt
 
 CMD ["kedro", "viz", "--host", "0.0.0.0", "--port", "4141", "--no-browser"]
+
+ENV ADD_SECURITY_HEADERS=true

--- a/package/kedro_viz/api/apps.py
+++ b/package/kedro_viz/api/apps.py
@@ -1,8 +1,8 @@
 """`kedro_viz.api.app` defines the FastAPI app to serve Kedro data in a RESTful API.
 This data could either come from a real Kedro project or a file.
 """
-import os
 import json
+import os
 import time
 from pathlib import Path
 
@@ -22,6 +22,7 @@ from .rest.router import router as rest_router
 
 _HTML_DIR = Path(__file__).parent.parent.absolute() / "html"
 
+
 def _create_etag() -> str:
     """Generate the current timestamp to use as etag."""
     return str(time.time())
@@ -35,8 +36,9 @@ def _create_base_api_app() -> FastAPI:
         default_response_class=EnhancedORJSONResponse,
     )
 
-    if os.getenv('ADD_SECURITY_HEADERS', '').lower() == 'true':
+    if os.getenv("ADD_SECURITY_HEADERS", "").lower() == "true":
         secure_headers = secure.Secure()
+
         @app.middleware("http")
         async def set_secure_headers(request, call_next):
             response = await call_next(request)

--- a/package/kedro_viz/api/apps.py
+++ b/package/kedro_viz/api/apps.py
@@ -36,7 +36,7 @@ def _create_base_api_app() -> FastAPI:
         default_response_class=EnhancedORJSONResponse,
     )
 
-    if os.getenv("ADD_SECURITY_HEADERS", "").lower() == "true":
+    if os.getenv("ADD_SECURITY_HEADERS", "").lower() == "true": # pragma: no cover
         secure_headers = secure.Secure()
 
         @app.middleware("http")

--- a/package/kedro_viz/api/apps.py
+++ b/package/kedro_viz/api/apps.py
@@ -36,7 +36,7 @@ def _create_base_api_app() -> FastAPI:
         default_response_class=EnhancedORJSONResponse,
     )
 
-    if os.getenv("ADD_SECURITY_HEADERS", "").lower() == "true": # pragma: no cover
+    if os.getenv("ADD_SECURITY_HEADERS", "").lower() == "true":  # pragma: no cover
         secure_headers = secure.Secure()
 
         @app.middleware("http")


### PR DESCRIPTION
## Description

In response to issue #1348, which required the addition of security headers to demo.kedro.org, we implemented a solution in PR #1355. This solution involved adding security headers to the FastAPI application which results in all instances of kedro-viz, whether hosted or local, having these security headers. Having the security headers introduced a limitation where kedro-viz could not be used as an IFrame, affecting functionalities like %run_viz that embed kedro-viz in an iframe.

To address this, the current ticket introduces a conditional approach. We will add security headers only if the environment variable ADD_SECURITY_HEADER is set to true. This modification will be implemented in the Dockerfile when creating the docker image for the demo project. This image will then be uploaded to an EC2 instance and deployed using Lightsail.

<!-- What have you changed? Consider adding a screenshot or GIF. -->

## QA notes

I've conducted local tests and confirmed that security headers are no longer being added. Additionally, I tested this by creating a Docker image of the demo-project. In this scenario, the security headers are present and functioning as expected. 



## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes
