### PR TITLE
Drop Kedro 17 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -174,6 +174,9 @@ Finally, you can use pseudo-random data, which is procedurally-generated on page
 
 > **Note**: Kedro-Viz>=3.8.0 will not work with projects created with Kedro<=0.16.6. Please consider migrating your project to Kedro>=0.17.0 before you develop against the latest version of Kedro-Viz.
 
+> **Note**: Kedro-Viz>=7.0.0 will not work with projects created with Kedro<=0.17.0. Please consider migrating your project to Kedro>=0.18.0 before you develop against the latest version of Kedro-Viz.
+
+
 Before launching a development server with a real Kedro project, you'd need to have [Python](https://www.python.org/)(>=3.8) installed. We strongly recommend setting up [conda](https://docs.conda.io/en/latest/) to manage your Python versions and virtual environments. You can visit Kedro's [guide to installing conda](https://docs.kedro.org/en/latest/get_started/install.html#create-a-virtual-environment-for-your-kedro-project) for more information.
 
 The Kedro-Viz repository comes with an example project in the `demo-project` folder. This is used on the [public demo](https://demo.kedro.org/). To use it in your development environment, you need to install both the Kedro-Viz dependencies and a minimal set of dependencies for the demo project:

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@quantumblack/kedro-viz",
-      "version": "6.6.1",
+      "version": "6.7.0",
       "dependencies": {
         "@apollo/client": "^3.5.6",
         "@emotion/react": "^11.10.6",

--- a/package/features/steps/cli_steps.py
+++ b/package/features/steps/cli_steps.py
@@ -143,11 +143,6 @@ def check_kedroviz_up(context):
     try:
         assert context.result.poll() is None
         assert (
-            # for Kedro 0.17.5
-            "example_iris_data"
-            == sorted(data_json["nodes"], key=lambda i: i["name"])[0]["name"]
-        ) or (
-            # for Kedro 0.18.0 onwards
             "X_test"
             == sorted(data_json["nodes"], key=lambda i: i["name"])[0]["name"]
         )

--- a/package/features/steps/cli_steps.py
+++ b/package/features/steps/cli_steps.py
@@ -143,8 +143,7 @@ def check_kedroviz_up(context):
     try:
         assert context.result.poll() is None
         assert (
-            "X_test"
-            == sorted(data_json["nodes"], key=lambda i: i["name"])[0]["name"]
+            "X_test" == sorted(data_json["nodes"], key=lambda i: i["name"])[0]["name"]
         )
     finally:
         context.result.terminate()

--- a/package/kedro_viz/integrations/kedro/data_loader.py
+++ b/package/kedro_viz/integrations/kedro/data_loader.py
@@ -33,7 +33,6 @@ except ImportError:  # kedro_datasets is not installed.
 from kedro.io import DataCatalog
 from kedro.io.core import get_filepath_str
 from kedro.pipeline import Pipeline
-from packaging.version import parse
 
 from kedro_viz.constants import KEDRO_VERSION
 
@@ -64,20 +63,11 @@ def _bootstrap(project_path: Path):
     """Bootstrap the integration by running various Kedro bootstrapping methods
     depending on the version
     """
-    if KEDRO_VERSION >= parse("0.17.3"):
-        from kedro.framework.startup import bootstrap_project
+    from kedro.framework.startup import bootstrap_project
 
-        bootstrap_project(project_path)
-        return
+    bootstrap_project(project_path)
+    return
 
-    if KEDRO_VERSION >= parse("0.17.1"):
-        from kedro.framework.project import configure_project
-        from kedro.framework.startup import _get_project_metadata
-
-        package_name = _get_project_metadata(project_path).package_name
-
-        configure_project(package_name)
-        return
 
 
 def _get_dataset_stats(project_path: Path) -> Dict:
@@ -128,67 +118,30 @@ def load_data(
     """
     _bootstrap(project_path)
 
-    if KEDRO_VERSION >= parse("0.17.3"):
-        from kedro.framework.project import pipelines
+    from kedro.framework.project import pipelines
 
-        with KedroSession.create(
-            project_path=project_path,
-            env=env,  # type: ignore
-            save_on_close=False,
-            extra_params=extra_params,  # type: ignore
-        ) as session:
-            # check for --ignore-plugins option
-            if ignore_plugins:
-                session._hook_manager = _VizNullPluginManager()
+    with KedroSession.create(
+        project_path=project_path,
+        env=env,  # type: ignore
+        save_on_close=False,
+        extra_params=extra_params,  # type: ignore
+    ) as session:
+        # check for --ignore-plugins option
+        if ignore_plugins:
+            session._hook_manager = _VizNullPluginManager()
 
-            context = session.load_context()
-            session_store = session._store
-            catalog = context.catalog
+        context = session.load_context()
+        session_store = session._store
+        catalog = context.catalog
 
-            # Pipelines is a lazy dict-like object, so we force it to populate here
-            # in case user doesn't have an active session down the line when it's first accessed.
-            # Useful for users who have `get_current_session` in their `register_pipelines()`.
-            pipelines_dict = dict(pipelines)
-            stats_dict = _get_dataset_stats(project_path)
+        # Pipelines is a lazy dict-like object, so we force it to populate here
+        # in case user doesn't have an active session down the line when it's first accessed.
+        # Useful for users who have `get_current_session` in their `register_pipelines()`.
+        pipelines_dict = dict(pipelines)
+        stats_dict = _get_dataset_stats(project_path)
 
-        return catalog, pipelines_dict, session_store, stats_dict
-    elif KEDRO_VERSION >= parse("0.17.1"):
-        with KedroSession.create(
-            project_path=project_path,
-            env=env,  # type: ignore
-            save_on_close=False,
-            extra_params=extra_params,  # type: ignore
-        ) as session:
-            # check for --ignore-plugins option
-            if ignore_plugins:
-                session._hook_manager = _VizNullPluginManager()
+    return catalog, pipelines_dict, session_store, stats_dict
 
-            context = session.load_context()
-            session_store = session._store
-            stats_dict = _get_dataset_stats(project_path)
-
-        return context.catalog, context.pipelines, session_store, stats_dict
-    else:
-        # Since Viz is only compatible with kedro>=0.17.0, this just matches 0.17.0
-        from kedro.framework.startup import _get_project_metadata
-
-        metadata = _get_project_metadata(project_path)
-        with KedroSession.create(
-            package_name=metadata.package_name,
-            project_path=project_path,
-            env=env,  # type: ignore
-            save_on_close=False,
-            extra_params=extra_params,  # type: ignore
-        ) as session:
-            # check for --ignore-plugins option
-            if ignore_plugins:
-                session._hook_manager = _VizNullPluginManager()
-
-            context = session.load_context()
-            session_store = session._store
-            stats_dict = _get_dataset_stats(project_path)
-
-        return context.catalog, context.pipelines, session_store, stats_dict
 
 
 # Try to access the attribute to trigger the import of dependencies, only modify the _load

--- a/package/kedro_viz/integrations/kedro/data_loader.py
+++ b/package/kedro_viz/integrations/kedro/data_loader.py
@@ -3,7 +3,7 @@ load data from a Kedro project. It takes care of making sure viz can
 load data from projects created in a range of Kedro versions.
 """
 # pylint: disable=import-outside-toplevel, protected-access
-# pylint: disable=missing-function-docstring, no-else-return
+# pylint: disable=missing-function-docstring
 
 import base64
 import json
@@ -33,8 +33,6 @@ except ImportError:  # kedro_datasets is not installed.
 from kedro.io import DataCatalog
 from kedro.io.core import get_filepath_str
 from kedro.pipeline import Pipeline
-
-from kedro_viz.constants import KEDRO_VERSION
 
 logger = logging.getLogger(__name__)
 
@@ -66,8 +64,6 @@ def _bootstrap(project_path: Path):
     from kedro.framework.startup import bootstrap_project
 
     bootstrap_project(project_path)
-    return
-
 
 
 def _get_dataset_stats(project_path: Path) -> Dict:
@@ -141,7 +137,6 @@ def load_data(
         stats_dict = _get_dataset_stats(project_path)
 
     return catalog, pipelines_dict, session_store, stats_dict
-
 
 
 # Try to access the attribute to trigger the import of dependencies, only modify the _load

--- a/package/requirements.txt
+++ b/package/requirements.txt
@@ -1,5 +1,5 @@
 packaging~=23.0
-kedro>=0.17.5
+kedro>=0.18.0
 ipython>=7.0.0, <9.0
 fastapi>=0.73.0,<0.200.0
 pydantic<2

--- a/package/test_requirements.txt
+++ b/package/test_requirements.txt
@@ -1,6 +1,6 @@
 -r requirements.txt
 
-kedro >=0.17.0
+kedro >=0.18.0
 kedro-datasets[pandas.ParquetDataset, pandas.CSVDataset, pandas.ExcelDataset, plotly.JSONDataset]~=1.7
 kedro-telemetry>=0.1.1  # for testing telemetry integration
 bandit~=1.7


### PR DESCRIPTION
## Description

Kedro-viz should always support last 2 versions of Kedro. Given that Kedro 19 is releasing soon, we can stop supporting Kedro 17 from Kedro-viz 7.0.0 and only support Kedro>18 

## Development notes

<!-- What have you changed? Consider adding a screenshot or GIF. -->

## QA notes

<!-- How has the expected behaviour changed? What testing strategies have you used? -->

## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes
