### PR TITLE
Remove Python3.8 Support

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -207,7 +207,7 @@ jobs:
   javascript_lint_and_tests:
     executor:
       name: docker
-      python_version: '3.8'
+      python_version: '3.9'
     steps:
       - checkout
       - setup_python_env
@@ -235,7 +235,7 @@ jobs:
   release_to_npm:
     executor:
       name: docker
-      python_version: '3.8'
+      python_version: '3.9'
     steps:
       - checkout
       - install_node_dependencies
@@ -250,7 +250,7 @@ jobs:
   release_to_pypi:
     executor:
       name: docker
-      python_version: '3.8'
+      python_version: '3.9'
     steps:
       - setup
       - run:
@@ -266,7 +266,7 @@ jobs:
   deploy_demo:
     executor:
       name: docker
-      python_version: '3.8'
+      python_version: '3.9'
     steps:
       - checkout
       - setup_remote_docker
@@ -341,11 +341,11 @@ workflows:
       - e2e_tests:
           matrix:
             parameters:
-              python_version: ['3.8', '3.9', '3.10', '3.11']
+              python_version: ['3.9', '3.10', '3.11']
       - win_e2e_tests:
           matrix:
             parameters:
-              python_version: ['3.8', '3.9', '3.10', '3.11']
+              python_version: ['3.9', '3.10', '3.11']
           filters:
             branches:
               only:
@@ -354,11 +354,11 @@ workflows:
       - unit_tests:
           matrix:
             parameters:
-              python_version: ['3.8', '3.9', '3.10', '3.11']
+              python_version: ['3.9', '3.10', '3.11']
       - win_unit_tests:
           matrix:
             parameters:
-              python_version: ['3.8', '3.9', '3.10', '3.11']
+              python_version: ['3.9', '3.10', '3.11']
           filters:
             branches:
               only:
@@ -367,7 +367,7 @@ workflows:
       - lint:
           matrix:
             parameters:
-              python_version: ['3.8', '3.9', '3.10', '3.11']
+              python_version: ['3.9', '3.10', '3.11']
       - all_circleci_checks_succeeded:
           requires:
             - e2e_tests
@@ -393,21 +393,21 @@ workflows:
       - e2e_tests:
           matrix:
             parameters:
-              python_version: ['3.8', '3.9', '3.10', '3.11']
+              python_version: ['3.9', '3.10', '3.11']
       - win_e2e_tests:
           matrix:
             parameters:
-              python_version: ['3.8', '3.9', '3.10', '3.11']
+              python_version: ['3.9', '3.10', '3.11']
       - unit_tests:
           matrix:
             parameters:
-              python_version: ['3.8', '3.9', '3.10', '3.11']
+              python_version: ['3.9', '3.10', '3.11']
       - win_unit_tests:
           matrix:
             parameters:
-              python_version: ['3.8', '3.9', '3.10', '3.11']
+              python_version: ['3.9', '3.10', '3.11']
       - lint:
           matrix:
             parameters:
-              python_version: ['3.8', '3.9', '3.10', '3.11']
+              python_version: ['3.9', '3.10', '3.11']
       - javascript_lint_and_tests

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,7 +7,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.8"
+    python: "3.9"
     nodejs: "19"
 
 sphinx:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ Working on your first pull request? You can learn how from these resources:
 
 - Aim for cross-platform compatibility on Windows, macOS and Linux, and support recent versions of major browsers
 - We use [SemVer](https://semver.org/) for versioning
-- Our code is designed to be compatible with Python 3.8 onwards
+- Our code is designed to be compatible with Python 3.9 onwards
 - We use [Anaconda](https://www.anaconda.com/distribution/) as a preferred virtual environment
 - We use [PEP 8 conventions](https://www.python.org/dev/peps/pep-0008/) for all Python code
 - We use [Google docstrings](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings) for code comments
@@ -175,7 +175,7 @@ Finally, you can use pseudo-random data, which is procedurally-generated on page
 > **Note**: Kedro-Viz>=7.0.0 will not work with projects created with Kedro<=0.17.0. Please consider migrating your project to Kedro>=0.18.0 before you develop against the latest version of Kedro-Viz.
 
 
-Before launching a development server with a real Kedro project, you'd need to have [Python](https://www.python.org/)(>=3.8) installed. We strongly recommend setting up [conda](https://docs.conda.io/en/latest/) to manage your Python versions and virtual environments. You can visit Kedro's [guide to installing conda](https://docs.kedro.org/en/latest/get_started/install.html#create-a-virtual-environment-for-your-kedro-project) for more information.
+Before launching a development server with a real Kedro project, you'd need to have [Python](https://www.python.org/)(>=3.9) installed. We strongly recommend setting up [conda](https://docs.conda.io/en/latest/) to manage your Python versions and virtual environments. You can visit Kedro's [guide to installing conda](https://docs.kedro.org/en/latest/get_started/install.html#create-a-virtual-environment-for-your-kedro-project) for more information.
 
 The Kedro-Viz repository comes with an example project in the `demo-project` folder. This is used on the [public demo](https://demo.kedro.org/). To use it in your development environment, you need to install both the Kedro-Viz dependencies and a minimal set of dependencies for the demo project:
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Live Demo: <a href="https://demo.kedro.org/" target="_blank">https://demo.kedro.
 
 [![CircleCI](https://circleci.com/gh/kedro-org/kedro-viz/tree/main.svg?style=shield)](https://circleci.com/gh/kedro-org/kedro-viz/tree/main)
 [![Documentation](https://readthedocs.org/projects/kedro/badge/?version=stable)](https://docs.kedro.org/en/stable/visualisation/)
-[![Python Version](https://img.shields.io/badge/python-3.8%20%7C%203.9%20%7C%203.10%20%7C%203.11-orange.svg)](https://pypi.org/project/kedro-viz/)
+[![Python Version](https://img.shields.io/badge/python-3.9%20%7C%203.10%20%7C%203.11-orange.svg)](https://pypi.org/project/kedro-viz/)
 [![PyPI version](https://img.shields.io/pypi/v/kedro-viz.svg?color=yellow)](https://pypi.org/project/kedro-viz/)
 [![Downloads](https://static.pepy.tech/badge/kedro-viz/week)](https://pepy.tech/project/kedro-viz)
 [![npm version](https://img.shields.io/npm/v/@quantumblack/kedro-viz.svg?color=cc3534)](https://badge.fury.io/js/%40quantumblack%2Fkedro-viz)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -10,7 +10,7 @@ Please follow the established format:
 
 ## Major features and improvements
 
-- Drop support for `python=3.8`. (#1744)
+- Drop support for `python=3.8`. (#1747)
 
 ## Bug fixes and other changes
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -9,7 +9,11 @@ Please follow the established format:
 # Upcoming release
 
 ## Major features and improvements
+
+- Drop support for `python=3.8`. (#1744)
+
 ## Bug fixes and other changes
+
 - Change the `%run_viz` line magic to open Kedro-viz in a new browser tab. (#1722)
 
 

--- a/package/setup.py
+++ b/package/setup.py
@@ -36,7 +36,7 @@ setup(
     long_description_content_type="text/markdown",
     license="Apache Software License (Apache 2.0)",
     url="https://github.com/kedro-org/kedro-viz",
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     install_requires=requires,
     keywords="pipelines, machine learning, data pipelines, data science, data engineering, visualisation",
     author="Kedro",

--- a/package/test_requirements.txt
+++ b/package/test_requirements.txt
@@ -22,7 +22,6 @@ pytest-cov~=4.1
 sqlalchemy-stubs~=0.4
 strawberry-graphql[cli]>=0.99.0, <1.0
 trufflehog~=2.2
-typing_extensions~=4.7.0; python_version < '3.9'
 httpx~=0.24.0
 
 # mypy


### PR DESCRIPTION
## Description

Resolves #1746 and unblocks #1700 

## Development notes

* Remove instances of python 3.8 from kedro viz requirement files and circle ci config
* Update readME and Contribution docs to reflect support from python 3.9

## QA notes

* All tests should pass with python env >=3.9

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [x] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes
