### PR TITLE
Remove dataset factory discovery

### DIFF
--- a/package/kedro_viz/data_access/managers.py
+++ b/package/kedro_viz/data_access/managers.py
@@ -69,40 +69,17 @@ class DataAccessManager:
         """Set db session on repositories that need it."""
         self.runs.set_db_session(db_session_class)
 
-    def resolve_dataset_factory_patterns(
-        self, catalog: DataCatalog, pipelines: Dict[str, KedroPipeline]
-    ):
-        """Resolve dataset factory patterns in data catalog by matching
-        them against the datasets in the pipelines.
-        """
-        for pipeline in pipelines.values():
-            if hasattr(pipeline, "data_sets"):
-                # Support for Kedro 0.18.x
-                datasets = pipeline.data_sets()
-            else:
-                datasets = pipeline.datasets()
-
-            for dataset_name in datasets:
-                try:
-                    catalog.exists(dataset_name)
-                # pylint: disable=broad-except
-                except Exception as exc:  # pragma: no cover
-                    logger.warning(
-                        "'%s' does not exist. Full exception: %s: %s",
-                        dataset_name,
-                        type(exc).__name__,
-                        exc,
-                    )
-
-    def add_catalog(self, catalog: DataCatalog, pipelines: Dict[str, KedroPipeline]):
+    def add_catalog(self, catalog: DataCatalog):
         """Resolve dataset factory patterns, add the catalog to the CatalogRepository
         and relevant tracking datasets to TrackingDatasetRepository.
 
         Args:
             catalog: The DataCatalog instance to add.
-            pipelines: A dictionary which holds project pipelines
         """
-        self.resolve_dataset_factory_patterns(catalog, pipelines)
+
+        # TODO: Implement dataset factory pattern discovery for
+        # experiment tracking datasets.
+
         self.catalog.set_catalog(catalog)
 
         for dataset_name, dataset in self.catalog.as_dict().items():

--- a/package/kedro_viz/server.py
+++ b/package/kedro_viz/server.py
@@ -38,7 +38,7 @@ def populate_data(
         session_class = make_db_session_factory(session_store.location)
         data_access_manager.set_db_session(session_class)
 
-    data_access_manager.add_catalog(catalog, pipelines)
+    data_access_manager.add_catalog(catalog)
 
     # add dataset stats before adding pipelines as the data nodes
     # need stats information and they are created during add_pipelines

--- a/package/tests/test_api/test_graphql/test_queries.py
+++ b/package/tests/test_api/test_graphql/test_queries.py
@@ -68,11 +68,8 @@ class TestQueryWithRuns:
         client,
         example_tracking_catalog,
         data_access_manager_with_runs,
-        example_pipelines,
     ):
-        data_access_manager_with_runs.add_catalog(
-            example_tracking_catalog, example_pipelines
-        )
+        data_access_manager_with_runs.add_catalog(example_tracking_catalog)
         example_run_id = example_run_ids[0]
 
         response = client.post(
@@ -173,15 +170,9 @@ class TestQueryWithRuns:
         assert response.json() == expected_response
 
     def test_metrics_data(
-        self,
-        client,
-        example_tracking_catalog,
-        data_access_manager_with_runs,
-        example_pipelines,
+        self, client, example_tracking_catalog, data_access_manager_with_runs
     ):
-        data_access_manager_with_runs.add_catalog(
-            example_tracking_catalog, example_pipelines
-        )
+        data_access_manager_with_runs.add_catalog(example_tracking_catalog)
 
         response = client.post(
             "/graphql",
@@ -295,11 +286,8 @@ class TestQueryWithRuns:
         data_access_manager_with_runs,
         show_diff,
         expected_response,
-        example_pipelines,
     ):
-        data_access_manager_with_runs.add_catalog(
-            example_multiple_run_tracking_catalog, example_pipelines
-        )
+        data_access_manager_with_runs.add_catalog(example_multiple_run_tracking_catalog)
 
         response = client.post(
             "/graphql",
@@ -355,11 +343,9 @@ class TestQueryWithRuns:
         data_access_manager_with_runs,
         show_diff,
         expected_response,
-        example_pipelines,
     ):
         data_access_manager_with_runs.add_catalog(
-            example_multiple_run_tracking_catalog_at_least_one_empty_run,
-            example_pipelines,
+            example_multiple_run_tracking_catalog_at_least_one_empty_run
         )
 
         response = client.post(
@@ -393,10 +379,9 @@ class TestQueryWithRuns:
         data_access_manager_with_runs,
         show_diff,
         expected_response,
-        example_pipelines,
     ):
         data_access_manager_with_runs.add_catalog(
-            example_multiple_run_tracking_catalog_all_empty_runs, example_pipelines
+            example_multiple_run_tracking_catalog_all_empty_runs
         )
 
         response = client.post(

--- a/package/tests/test_data_access/test_managers.py
+++ b/package/tests/test_data_access/test_managers.py
@@ -9,7 +9,6 @@ from kedro_datasets.pandas import CSVDataset
 
 from kedro_viz.constants import DEFAULT_REGISTERED_PIPELINE_ID, ROOT_MODULAR_PIPELINE_ID
 from kedro_viz.data_access.managers import DataAccessManager
-from kedro_viz.data_access.repositories.catalog import CatalogRepository
 from kedro_viz.models.flowchart import (
     DataNode,
     GraphEdge,
@@ -25,14 +24,10 @@ def identity(x):
 
 
 class TestAddCatalog:
-    def test_add_catalog(
-        self,
-        data_access_manager: DataAccessManager,
-        example_pipelines: Dict[str, Pipeline],
-    ):
+    def test_add_catalog(self, data_access_manager: DataAccessManager):
         dataset = CSVDataset(filepath="dataset.csv")
         catalog = DataCatalog(datasets={"dataset": dataset})
-        data_access_manager.add_catalog(catalog, example_pipelines)
+        data_access_manager.add_catalog(catalog)
         assert data_access_manager.catalog.get_catalog() is catalog
 
 
@@ -70,11 +65,7 @@ class TestAddNode:
             "uk.data_science.modular_pipeline",
         ]
 
-    def test_add_node_input(
-        self,
-        data_access_manager: DataAccessManager,
-        example_pipelines: Dict[str, Pipeline],
-    ):
+    def test_add_node_input(self, data_access_manager: DataAccessManager):
         dataset = CSVDataset(filepath="dataset.csv")
         dataset_name = "x"
         registered_pipeline_id = "my_pipeline"
@@ -89,7 +80,7 @@ class TestAddNode:
         catalog = DataCatalog(
             datasets={dataset_name: dataset},
         )
-        data_access_manager.add_catalog(catalog, example_pipelines)
+        data_access_manager.add_catalog(catalog)
         data_access_manager.add_dataset(registered_pipeline_id, dataset_name)
         data_node = data_access_manager.add_node_input(
             registered_pipeline_id, dataset_name, task_node
@@ -113,15 +104,11 @@ class TestAddNode:
             }
         }
 
-    def test_add_parameters_as_node_input(
-        self,
-        data_access_manager: DataAccessManager,
-        example_pipelines: Dict[str, Pipeline],
-    ):
+    def test_add_parameters_as_node_input(self, data_access_manager: DataAccessManager):
         parameters = {"train_test_split": 0.1, "num_epochs": 1000}
         catalog = DataCatalog()
         catalog.add_feed_dict({"parameters": parameters})
-        data_access_manager.add_catalog(catalog, example_pipelines)
+        data_access_manager.add_catalog(catalog)
         registered_pipeline_id = "my_pipeline"
         kedro_node = node(identity, inputs="parameters", outputs="output")
         task_node = data_access_manager.add_node(registered_pipeline_id, kedro_node)
@@ -132,13 +119,11 @@ class TestAddNode:
         assert task_node.parameters == parameters
 
     def test_add_single_parameter_as_node_input(
-        self,
-        data_access_manager: DataAccessManager,
-        example_pipelines: Dict[str, Pipeline],
+        self, data_access_manager: DataAccessManager
     ):
         catalog = DataCatalog()
         catalog.add_feed_dict({"params:train_test_split": 0.1})
-        data_access_manager.add_catalog(catalog, example_pipelines)
+        data_access_manager.add_catalog(catalog)
         registered_pipeline_id = "my_pipeline"
         kedro_node = node(identity, inputs="params:train_test_split", outputs="output")
         task_node = data_access_manager.add_node(registered_pipeline_id, kedro_node)
@@ -151,12 +136,11 @@ class TestAddNode:
     def test_parameters_yaml_namespace_not_added_to_modular_pipelines(
         self,
         data_access_manager: DataAccessManager,
-        example_pipelines: Dict[str, Pipeline],
     ):
         parameter_name = "params:uk.data_science.train_test_split.ratio"
         catalog = DataCatalog()
         catalog.add_feed_dict({parameter_name: 0.1})
-        data_access_manager.add_catalog(catalog, example_pipelines)
+        data_access_manager.add_catalog(catalog)
         registered_pipeline_id = "my_pipeline"
         kedro_node = node(
             identity,
@@ -176,11 +160,7 @@ class TestAddNode:
         # make sure parameters YAML namespace not accidentally added to the modular pipeline tree
         assert "uk.data_science.train_test_split" not in modular_pipelines_tree
 
-    def test_add_node_output(
-        self,
-        data_access_manager: DataAccessManager,
-        example_pipelines: Dict[str, Pipeline],
-    ):
+    def test_add_node_output(self, data_access_manager: DataAccessManager):
         dataset = CSVDataset(filepath="dataset.csv")
         registered_pipeline_id = "my_pipeline"
         dataset_name = "x"
@@ -195,7 +175,7 @@ class TestAddNode:
         catalog = DataCatalog(
             datasets={dataset_name: dataset},
         )
-        data_access_manager.add_catalog(catalog, example_pipelines)
+        data_access_manager.add_catalog(catalog)
         data_access_manager.add_dataset(registered_pipeline_id, dataset_name)
         data_node = data_access_manager.add_node_output(
             registered_pipeline_id, dataset_name, task_node
@@ -220,15 +200,11 @@ class TestAddNode:
 
 
 class TestAddDataset:
-    def test_add_dataset(
-        self,
-        data_access_manager: DataAccessManager,
-        example_pipelines: Dict[str, Pipeline],
-    ):
+    def test_add_dataset(self, data_access_manager: DataAccessManager):
         dataset = CSVDataset(filepath="dataset.csv")
         dataset_name = "x"
         catalog = DataCatalog(datasets={dataset_name: dataset})
-        data_access_manager.add_catalog(catalog, example_pipelines)
+        data_access_manager.add_catalog(catalog)
         data_access_manager.add_dataset("my_pipeline", dataset_name)
 
         # dataset should be added as a graph node
@@ -241,12 +217,10 @@ class TestAddDataset:
         assert not graph_node.modular_pipelines
 
     def test_add_memory_dataset_when_dataset_not_in_catalog(
-        self,
-        data_access_manager: DataAccessManager,
-        example_pipelines: Dict[str, Pipeline],
+        self, data_access_manager: DataAccessManager
     ):
         catalog = DataCatalog()
-        data_access_manager.add_catalog(catalog, example_pipelines)
+        data_access_manager.add_catalog(catalog)
         data_access_manager.add_dataset("my_pipeline", "memory_dataset")
         # dataset should be added as a graph node
         nodes_list = data_access_manager.nodes.as_list()
@@ -256,16 +230,14 @@ class TestAddDataset:
         assert isinstance(graph_node.kedro_obj, MemoryDataset)
 
     def test_add_dataset_with_modular_pipeline(
-        self,
-        data_access_manager: DataAccessManager,
-        example_pipelines: Dict[str, Pipeline],
+        self, data_access_manager: DataAccessManager
     ):
         dataset = CSVDataset(filepath="dataset.csv")
         dataset_name = "uk.data_science.x"
         catalog = DataCatalog(
             datasets={dataset_name: dataset},
         )
-        data_access_manager.add_catalog(catalog, example_pipelines)
+        data_access_manager.add_catalog(catalog)
         data_access_manager.add_dataset("my_pipeline", dataset_name)
         nodes_list = data_access_manager.nodes.as_list()
         graph_node: DataNode = nodes_list[0]
@@ -274,16 +246,12 @@ class TestAddDataset:
             "uk.data_science",
         ]
 
-    def test_add_all_parameters(
-        self,
-        data_access_manager: DataAccessManager,
-        example_pipelines: Dict[str, Pipeline],
-    ):
+    def test_add_all_parameters(self, data_access_manager: DataAccessManager):
         catalog = DataCatalog()
         catalog.add_feed_dict(
             {"parameters": {"train_test_split": 0.1, "num_epochs": 1000}}
         )
-        data_access_manager.add_catalog(catalog, example_pipelines)
+        data_access_manager.add_catalog(catalog)
         data_access_manager.add_dataset("my_pipeline", "parameters")
 
         nodes_list = data_access_manager.nodes.as_list()
@@ -296,14 +264,10 @@ class TestAddDataset:
             "num_epochs": 1000,
         }
 
-    def test_add_single_parameter(
-        self,
-        data_access_manager: DataAccessManager,
-        example_pipelines: Dict[str, Pipeline],
-    ):
+    def test_add_single_parameter(self, data_access_manager: DataAccessManager):
         catalog = DataCatalog()
         catalog.add_feed_dict({"params:train_test_split": 0.1})
-        data_access_manager.add_catalog(catalog, example_pipelines)
+        data_access_manager.add_catalog(catalog)
         data_access_manager.add_dataset("my_pipeline", "params:train_test_split")
         nodes_list = data_access_manager.nodes.as_list()
         assert len(nodes_list) == 1
@@ -313,13 +277,11 @@ class TestAddDataset:
         assert graph_node.parameter_value == 0.1
 
     def test_add_dataset_with_params_prefix(
-        self,
-        data_access_manager: DataAccessManager,
-        example_pipelines: Dict[str, Pipeline],
+        self, data_access_manager: DataAccessManager
     ):
         catalog = DataCatalog()
         catalog.add_feed_dict({"params_train_test_split": 0.1})
-        data_access_manager.add_catalog(catalog, example_pipelines)
+        data_access_manager.add_catalog(catalog)
         data_access_manager.add_dataset("my_pipeline", "params_train_test_split")
         nodes_list = data_access_manager.nodes.as_list()
         assert len(nodes_list) == 1
@@ -335,7 +297,7 @@ class TestAddPipelines:
         example_pipelines: Dict[str, Pipeline],
         example_catalog: DataCatalog,
     ):
-        data_access_manager.add_catalog(example_catalog, example_pipelines)
+        data_access_manager.add_catalog(example_catalog)
         data_access_manager.add_pipelines(example_pipelines)
 
         assert [p.id for p in data_access_manager.registered_pipelines.as_list()] == [
@@ -381,9 +343,7 @@ class TestAddPipelines:
         example_transcoded_pipelines: Dict[str, Pipeline],
         example_transcoded_catalog: DataCatalog,
     ):
-        data_access_manager.add_catalog(
-            example_transcoded_catalog, example_transcoded_pipelines
-        )
+        data_access_manager.add_catalog(example_transcoded_catalog)
         data_access_manager.add_pipelines(example_transcoded_pipelines)
         assert any(
             isinstance(node, TranscodedDataNode)
@@ -405,7 +365,7 @@ class TestAddPipelines:
             ),
         }
 
-        data_access_manager.add_catalog(DataCatalog(), registered_pipelines)
+        data_access_manager.add_catalog(DataCatalog())
         data_access_manager.add_pipelines(registered_pipelines)
         modular_pipeline_tree = (
             data_access_manager.create_modular_pipelines_tree_for_registered_pipeline(
@@ -420,7 +380,7 @@ class TestAddPipelines:
         example_pipelines: Dict[str, Pipeline],
         example_catalog: DataCatalog,
     ):
-        data_access_manager.add_catalog(example_catalog, example_pipelines)
+        data_access_manager.add_catalog(example_catalog)
         del example_pipelines[DEFAULT_REGISTERED_PIPELINE_ID]
         data_access_manager.add_pipelines(example_pipelines)
         assert not data_access_manager.registered_pipelines.get_pipeline_by_id(
@@ -475,7 +435,7 @@ class TestAddPipelines:
         registered_pipelines = {
             "__default__": internal + external,
         }
-        data_access_manager.add_catalog(DataCatalog(), registered_pipelines)
+        data_access_manager.add_catalog(DataCatalog())
         data_access_manager.add_pipelines(registered_pipelines)
         data_access_manager.create_modular_pipelines_tree_for_registered_pipeline(
             DEFAULT_REGISTERED_PIPELINE_ID
@@ -494,25 +454,3 @@ class TestAddPipelines:
             digraph.add_edge(edge.source, edge.target)
         with pytest.raises(nx.NetworkXNoCycle):
             nx.find_cycle(digraph)
-
-
-class TestResolveDatasetFactoryPatterns:
-    def test_resolve_dataset_factory_patterns(
-        self,
-        example_catalog,
-        pipeline_with_datasets_mock,
-        pipeline_with_data_sets_mock,
-        data_access_manager: DataAccessManager,
-    ):
-        pipelines = {
-            "pipeline1": pipeline_with_datasets_mock,
-            "pipeline2": pipeline_with_data_sets_mock,
-        }
-        new_catalog = CatalogRepository()
-        new_catalog.set_catalog(example_catalog)
-
-        assert "model_inputs#csv" not in new_catalog.as_dict().keys()
-
-        data_access_manager.resolve_dataset_factory_patterns(example_catalog, pipelines)
-
-        assert "model_inputs#csv" in new_catalog.as_dict().keys()

--- a/package/tests/test_server.py
+++ b/package/tests/test_server.py
@@ -70,9 +70,7 @@ class TestServer:
         example_pipelines,
     ):
         run_server()
-        patched_data_access_manager.add_catalog.assert_called_once_with(
-            example_catalog, example_pipelines
-        )
+        patched_data_access_manager.add_catalog.assert_called_once_with(example_catalog)
         patched_data_access_manager.add_pipelines.assert_called_once_with(
             example_pipelines
         )
@@ -95,9 +93,7 @@ class TestServer:
     ):
         run_server()
         # assert that when running server, data are added correctly to the data access manager
-        patched_data_access_manager.add_catalog.assert_called_once_with(
-            example_catalog, example_pipelines
-        )
+        patched_data_access_manager.add_catalog.assert_called_once_with(example_catalog)
         patched_data_access_manager.add_pipelines.assert_called_once_with(
             example_pipelines
         )


### PR DESCRIPTION
## Description

* Dataset Factory Pattern discovery was introduced to discover datasets (mostly Tracking datasets used in Experiment Tracking) before we populate kedro viz data repositories
* Due to this discovery, datasets that users do not have access to, are either timed-out or raise exceptions. This causes Kedro Viz to timeout or fail.
* This PR removes the dataset factory pattern discovery implementation as a temporary fix. This restricts users from using Dataset Factory Patterns for Experiment Tracking

## Development notes

* Remove all instances of dataset factory pattern discovery implementation

## QA notes

* All tests should pass

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [x] Added tests to cover my changes
