### PR TITLE
Increase Kedro Viz timeout

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -5,6 +5,12 @@ Please follow the established format:
 - Use present tense (e.g. 'Add new feature')
 - Include the ID number for the related PR (or PRs) in parentheses
 -->
+# Upcoming Release
+
+## Bug fixes and other changes
+
+- Increase Kedro-Viz timeout. (#1803)
+
 # Release 8.0.1 
 
 ## Bug fixes and other changes

--- a/package/kedro_viz/launchers/utils.py
+++ b/package/kedro_viz/launchers/utils.py
@@ -18,7 +18,7 @@ class WaitForException(Exception):
 def _wait_for(
     func: Callable,
     expected_result: Any = True,
-    timeout: int = 60,
+    timeout: int = 600,  # [TODO] This is a temporary fix for https://github.com/kedro-org/kedro-viz/issues/1768.
     print_error: bool = True,
     sleep_for: int = 1,
     **kwargs,

--- a/package/kedro_viz/launchers/utils.py
+++ b/package/kedro_viz/launchers/utils.py
@@ -18,7 +18,8 @@ class WaitForException(Exception):
 def _wait_for(
     func: Callable,
     expected_result: Any = True,
-    timeout: int = 600,  # [TODO] This is a temporary fix for https://github.com/kedro-org/kedro-viz/issues/1768.
+    # [TODO] This is a temporary fix for https://github.com/kedro-org/kedro-viz/issues/1768.
+    timeout: int = 600,
     print_error: bool = True,
     sleep_for: int = 1,
     **kwargs,

--- a/package/tests/test_launchers/test_cli.py
+++ b/package/tests/test_launchers/test_cli.py
@@ -178,7 +178,7 @@ def test_kedro_viz_command_run_server(
 ):
     process_init = mocker.patch("multiprocessing.Process")
     runner = CliRunner()
-
+    # Reduce the timeout argument from 600 to 1 to make test run faster.
     mocker.patch("kedro_viz.launchers.cli._wait_for.__defaults__", (True, 1, True, 1))
 
     with runner.isolated_filesystem():
@@ -190,34 +190,37 @@ def test_kedro_viz_command_run_server(
     assert run_server_args["port"] in cli._VIZ_PROCESSES
 
 
-# def test_kedro_viz_command_should_log_outdated_version(
-#     mocker, mock_http_response, mock_click_echo
-# ):
-#     installed_version = parse(__version__)
-#     mock_version = f"{installed_version.major + 1}.0.0"
-#     requests_get = mocker.patch("requests.get")
-#     requests_get.return_value = mock_http_response(
-#         data={"info": {"version": mock_version}}
-#     )
+def test_kedro_viz_command_should_log_outdated_version(
+    mocker, mock_http_response, mock_click_echo
+):
+    installed_version = parse(__version__)
+    mock_version = f"{installed_version.major + 1}.0.0"
+    requests_get = mocker.patch("requests.get")
+    requests_get.return_value = mock_http_response(
+        data={"info": {"version": mock_version}}
+    )
 
-#     # test push
-#     mocker.patch("kedro_viz.server.run_server")
-#     runner = CliRunner()
-#     with runner.isolated_filesystem():
-#         runner.invoke(cli.viz_cli, ["viz", "run"])
+    # test push
+    mocker.patch("kedro_viz.server.run_server")
 
-#     mock_click_echo_calls = [
-#         call(
-#             "\x1b[33mWARNING: You are using an old version of Kedro Viz. "
-#             f"You are using version {installed_version}; "
-#             f"however, version {mock_version} is now available.\n"
-#             "You should consider upgrading via the `pip install -U kedro-viz` command.\n"
-#             "You can view the complete changelog at "
-#             "https://github.com/kedro-org/kedro-viz/releases.\x1b[0m"
-#         )
-#     ]
+    # Reduce the timeout argument from 600 to 1 to make test run faster.
+    mocker.patch("kedro_viz.launchers.cli._wait_for.__defaults__", (True, 1, True, 1))
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        runner.invoke(cli.viz_cli, ["viz", "run"])
 
-#     mock_click_echo.assert_has_calls(mock_click_echo_calls)
+    mock_click_echo_calls = [
+        call(
+            "\x1b[33mWARNING: You are using an old version of Kedro Viz. "
+            f"You are using version {installed_version}; "
+            f"however, version {mock_version} is now available.\n"
+            "You should consider upgrading via the `pip install -U kedro-viz` command.\n"
+            "You can view the complete changelog at "
+            "https://github.com/kedro-org/kedro-viz/releases.\x1b[0m"
+        )
+    ]
+
+    mock_click_echo.assert_has_calls(mock_click_echo_calls)
 
 
 def test_kedro_viz_command_should_not_log_latest_version(
@@ -229,6 +232,8 @@ def test_kedro_viz_command_should_not_log_latest_version(
     )
 
     mocker.patch("kedro_viz.server.run_server")
+    # Reduce the timeout argument from 600 to 1 to make test run faster.
+    mocker.patch("kedro_viz.launchers.cli._wait_for.__defaults__", (True, 1, True, 1))
     runner = CliRunner()
     with runner.isolated_filesystem():
         runner.invoke(cli.viz_cli, ["viz", "run"])
@@ -245,6 +250,8 @@ def test_kedro_viz_command_should_not_log_if_pypi_is_down(
     requests_get.side_effect = requests.exceptions.RequestException("PyPI is down")
 
     mocker.patch("kedro_viz.server.run_server")
+    # Reduce the timeout argument from 600 to 1 to make test run faster.
+    mocker.patch("kedro_viz.launchers.cli._wait_for.__defaults__", (True, 1, True, 1))
     runner = CliRunner()
     with runner.isolated_filesystem():
         runner.invoke(cli.viz_cli, ["viz", "run"])
@@ -259,7 +266,7 @@ def test_kedro_viz_command_with_autoreload(
 ):
     process_init = mocker.patch("multiprocessing.Process")
 
-    # Reduce the timeout argument from 60 to 1 to make test run faster.
+    # Reduce the timeout argument from 600 to 1 to make test run faster.
     mocker.patch("kedro_viz.launchers.cli._wait_for.__defaults__", (True, 1, True, 1))
     runner = CliRunner()
     with runner.isolated_filesystem():

--- a/package/tests/test_launchers/test_cli.py
+++ b/package/tests/test_launchers/test_cli.py
@@ -200,6 +200,7 @@ def test_kedro_viz_command_should_log_outdated_version(
         data={"info": {"version": mock_version}}
     )
 
+    # test push
     mocker.patch("kedro_viz.server.run_server")
     runner = CliRunner()
     with runner.isolated_filesystem():

--- a/package/tests/test_launchers/test_cli.py
+++ b/package/tests/test_launchers/test_cli.py
@@ -190,34 +190,34 @@ def test_kedro_viz_command_run_server(
     assert run_server_args["port"] in cli._VIZ_PROCESSES
 
 
-def test_kedro_viz_command_should_log_outdated_version(
-    mocker, mock_http_response, mock_click_echo
-):
-    installed_version = parse(__version__)
-    mock_version = f"{installed_version.major + 1}.0.0"
-    requests_get = mocker.patch("requests.get")
-    requests_get.return_value = mock_http_response(
-        data={"info": {"version": mock_version}}
-    )
+# def test_kedro_viz_command_should_log_outdated_version(
+#     mocker, mock_http_response, mock_click_echo
+# ):
+#     installed_version = parse(__version__)
+#     mock_version = f"{installed_version.major + 1}.0.0"
+#     requests_get = mocker.patch("requests.get")
+#     requests_get.return_value = mock_http_response(
+#         data={"info": {"version": mock_version}}
+#     )
 
-    # test push
-    mocker.patch("kedro_viz.server.run_server")
-    runner = CliRunner()
-    with runner.isolated_filesystem():
-        runner.invoke(cli.viz_cli, ["viz", "run"])
+#     # test push
+#     mocker.patch("kedro_viz.server.run_server")
+#     runner = CliRunner()
+#     with runner.isolated_filesystem():
+#         runner.invoke(cli.viz_cli, ["viz", "run"])
 
-    mock_click_echo_calls = [
-        call(
-            "\x1b[33mWARNING: You are using an old version of Kedro Viz. "
-            f"You are using version {installed_version}; "
-            f"however, version {mock_version} is now available.\n"
-            "You should consider upgrading via the `pip install -U kedro-viz` command.\n"
-            "You can view the complete changelog at "
-            "https://github.com/kedro-org/kedro-viz/releases.\x1b[0m"
-        )
-    ]
+#     mock_click_echo_calls = [
+#         call(
+#             "\x1b[33mWARNING: You are using an old version of Kedro Viz. "
+#             f"You are using version {installed_version}; "
+#             f"however, version {mock_version} is now available.\n"
+#             "You should consider upgrading via the `pip install -U kedro-viz` command.\n"
+#             "You can view the complete changelog at "
+#             "https://github.com/kedro-org/kedro-viz/releases.\x1b[0m"
+#         )
+#     ]
 
-    mock_click_echo.assert_has_calls(mock_click_echo_calls)
+#     mock_click_echo.assert_has_calls(mock_click_echo_calls)
 
 
 def test_kedro_viz_command_should_not_log_latest_version(


### PR DESCRIPTION
## Description

Resolves #1768 

## Development notes

* Starting Kedro Viz might take more than 60sec in few cases where users receive a timeout error and are unable to proceed further
* To resolve the issue temporarily, we are increasing the timeout to 10min (which might be a rare case). 

**NOTE:** Ideally we would like kedro-viz to load within 60sec and we are working on few [tickets](https://github.com/kedro-org/kedro-viz/issues/1783) which would help us to acheive a permanent solution in near future.

## QA notes

* All tests should pass

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [x] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes
