### PR TITLE
Set Kedro Viz start method to spawn process while launching it from Jupyter Notebook

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -5,6 +5,12 @@ Please follow the established format:
 - Use present tense (e.g. 'Add new feature')
 - Include the ID number for the related PR (or PRs) in parentheses
 -->
+# Upcoming Release
+
+## Bug fixes and other changes
+
+- Set Kedro Viz start method to spawn process while launching it from Jupyter Notebook. (#1696)
+
 # Release 7.0.0
 
 ## Major features and improvements

--- a/package/kedro_viz/api/graphql/router.py
+++ b/package/kedro_viz/api/graphql/router.py
@@ -1,4 +1,5 @@
 """`kedro_viz.api.graphql.router` defines GraphQL routes."""
+# mypy: ignore-errors
 from fastapi import APIRouter
 from strawberry.asgi import GraphQL
 
@@ -8,9 +9,9 @@ router = APIRouter()
 
 # graphiql=False can be removed if you wish to use the graphiql playground locally
 graphql_app: GraphQL = GraphQL(schema, graphiql=False)
-router.add_route("/graphql", graphql_app)  # type: ignore
-router.add_websocket_route("/graphql", graphql_app)  # type: ignore
+router.add_route("/graphql", graphql_app)
+router.add_websocket_route("/graphql", graphql_app)
 
 # {subpath:path} is to handle urls with subpath e.g. demo.kedro.org/web
-router.add_route("/{subpath:path}/graphql", graphql_app)  # type: ignore
-router.add_websocket_route("/{subpath:path}/graphql", graphql_app)  # type: ignore
+router.add_route("/{subpath:path}/graphql", graphql_app)
+router.add_websocket_route("/{subpath:path}/graphql", graphql_app)

--- a/package/kedro_viz/api/graphql/router.py
+++ b/package/kedro_viz/api/graphql/router.py
@@ -8,9 +8,9 @@ router = APIRouter()
 
 # graphiql=False can be removed if you wish to use the graphiql playground locally
 graphql_app: GraphQL = GraphQL(schema, graphiql=False)
-router.add_route("/graphql", graphql_app)
-router.add_websocket_route("/graphql", graphql_app)
+router.add_route("/graphql", graphql_app)  # type: ignore
+router.add_websocket_route("/graphql", graphql_app)  # type: ignore
 
 # {subpath:path} is to handle urls with subpath e.g. demo.kedro.org/web
-router.add_route("/{subpath:path}/graphql", graphql_app)
-router.add_websocket_route("/{subpath:path}/graphql", graphql_app)
+router.add_route("/{subpath:path}/graphql", graphql_app)  # type: ignore
+router.add_websocket_route("/{subpath:path}/graphql", graphql_app)  # type: ignore

--- a/package/kedro_viz/launchers/jupyter.py
+++ b/package/kedro_viz/launchers/jupyter.py
@@ -107,8 +107,8 @@ def run_viz(port: int = None, local_ns: Dict[str, Any] = None) -> None:
         else None
     )
 
-    multiprocessing.set_start_method("spawn")
-    viz_process = multiprocessing.Process(
+    process_context = multiprocessing.get_context("spawn")
+    viz_process = process_context.Process(
         target=run_server,
         daemon=True,
         kwargs={"project_path": project_path, "host": host, "port": port},

--- a/package/kedro_viz/launchers/jupyter.py
+++ b/package/kedro_viz/launchers/jupyter.py
@@ -107,6 +107,7 @@ def run_viz(port: int = None, local_ns: Dict[str, Any] = None) -> None:
         else None
     )
 
+    multiprocessing.set_start_method("spawn")
     viz_process = multiprocessing.Process(
         target=run_server,
         daemon=True,


### PR DESCRIPTION
## Description

Resolves #1656 

## Development notes

* Add multiprocess start method to spawn
* Add mypy type ignore for `add_route` and `add_websocket_route` due to strict mypy check introduced [here](https://github.com/encode/starlette/pull/2180) in starlette

## QA notes

* All tests should pass
* Launch Kedro Viz via [jupyter notebook](https://docs.kedro.org/en/latest/notebooks_and_ipython/kedro_and_notebooks.html#)
* Run line magic %run_viz

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [x] Added new entries to the `RELEASE.md` file
- [x] Added tests to cover my changes
