### PR TITLE
[Experiment] Distinctive MemoryDataset view on flowchart

### DIFF
--- a/src/components/flowchart/draw.js
+++ b/src/components/flowchart/draw.js
@@ -135,6 +135,7 @@ export const drawNodes = function (changed) {
     nodes,
     focusMode,
     hoveredFocusMode,
+    flags,
   } = this.props;
 
   const isInputOutputNode = (nodeID) =>
@@ -171,6 +172,10 @@ export const drawNodes = function (changed) {
       )
       .classed('pipeline-node--data', (node) => node.type === 'data')
       .classed('pipeline-node--task', (node) => node.type === 'task')
+      .classed(
+        'pipeline-node--memory-data',
+        (node) => flags?.diffMemoryDatasets && node?.dataset?.includes('memory')
+      )
       .on('click', this.handleNodeClick)
       .on('mouseover', this.handleNodeMouseOver)
       .on('mouseout', this.handleNodeMouseOut)

--- a/src/components/flowchart/flowchart.js
+++ b/src/components/flowchart/flowchart.js
@@ -708,6 +708,7 @@ export const mapStateToProps = (state, ownProps) => ({
   visibleSidebar: state.visible.sidebar,
   visibleCode: state.visible.code,
   visibleMetaSidebar: getVisibleMetaSidebar(state),
+  flags: state.flags,
   ...ownProps,
 });
 

--- a/src/components/flowchart/styles/_node.scss
+++ b/src/components/flowchart/styles/_node.scss
@@ -136,3 +136,7 @@
 .pipeline-node__text {
   transition: opacity 0.15s ease;
 }
+
+.pipeline-node--memory-data {
+  opacity: 0.3;
+}

--- a/src/config.js
+++ b/src/config.js
@@ -69,6 +69,13 @@ export const flags = {
     default: false,
     icon: '🔛',
   },
+  diffMemoryDatasets: {
+    name: 'Distinctive Memory Dataset flowchart view',
+    description:
+      'Fades non-persistent i.e. MemoryDatasets to distinguish them from persistent datasets in the flowchart',
+    default: false,
+    icon: '🔛',
+  },
 };
 
 export const settings = {

--- a/src/selectors/nodes.js
+++ b/src/selectors/nodes.js
@@ -396,6 +396,7 @@ export const getVisibleNodes = createSelector(
       name: nodeLabel[id],
       fullName: nodeFullName[id],
       icon: getShortType(nodeDatasetType[id], nodeType[id]),
+      dataset: nodeDatasetType[id],
       type: nodeType[id],
       layer: nodeLayer[id],
       rank: nodeRank[id],


### PR DESCRIPTION
## Description

Suggested for quick experimentation by @datajoely: MemoryDatasets are non-persistent datasets, meaning they are not saved after a run. Some flowcharts contain numerous MemoryDatasets, and Kedro-viz currently lacks a way to differentiate them from persistent datasets. This PR introduces opacity to MemoryDatasets, making them easily distinguishable on the flowchart. The transparency also signifies their non-persistent nature.

Currently this feature is under an experiment flag. 

## Development notes

![MemoryDatasets](https://github.com/kedro-org/kedro-viz/assets/37628668/778f978a-982d-44a0-83a8-bf838dc14964)

## QA notes

<!-- How has the expected behaviour changed? What testing strategies have you used? -->

## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes
