### PR TITLE
Change 'Kedro Viz' to 'Kedro Viz Run'

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ For **Python 3.6** users, the last supported version of Kedro-Viz is **3.16.0**
 To launch Kedro-Viz from the command line as a Kedro plugin, use the following command from the root folder of your Kedro project:
 
 ```bash
-kedro viz
+kedro viz run
 ```
 
 A browser tab opens automatically to serve the visualisation at `http://127.0.0.1:4141/`.
@@ -183,7 +183,7 @@ const MyApp = () => <NoSSRKedro data={json} />;
 The JSON can be obtained by running:
 
 ```bash
-kedro viz --save-file=filename.json
+kedro viz run --save-file=filename.json
 ```
 
 We also recommend wrapping the `Kedro-Viz` component with a parent HTML/JSX element that has a specified height (as seen in the above example) in order for Kedro-Viz to be styled properly.

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ A browser tab opens automatically to serve the visualisation at `http://127.0.0.
 Kedro-Viz also supports the following additional arguments on the command line:
 
 ```bash
-Usage: kedro viz [OPTIONS]
+Usage: kedro viz run [OPTIONS]
 
   Visualise a Kedro pipeline using Kedro-Viz.
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -16,7 +16,6 @@ Please follow the established format:
 - Fix for dataset existence check in factory pattern discovery (#1659)
 - Remove support for Python 3.7 (#1660)
 - Adjust CLI to use 'kedro viz run' instead of 'kedro viz' (#1671)
-- Add 'viz' as new CLI command group (#1671)
 
 # Release 6.7.0 
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -15,7 +15,7 @@ Please follow the established format:
 
 - Fix for dataset existence check in factory pattern discovery (#1659)
 - Remove support for Python 3.7 (#1660)
-- Adjust CLI to use 'kedro viz run' instead of 'kedro run' (#1671)
+- Adjust CLI to use 'kedro viz run' instead of 'kedro viz' (#1671)
 - Add 'viz' as new CLI command group (#1671)
 
 # Release 6.7.0 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -15,6 +15,8 @@ Please follow the established format:
 
 - Fix for dataset existence check in factory pattern discovery (#1659)
 - Remove support for Python 3.7 (#1660)
+- Adjust CLI to use 'kedro viz run' instead of 'kedro run' (#1671)
+- Add 'viz' as new CLI command group (#1671)
 
 # Release 6.7.0 
 

--- a/demo-project/README.md
+++ b/demo-project/README.md
@@ -7,4 +7,4 @@ This project is designed to be a realistic example of what Kedro looks like when
 1. Run `pip install kedro~=0.18.0`
 2. Run `pip install -r src/demo_project/requirements.in`
 3. Run `kedro run`
-4. Run `kedro viz`
+4. Run `kedro viz run`

--- a/docs/source/experiment_tracking.md
+++ b/docs/source/experiment_tracking.md
@@ -323,7 +323,7 @@ confusion_matrix:
   versioned: true
 ```
 
-After running the pipeline with `kedro run`, the plot is saved and you can see it in the experiment tracking panel when you execute `kedro viz`. Clicking on a plot expands it. When in comparison view, expanding a plot shows all the plots in that view for side-by-side comparison.
+After running the pipeline with `kedro run`, the plot is saved and you can see it in the experiment tracking panel when you execute `kedro viz run`. Clicking on a plot expands it. When in comparison view, expanding a plot shows all the plots in that view for side-by-side comparison.
 
 ![](./images/experiment-tracking-plots-comparison.png)
 

--- a/docs/source/experiment_tracking.md
+++ b/docs/source/experiment_tracking.md
@@ -247,7 +247,7 @@ Execute `kedro run` a few times in a row to generate a larger set of experiment 
 Here comes the fun part of accessing your run data on Kedro-Viz. Having generated some run data, execute the following command:
 
 ```bash
-kedro viz
+kedro viz run
 ```
 
 When you open the Kedro-Viz web app, you see an experiment tracking icon on the left-hand side of the screen.

--- a/docs/source/kedro-viz_visualisation.md
+++ b/docs/source/kedro-viz_visualisation.md
@@ -33,12 +33,12 @@ kedro run
 To start Kedro-Viz, type the following into your terminal from the project directory:
 
 ```bash
-kedro viz
+kedro viz run
 ```
 
 ```{important}
-The `kedro viz` command will be deprecated with the release of Kedro-Viz 7.0.0. 
-`kedro viz run` will be the new way to run the tool.
+The former `kedro viz` command used here is now deprecated with the release of Kedro-Viz 7.0.0. 
+`kedro viz run` is now the new way to run the tool.
 ```
 
 The command opens a browser tab to serve the visualisation at `http://127.0.0.1:4141/`.
@@ -59,7 +59,7 @@ To exit the visualisation, close the browser tab. To regain control of the termi
 You can use the `--autoreload` flag to autoreload Kedro-Viz when a `Python` or `YAML` file changes in the project. Add the flag to the command you use to start Kedro-Viz:
 
 ```bash
-kedro viz --autoreload
+kedro viz run --autoreload
 ```
 
 ![](./images/kedro_viz_autoreload.gif)
@@ -162,7 +162,7 @@ The visualisation now includes the layers:
 You can share a pipeline structure within a Kedro-Viz visualisation as a JSON file from the terminal:
 
 ```bash
-kedro viz --save-file=my_shareable_pipeline.json
+kedro viz run --save-file=my_shareable_pipeline.json
 ```
 
 This command will save a visualisation of the `__default__` pipeline as a JSON file called `my_shareable_pipeline.json`. It doesn't share data, such as that in the code panel, nor can you share images or charts.
@@ -170,7 +170,7 @@ This command will save a visualisation of the `__default__` pipeline as a JSON f
 To visualise the shared file, type the following to load it from the terminal:
 
 ```bash
-kedro viz --load-file=my_shareable_pipeline.json
+kedro viz run --load-file=my_shareable_pipeline.json
 ```
 
 You can also share a complete project visualisation, described in more detail on [the following page](./share_kedro_viz). 

--- a/docs/source/preview_datasets.md
+++ b/docs/source/preview_datasets.md
@@ -67,7 +67,7 @@ shuttles:
 After you've configured the Data Catalog, you can preview the datasets on Kedro-Viz. Start Kedro-Viz by running the following command in your terminal:
 
 ```bash
-kedro viz
+kedro viz run
 ```
 
 The previews are shown as follows:

--- a/docs/source/share_kedro_viz.md
+++ b/docs/source/share_kedro_viz.md
@@ -81,7 +81,7 @@ For more information, see the official AWS documentation about [how to work with
 You're now ready to publish and share your Kedro-Viz project. Start Kedro-Viz by running the following command in your terminal:
 
 ```bash
-kedro viz
+kedro viz run
 ```
 
 Click the **Publish and share** icon in the lower-left of the application. You will see a modal dialog to select your relevant AWS Bucket Region and enter your Bucket Name.

--- a/docs/source/visualise_charts_with_matplotlib.md
+++ b/docs/source/visualise_charts_with_matplotlib.md
@@ -93,7 +93,7 @@ def create_pipeline(**kwargs) -> Pipeline:
 
 ## Run the pipeline
 
-Run the pipelines with `kedro run` and then visualise the result with `kedro viz`.
+Run the pipelines with `kedro run` and then visualise the result with `kedro viz run`.
 
 Click to see a small preview of the Matplotlib image in the metadata panel.
 

--- a/docs/source/visualise_charts_with_plotly.md
+++ b/docs/source/visualise_charts_with_plotly.md
@@ -151,7 +151,7 @@ Now run the pipelines:
 kedro run
 ```
 
-Then visualise with `kedro viz`
+Then visualise with `kedro viz run`
 
 The generated charts are shown as follows:
 

--- a/package/features/steps/cli_steps.py
+++ b/package/features/steps/cli_steps.py
@@ -119,7 +119,7 @@ def install_kedro(context, version):
 def exec_viz_command(context):
     """Execute Kedro-Viz command."""
     context.result = ChildTerminatingPopen(
-        [context.kedro, "viz", "--no-browser"],
+        [context.kedro, "viz", "run", "--no-browser"],
         env=context.env,
         cwd=str(context.root_project_dir),
     )

--- a/package/kedro_viz/launchers/cli.py
+++ b/package/kedro_viz/launchers/cli.py
@@ -19,12 +19,25 @@ from kedro_viz.launchers.utils import _check_viz_up, _start_browser, _wait_for
 _VIZ_PROCESSES: Dict[str, int] = {}
 
 
+class VizCommandGroup(click.Group):
+    """A custom class for ordering the `kedro viz` command groups"""
+
+    def list_commands(self, ctx):
+        """List commands according to a custom order"""
+        return ["run", "deploy"]
+
+
 @click.group(name="Kedro-Viz")
-def commands():  # pylint: disable=missing-function-docstring
+def viz_cli():  # pylint: disable=missing-function-docstring
     pass
 
 
-@commands.command(context_settings={"help_option_names": ["-h", "--help"]})
+@viz_cli.group(cls=VizCommandGroup)
+def viz():
+    """Visualise a Kedro pipeline using Kedro viz."""
+
+
+@viz.command(context_settings={"help_option_names": ["-h", "--help"]})
 @click.option(
     "--host",
     default=DEFAULT_HOST,
@@ -89,7 +102,7 @@ def commands():  # pylint: disable=missing-function-docstring
     callback=_split_params,
 )
 # pylint: disable=import-outside-toplevel, too-many-locals
-def viz(
+def run(
     host,
     port,
     browser,
@@ -101,7 +114,7 @@ def viz(
     ignore_plugins,
     params,
 ):
-    """Visualise a Kedro pipeline using Kedro viz."""
+    """Opens a visualizer of your Kedro project using Kedro Viz"""
     from kedro_viz.server import run_server
 
     installed_version = parse(__version__)

--- a/package/kedro_viz/launchers/cli.py
+++ b/package/kedro_viz/launchers/cli.py
@@ -39,7 +39,7 @@ def viz(ctx):
     if ctx.invoked_subcommand is None:
         click.echo(
             click.style(
-                "\nDid you mean this ? \n" "  kedro viz run \n\n",
+                "\nDid you mean this ? \n kedro viz run \n\n",
                 fg="yellow",
             )
         )

--- a/package/kedro_viz/launchers/cli.py
+++ b/package/kedro_viz/launchers/cli.py
@@ -19,20 +19,12 @@ from kedro_viz.launchers.utils import _check_viz_up, _start_browser, _wait_for
 _VIZ_PROCESSES: Dict[str, int] = {}
 
 
-class VizCommandGroup(click.Group):
-    """A custom class for ordering the `kedro viz` command groups"""
-
-    def list_commands(self, ctx):
-        """List commands according to a custom order"""
-        return ["run"]
-
-
 @click.group(name="Kedro-Viz")
 def viz_cli():  # pylint: disable=missing-function-docstring
     pass
 
 
-@viz_cli.group(cls=VizCommandGroup, invoke_without_command=True)
+@viz_cli.group(invoke_without_command=True)
 @click.pass_context
 def viz(ctx):
     """Visualise a Kedro pipeline using Kedro viz."""

--- a/package/kedro_viz/launchers/cli.py
+++ b/package/kedro_viz/launchers/cli.py
@@ -24,7 +24,7 @@ class VizCommandGroup(click.Group):
 
     def list_commands(self, ctx):
         """List commands according to a custom order"""
-        return ["run", "deploy"]
+        return ["run"]
 
 
 @click.group(name="Kedro-Viz")

--- a/package/kedro_viz/launchers/cli.py
+++ b/package/kedro_viz/launchers/cli.py
@@ -32,9 +32,18 @@ def viz_cli():  # pylint: disable=missing-function-docstring
     pass
 
 
-@viz_cli.group(cls=VizCommandGroup)
-def viz():
+@viz_cli.group(cls=VizCommandGroup, invoke_without_command=True)
+@click.pass_context
+def viz(ctx):
     """Visualise a Kedro pipeline using Kedro viz."""
+    if ctx.invoked_subcommand is None:
+        click.echo(
+            click.style(
+                "\nDid you mean this ? \n" "  kedro viz run \n\n",
+                fg="yellow",
+            )
+        )
+        click.echo(click.style(f"{ctx.get_help()}"))
 
 
 @viz.command(context_settings={"help_option_names": ["-h", "--help"]})
@@ -114,7 +123,7 @@ def run(
     ignore_plugins,
     params,
 ):
-    """Opens a visualizer of your Kedro project using Kedro Viz"""
+    """Launch local Kedro Viz instance"""
     from kedro_viz.server import run_server
 
     installed_version = parse(__version__)
@@ -131,14 +140,6 @@ def run(
                 fg="yellow",
             ),
         )
-
-    click.echo(
-        click.style(
-            "WARNING: The `kedro viz` command will be deprecated with the release of "
-            "Kedro-Viz 7.0.0. `kedro viz run` will be the new way to run the tool.",
-            fg="yellow",
-        ),
-    )
 
     try:
         if port in _VIZ_PROCESSES and _VIZ_PROCESSES[port].is_alive():

--- a/package/setup.py
+++ b/package/setup.py
@@ -44,7 +44,7 @@ setup(
     package_data={"kedro_viz": list(files)},
     zip_safe=False,
     entry_points={
-        "kedro.global_commands": ["kedro-viz = kedro_viz.launchers.cli:commands"],
+        "kedro.global_commands": ["kedro-viz = kedro_viz.launchers.cli:viz_cli"],
         "kedro.line_magic": ["line_magic = kedro_viz.launchers.jupyter:run_viz"],
         "kedro.hooks": [
             "kedro-dataset-stats = kedro_viz.integrations.kedro.hooks:dataset_stats_hook"


### PR DESCRIPTION
## Description
Resolves [1616](https://github.com/orgs/kedro-org/projects/1/views/4?pane=issue&itemId=43121094) - changes 'kedro viz' to 'kedro viz run', making 'viz' into a command group

## Development notes
Adjusts the cli.py files within the package folder, instructing to use 'viz run' going forward and making 'viz' into the new command group

## QA notes

Can be tested normally via `npm test`, the e2e tests, and directly using the command group in the CLI