### PR TITLE
Fix posix path conversion on Windows in DatasetStatsHook

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -17,6 +17,7 @@ Please follow the established format:
 - Increase Kedro-Viz timeout. (#1803)
 - Remove demo data source and update feature hints. (#1804)
 - Add markdown support for backticks in the pop-up reminder. (#1826)
+- Fix posix path conversion on Windows in DatasetStatsHook. (#1843)
 
 # Release 8.0.1 
 

--- a/demo-project/src/demo_project/pipelines/data_ingestion/nodes.py
+++ b/demo-project/src/demo_project/pipelines/data_ingestion/nodes.py
@@ -86,9 +86,9 @@ def aggregate_company_data(typed_companies: pd.DataFrame) -> pd.DataFrame:
 
     working_companies = typed_companies.groupby(["id"]).agg(
         {
-            "company_rating": np.mean,
+            "company_rating": "mean",
             "company_location": lambda x: list(set(x))[0],  # Take first item
-            "total_fleet_count": max,
+            "total_fleet_count": "max",
             "iata_approved": any,
         }
     )

--- a/package/kedro_viz/integrations/kedro/hooks.py
+++ b/package/kedro_viz/integrations/kedro/hooks.py
@@ -5,6 +5,7 @@ functionalities for a kedro run."""
 import json
 import logging
 from collections import defaultdict
+from pathlib import Path
 from typing import Any, Union
 
 from kedro.framework.hooks import hook_impl
@@ -134,7 +135,7 @@ class DatasetStatsHook:
             return None
 
         try:
-            file_path = get_filepath_str(dataset._filepath, dataset._protocol)
+            file_path = get_filepath_str(Path(dataset._filepath), dataset._protocol)
             return dataset._fs.size(file_path)
 
         except Exception as exc:

--- a/package/kedro_viz/integrations/kedro/hooks.py
+++ b/package/kedro_viz/integrations/kedro/hooks.py
@@ -6,13 +6,12 @@ import json
 import logging
 from collections import defaultdict
 from pathlib import Path
-from typing import Any, Dict, Union
+from typing import Any, Union
 
 from kedro.framework.hooks import hook_impl
 from kedro.io import DataCatalog
 from kedro.io.core import get_filepath_str
 from kedro.pipeline.pipeline import TRANSCODING_SEPARATOR, _strip_transcoding
-from kedro.runner.parallel_runner import ParallelRunner
 
 logger = logging.getLogger(__name__)
 
@@ -38,26 +37,6 @@ class DatasetStatsHook:
         except Exception:  # pragma: no cover
             # Support for Kedro 0.18.x
             self.datasets = catalog._data_sets  # type: ignore[attr-defined]
-
-    @hook_impl
-    def before_pipeline_run(
-        self, run_params: Dict[str, Any], pipeline, catalog, **kwargs
-    ) -> None:
-        """Hook implementation to start an MLflow run
-        with the session_id of the Kedro pipeline run.
-        """
-        import pdb
-
-        pdb.set_trace()
-
-        pipeline_runner_obj = run_params["runner"]
-        print(run_params)
-        if isinstance(pipeline_runner_obj, ParallelRunner):
-            print(pipeline_runner_obj._manager)
-            runnerManager = pipeline_runner_obj._manager
-            self._stats = runnerManager.dict()
-        else:
-            print("Sq Runner")
 
     @hook_impl
     def after_dataset_loaded(self, dataset_name: str, data: Any):

--- a/package/kedro_viz/integrations/kedro/hooks.py
+++ b/package/kedro_viz/integrations/kedro/hooks.py
@@ -6,12 +6,13 @@ import json
 import logging
 from collections import defaultdict
 from pathlib import Path
-from typing import Any, Union
+from typing import Any, Dict, Union
 
 from kedro.framework.hooks import hook_impl
 from kedro.io import DataCatalog
 from kedro.io.core import get_filepath_str
 from kedro.pipeline.pipeline import TRANSCODING_SEPARATOR, _strip_transcoding
+from kedro.runner.parallel_runner import ParallelRunner
 
 logger = logging.getLogger(__name__)
 
@@ -37,6 +38,26 @@ class DatasetStatsHook:
         except Exception:  # pragma: no cover
             # Support for Kedro 0.18.x
             self.datasets = catalog._data_sets  # type: ignore[attr-defined]
+
+    @hook_impl
+    def before_pipeline_run(
+        self, run_params: Dict[str, Any], pipeline, catalog, **kwargs
+    ) -> None:
+        """Hook implementation to start an MLflow run
+        with the session_id of the Kedro pipeline run.
+        """
+        import pdb
+
+        pdb.set_trace()
+
+        pipeline_runner_obj = run_params["runner"]
+        print(run_params)
+        if isinstance(pipeline_runner_obj, ParallelRunner):
+            print(pipeline_runner_obj._manager)
+            runnerManager = pipeline_runner_obj._manager
+            self._stats = runnerManager.dict()
+        else:
+            print("Sq Runner")
 
     @hook_impl
     def after_dataset_loaded(self, dataset_name: str, data: Any):


### PR DESCRIPTION
## Description

Resolves #1797 

## Development notes

* Passing PurePath to the get_filepath_str function instead of str filepath which complains on Windows
* Addressed warnings of deprecation in demo-project

```python
file_path = get_filepath_str(Path(dataset._filepath), dataset._protocol)
```

## QA notes

* All tests should pass
* When running on a windows machine, there should not be any warning message as shown [here](https://kedro-org.slack.com/archives/C03RKP2LW64/p1709912797979079) -

```bash
WARNING  Unable to get file size for the dataset SQLQueryDataset(execution_options={}, filepath=C:/path/to/data/00_scripts/dim_postal_code.sql, load_args={}, sql=None): 'str' object has no attribute 'as_posix'
```
## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [x] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes
