### PR TITLE
Make `kedro viz build` compatible with Kedro 18

### DIFF
--- a/package/kedro_viz/api/rest/responses.py
+++ b/package/kedro_viz/api/rest/responses.py
@@ -448,7 +448,7 @@ def save_api_pipeline_response_to_fs(pipelines_path: str, remote_fs: Any):
 def save_api_responses_to_fs(api_dir: str):
     """Saves all Kedro Viz API responses to a directory."""
     try:
-        protocol, path = get_protocol_and_path(api_dir)
+        protocol, path = get_protocol_and_path(str(api_dir))
         remote_fs = fsspec.filesystem(protocol)
 
         logger.debug(

--- a/package/kedro_viz/integrations/deployment/local_deployer.py
+++ b/package/kedro_viz/integrations/deployment/local_deployer.py
@@ -29,8 +29,9 @@ class LocalDeployer(BaseDeployer):
     def __init__(self):
         super().__init__()
         self._path = Path(_BUILD_PATH)
-        self._path.mkdir(parents=True, exist_ok=True)
         self._fs = fsspec.filesystem(_FILE_PROTOCOL)
+        self._fs.makedirs(self._path, exist_ok=True)
+        self._fs.makedirs(self._path / "html", exist_ok=True)
 
     def deploy_and_get_url(self):
         """Copy Kedro-viz to local build folder and return its URL."""


### PR DESCRIPTION
## Description

If you are using Kedro 18 and attempting to use the newly introduced `kedro viz build` feature, it will fail. This PR resolves this issue.

![image](https://github.com/kedro-org/kedro-viz/assets/37628668/408ce7f2-f1d3-4a86-93be-ed3f35f78902)


## Development notes

The issue arises because Kedro 18 only accepts `Paths` and not `strings` as arguments to the `get_protocol_and_path()` function. This behavior change was introduced in [PR #3345](https://github.com/kedro-org/kedro/pull/3345/files). To make get_protocol_and_path() work with both Kedro 18 and 19, we have reinforced casting to a string when calling this function from kedro-core.

## QA notes

<!-- How has the expected behaviour changed? What testing strategies have you used? -->

## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes 