### PR TITLE
Fix Metadata timestamp for Shareable Viz

### DIFF
--- a/src/components/flowchart-wrapper/flowchart-wrapper.js
+++ b/src/components/flowchart-wrapper/flowchart-wrapper.js
@@ -21,6 +21,7 @@ import PipelineWarning from '../pipeline-warning';
 import LoadingIcon from '../icons/loading';
 import MetaData from '../metadata';
 import MetadataModal from '../metadata-modal';
+import ShareableUrlMetadata from '../shareable-url-modal/shareable-url-metadata';
 import Sidebar from '../sidebar';
 import Button from '../ui/button';
 import CircleProgressBar from '../ui/circle-progress-bar';
@@ -33,7 +34,7 @@ import {
 } from '../../config';
 import { findMatchedPath } from '../../utils/match-path';
 import { getKeyByValue } from '../../utils/get-key-by-value';
-
+import { isRunningLocally } from '../../utils';
 import './flowchart-wrapper.scss';
 
 /**
@@ -294,6 +295,7 @@ export const FlowChartWrapper = ({
           >
             <LoadingIcon visible={loading} />
           </div>
+          {isRunningLocally() ? null : <ShareableUrlMetadata />}
         </div>
         <ExportModal />
         <MetadataModal />

--- a/src/components/wrapper/wrapper.js
+++ b/src/components/wrapper/wrapper.js
@@ -15,7 +15,6 @@ import ExperimentWrapper from '../experiment-wrapper';
 import SettingsModal from '../settings-modal';
 import UpdateReminder from '../update-reminder';
 import ShareableUrlModal from '../shareable-url-modal';
-import ShareableUrlMetadata from '../shareable-url-modal/shareable-url-metadata';
 
 import './wrapper.scss';
 
@@ -53,7 +52,6 @@ export const Wrapper = ({ displayGlobalToolbar, theme }) => {
               isOutdated={isOutdated}
               latestVersion={latestVersion}
             />
-            {isRunningLocally() ? null : <ShareableUrlMetadata />}
             {isRunningLocally() ? <ShareableUrlModal /> : null}
             {versionData && (
               <UpdateReminder


### PR DESCRIPTION
## Description

Fix for timestamp not appearing in shareable viz

## Development notes

* Moved the shareable url metadata inside kedro pipeline div to make it visible

## QA notes

* Deploy Kedro Viz and you should see the version and deployed timestamp on the screen
<img width="1559" alt="image" src="https://github.com/kedro-org/kedro-viz/assets/87735534/cde3a88b-236f-4255-a510-bba176adc3f6">

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes
