### PR TITLE
Fix CircleCI build failure due to secret scan and missing toposort dependency

### DIFF
--- a/package/requirements.txt
+++ b/package/requirements.txt
@@ -14,3 +14,5 @@ sqlalchemy>=1.4, <3
 strawberry-graphql>=0.192.0, <1.0
 uvicorn[standard]~=0.27.1
 watchgod~=0.8.2
+# [TODO: Need to drop toposort dependency in favor of in-built graphlib]
+toposort>=1.5 # Needs to be at least 1.5 to be able to raise CircularDependencyError

--- a/trufflehog-ignore.txt
+++ b/trufflehog-ignore.txt
@@ -7,3 +7,4 @@ README.md
 LAYOUT_ENGINE.md
 src/utils/random-utils.js
 src/components/update-reminder/update-reminder-content.js
+src/components/feature-hints/feature-hints-content.js


### PR DESCRIPTION
## Description

* Resolves the build failure - https://app.circleci.com/pipelines/github/kedro-org/kedro-viz/11807/workflows/c0708990-c866-4e6f-b59d-b4bb94068c36/jobs/75254

## Development notes

* Added `src/components/feature-hints/feature-hints-content.js` file to the trufflehog ignore text
* Added temporary dependency for toposort as Kedro has dropped the dependency - https://github.com/kedro-org/kedro/pull/3728

## QA notes

* CircleCI build should pass
* All tests should pass

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes
