### PR TITLE
Fix Flowchart bug with datasets within a nested modular pipeline. 

### DIFF
--- a/demo-project/src/demo_project/pipeline_registry.py
+++ b/demo-project/src/demo_project/pipeline_registry.py
@@ -1,12 +1,64 @@
 """Project pipelines."""
 from typing import Dict
 
-from kedro.pipeline import Pipeline
+from kedro.pipeline import Pipeline, node, pipeline
 
 from demo_project.pipelines import data_ingestion as di
 from demo_project.pipelines import feature_engineering as fe
 from demo_project.pipelines import modelling as mod
 from demo_project.pipelines import reporting as rep
+
+
+def _get_generic_pipe() -> Pipeline:
+    return Pipeline([
+        node(
+            func=lambda x: x,
+            inputs="input_df",
+            outputs="output_df",
+        ),
+    ])
+
+
+def create_pipeline(**kwargs) -> Pipeline:
+    pipe1 = Pipeline([
+        pipeline(
+            pipe=_get_generic_pipe(),
+            inputs={"input_df": "input_to_processing"},
+            outputs={"output_df": "post_first_pipe"},
+            namespace="first_processing_step",
+        ),
+        pipeline(
+            pipe=_get_generic_pipe(),
+            inputs={"input_df": "input_to_processing"},
+            outputs={"output_df": "output_from_processing"},
+            namespace="second_processing_step",
+        ),
+    ])
+    
+    pipe2= pipeline(
+        pipe=pipe1,
+        inputs="input_to_processing",
+        outputs={"output_from_processing","post_first_pipe"},
+        namespace="processing",
+    )
+    
+    
+    pipe3 = Pipeline([
+        pipeline(
+            pipe=_get_generic_pipe(),
+            inputs={"input_df": "input_to_processing"},
+            outputs={"output_df": "post_first_pipe_2"},
+            namespace="third_processing_step",
+        ),
+    ])
+  
+    return pipeline(
+        pipe=pipe2+pipe3,
+        inputs="input_to_processing",
+        outputs={"output_from_processing"},
+        namespace="main",
+    )
+    
 
 
 def register_pipelines() -> Dict[str, Pipeline]:
@@ -27,15 +79,16 @@ def register_pipelines() -> Dict[str, Pipeline]:
     reporting_pipeline = rep.create_pipeline()
 
     return {
-        "__default__": (
-            ingestion_pipeline
-            + feature_pipeline
-            + modelling_pipeline
-            + reporting_pipeline
-        ),
-        "Data ingestion": ingestion_pipeline,
-        "Modelling stage": modelling_pipeline,
-        "Feature engineering": feature_pipeline,
-        "Reporting stage": reporting_pipeline,
-        "Pre-modelling": ingestion_pipeline + feature_pipeline,
-    }
+        "__default__": create_pipeline(),}
+    #     "__default__": (
+    #         ingestion_pipeline
+    #         + feature_pipeline
+    #         + modelling_pipeline
+    #         + reporting_pipeline
+    #     ),
+    #     "Data ingestion": ingestion_pipeline,
+    #     "Modelling stage": modelling_pipeline,
+    #     "Feature engineering": feature_pipeline,
+    #     "Reporting stage": reporting_pipeline,
+    #     "Pre-modelling": ingestion_pipeline + feature_pipeline,
+    # }

--- a/demo-project/src/demo_project/pipeline_registry.py
+++ b/demo-project/src/demo_project/pipeline_registry.py
@@ -1,64 +1,12 @@
 """Project pipelines."""
 from typing import Dict
 
-from kedro.pipeline import Pipeline, node, pipeline
+from kedro.pipeline import Pipeline
 
 from demo_project.pipelines import data_ingestion as di
 from demo_project.pipelines import feature_engineering as fe
 from demo_project.pipelines import modelling as mod
 from demo_project.pipelines import reporting as rep
-
-
-def _get_generic_pipe() -> Pipeline:
-    return Pipeline([
-        node(
-            func=lambda x: x,
-            inputs="input_df",
-            outputs="output_df",
-        ),
-    ])
-
-
-def create_pipeline(**kwargs) -> Pipeline:
-    pipe1 = Pipeline([
-        pipeline(
-            pipe=_get_generic_pipe(),
-            inputs={"input_df": "input_to_processing"},
-            outputs={"output_df": "post_first_pipe"},
-            namespace="first_processing_step",
-        ),
-        pipeline(
-            pipe=_get_generic_pipe(),
-            inputs={"input_df": "input_to_processing"},
-            outputs={"output_df": "output_from_processing"},
-            namespace="second_processing_step",
-        ),
-    ])
-    
-    pipe2= pipeline(
-        pipe=pipe1,
-        inputs="input_to_processing",
-        outputs={"output_from_processing","post_first_pipe"},
-        namespace="processing",
-    )
-    
-    
-    pipe3 = Pipeline([
-        pipeline(
-            pipe=_get_generic_pipe(),
-            inputs={"input_df": "input_to_processing"},
-            outputs={"output_df": "post_first_pipe_2"},
-            namespace="third_processing_step",
-        ),
-    ])
-  
-    return pipeline(
-        pipe=pipe2+pipe3,
-        inputs="input_to_processing",
-        outputs={"output_from_processing"},
-        namespace="main",
-    )
-    
 
 
 def register_pipelines() -> Dict[str, Pipeline]:
@@ -79,16 +27,15 @@ def register_pipelines() -> Dict[str, Pipeline]:
     reporting_pipeline = rep.create_pipeline()
 
     return {
-        "__default__": create_pipeline(),}
-    #     "__default__": (
-    #         ingestion_pipeline
-    #         + feature_pipeline
-    #         + modelling_pipeline
-    #         + reporting_pipeline
-    #     ),
-    #     "Data ingestion": ingestion_pipeline,
-    #     "Modelling stage": modelling_pipeline,
-    #     "Feature engineering": feature_pipeline,
-    #     "Reporting stage": reporting_pipeline,
-    #     "Pre-modelling": ingestion_pipeline + feature_pipeline,
-    # }
+        "__default__": (
+            ingestion_pipeline
+            + feature_pipeline
+            + modelling_pipeline
+            + reporting_pipeline
+        ),
+        "Data ingestion": ingestion_pipeline,
+        "Modelling stage": modelling_pipeline,
+        "Feature engineering": feature_pipeline,
+        "Reporting stage": reporting_pipeline,
+        "Pre-modelling": ingestion_pipeline + feature_pipeline,
+    }

--- a/package/kedro_viz/data_access/repositories/modular_pipelines.py
+++ b/package/kedro_viz/data_access/repositories/modular_pipelines.py
@@ -14,21 +14,23 @@ from kedro_viz.models.flowchart import (
 )
 
 
-def _check_is_internal_input_output(
-    modular_pipeline_id: str, input_node_modular_pipeline: List
+def _is_internal_to_modular_pipeline(
+    input_node_modular_pipeline: List,
+    modular_pipeline_id: str,
 ) -> Optional[str]:
-    """Extracts the ID of the outer modular pipeline containing a nested modular pipeline.
+    """Checks if an input node's modular pipeline is part of
+    the given modular pipelines or it's parents.
 
     Args:
-        modular_pipeline_id: The ID of the nested modular pipeline.
+        modular_pipeline_id: The ID of the modular pipeline.
+        The modular pipeline can be a nested modular pipeline.
 
     Returns:
-        The ID of the outer modular pipeline containing the nested modular pipeline, if available.
+        True if the input node's modular pipeline ID
+        matches the given modular pipeline or it's parents, otherwise False.
 
-    Example:
-        >>> _get_outer_modular_pipeline_id("namespace_modular_pipeline.modular_pipeline")
-        'namespace_modular_pipeline'
     """
+
     all_modular_pipeline_ids = modular_pipeline_id.split(".")
     for pipeline_id in all_modular_pipeline_ids:
         if pipeline_id is not None and pipeline_id in input_node_modular_pipeline:
@@ -144,8 +146,8 @@ class ModularPipelinesRepository:
                 f"Attempt to add a non-data node as input to modular pipeline {modular_pipeline_id}"
             )
 
-        is_internal_input = _check_is_internal_input_output(
-            modular_pipeline_id, input_node.modular_pipelines
+        is_internal_input = _is_internal_to_modular_pipeline(
+            input_node.modular_pipelines, modular_pipeline_id
         )
 
         if is_internal_input:
@@ -179,8 +181,8 @@ class ModularPipelinesRepository:
             raise ValueError(
                 f"Attempt to add a non-data node as input to modular pipeline {modular_pipeline_id}"
             )
-        is_internal_output = _check_is_internal_input_output(
-            modular_pipeline_id, output_node.modular_pipelines
+        is_internal_output = _is_internal_to_modular_pipeline(
+            output_node.modular_pipelines, modular_pipeline_id
         )
 
         if is_internal_output:

--- a/package/kedro_viz/data_access/repositories/modular_pipelines.py
+++ b/package/kedro_viz/data_access/repositories/modular_pipelines.py
@@ -13,15 +13,18 @@ from kedro_viz.models.flowchart import (
     TranscodedDataNode,
 )
 
-def _get_namespace(modular_pipeline_id: str) -> Optional[str]:
-        """Extract the namespace from a nested modular pipeline .
+def _get_parent_modular_pipeline_id(modular_pipeline_id: str) -> Optional[str]:
+        """Extracts the ID of the outer modular pipeline containing a nested modular pipeline.
+    
         Args:
-            modular_pipeline_id: The id of the modular_pipeline.
+            modular_pipeline_id: The ID of the nested modular pipeline.
+            
         Returns:
-            The namespace of this dataset, if available.
+            The ID of the outer modular pipeline containing the nested modular pipeline, if available.
+            
         Example:
-            >>> GraphNode._get_namespace("pipeline.dataset")
-            'pipeline'
+            >>> _get_outer_modular_pipeline_id("namespace_modular_pipeline.modular_pipeline")
+            'namespace_modular_pipeline'
         """
         if "." not in modular_pipeline_id:
             return None
@@ -135,8 +138,8 @@ class ModularPipelinesRepository:
                 f"Attempt to add a non-data node as input to modular pipeline {modular_pipeline_id}"
             )
             
-        namespace = _get_namespace(modular_pipeline_id)
-        is_internal_input = (modular_pipeline_id in input_node.modular_pipelines) or (namespace is not None and namespace in input_node.modular_pipelines)
+        parent_modular_pipeline_id = _get_parent_modular_pipeline_id(modular_pipeline_id)
+        is_internal_input = (modular_pipeline_id in input_node.modular_pipelines) or (parent_modular_pipeline_id is not None and parent_modular_pipeline_id in input_node.modular_pipelines)
 
         if is_internal_input:
             self.tree[modular_pipeline_id].internal_inputs.add(input_node.id)
@@ -170,8 +173,8 @@ class ModularPipelinesRepository:
                 f"Attempt to add a non-data node as input to modular pipeline {modular_pipeline_id}"
             )
             
-        namespace = _get_namespace(modular_pipeline_id) 
-        is_internal_output = modular_pipeline_id in output_node.modular_pipelines or (namespace is not None and namespace in output_node.modular_pipelines)
+        parent_modular_pipeline_id = parent_modular_pipeline_id(modular_pipeline_id) 
+        is_internal_output = modular_pipeline_id in output_node.modular_pipelines or (parent_modular_pipeline_id is not None and parent_modular_pipeline_id in output_node.modular_pipelines)
         if is_internal_output:
             self.tree[modular_pipeline_id].internal_outputs.add(output_node.id)
         else:

--- a/package/kedro_viz/data_access/repositories/modular_pipelines.py
+++ b/package/kedro_viz/data_access/repositories/modular_pipelines.py
@@ -13,23 +13,25 @@ from kedro_viz.models.flowchart import (
     TranscodedDataNode,
 )
 
+
 def _get_parent_modular_pipeline_id(modular_pipeline_id: str) -> Optional[str]:
-        """Extracts the ID of the outer modular pipeline containing a nested modular pipeline.
-    
-        Args:
-            modular_pipeline_id: The ID of the nested modular pipeline.
-            
-        Returns:
-            The ID of the outer modular pipeline containing the nested modular pipeline, if available.
-            
-        Example:
-            >>> _get_outer_modular_pipeline_id("namespace_modular_pipeline.modular_pipeline")
-            'namespace_modular_pipeline'
-        """
-        if "." not in modular_pipeline_id:
-            return None
-        return modular_pipeline_id.rsplit(".", 1)[0]
-    
+    """Extracts the ID of the outer modular pipeline containing a nested modular pipeline.
+
+    Args:
+        modular_pipeline_id: The ID of the nested modular pipeline.
+
+    Returns:
+        The ID of the outer modular pipeline containing the nested modular pipeline, if available.
+
+    Example:
+        >>> _get_outer_modular_pipeline_id("namespace_modular_pipeline.modular_pipeline")
+        'namespace_modular_pipeline'
+    """
+    if "." not in modular_pipeline_id:
+        return None
+    return modular_pipeline_id.rsplit(".", 1)[0]
+
+
 class ModularPipelinesRepository:
     """Repository for the set of modular pipelines in a registered pipeline.
     Internally, the repository models the set of modular pipelines as a tree using child-references.
@@ -137,9 +139,14 @@ class ModularPipelinesRepository:
             raise ValueError(
                 f"Attempt to add a non-data node as input to modular pipeline {modular_pipeline_id}"
             )
-            
-        parent_modular_pipeline_id = _get_parent_modular_pipeline_id(modular_pipeline_id)
-        is_internal_input = (modular_pipeline_id in input_node.modular_pipelines) or (parent_modular_pipeline_id is not None and parent_modular_pipeline_id in input_node.modular_pipelines)
+
+        parent_modular_pipeline_id = _get_parent_modular_pipeline_id(
+            modular_pipeline_id
+        )
+        is_internal_input = (modular_pipeline_id in input_node.modular_pipelines) or (
+            parent_modular_pipeline_id is not None
+            and parent_modular_pipeline_id in input_node.modular_pipelines
+        )
 
         if is_internal_input:
             self.tree[modular_pipeline_id].internal_inputs.add(input_node.id)
@@ -172,9 +179,14 @@ class ModularPipelinesRepository:
             raise ValueError(
                 f"Attempt to add a non-data node as input to modular pipeline {modular_pipeline_id}"
             )
-            
-        parent_modular_pipeline_id = parent_modular_pipeline_id(modular_pipeline_id) 
-        is_internal_output = modular_pipeline_id in output_node.modular_pipelines or (parent_modular_pipeline_id is not None and parent_modular_pipeline_id in output_node.modular_pipelines)
+
+        parent_modular_pipeline_id = _get_parent_modular_pipeline_id(
+            modular_pipeline_id
+        )
+        is_internal_output = modular_pipeline_id in output_node.modular_pipelines or (
+            parent_modular_pipeline_id is not None
+            and parent_modular_pipeline_id in output_node.modular_pipelines
+        )
         if is_internal_output:
             self.tree[modular_pipeline_id].internal_outputs.add(output_node.id)
         else:


### PR DESCRIPTION
## Description

Resolves #1814 

## Development notes

There was a bug in the logic of modular pipelines. Essentially, datasets that served as inputs and outputs to nested modular pipelines (internal_inputs/internal_outputs to modular pipeline) were mistakenly treated as external_inputs/external_outputs to the modular pipeline. This occurred because we were only checking if datasets were internal by comparing them against the nested modular pipeline, neglecting to verify against the parent modular pipeline. Now, we check against both the nested modular pipeline and the parent modular pipeline to determine whether the dataset is either an internal input/output to the modular popular or external input/output. 



## QA notes

You can verify that the issue is resolved by comparing it to the pipeline example shared in issue #1814. 

Additionally, if you examine example number 2 in issue #1651, which includes a nested pipeline, you'll notice that the problem with 'main_pipeline.dataset_1' is fixed. Now, it's hidden inside the 'main_pipeline' node when viewed in collapsed mode.


## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes
