### PR TITLE
Fix TRANSCODING_SEPARATOR import errors

### DIFF
--- a/package/kedro_viz/data_access/repositories/catalog.py
+++ b/package/kedro_viz/data_access/repositories/catalog.py
@@ -1,11 +1,19 @@
 """`kedro_viz.data_access.repositories.catalog` defines interface to
 centralise access to Kedro data catalog."""
+
 # pylint: disable=missing-class-docstring,missing-function-docstring,protected-access
 import logging
 from typing import TYPE_CHECKING, Dict, Optional
 
 from kedro.io import DataCatalog
-from kedro.pipeline.pipeline import TRANSCODING_SEPARATOR, _strip_transcoding
+
+try:
+    # kedro 0.19.4 onwards
+    from kedro.pipeline._transcoding import TRANSCODING_SEPARATOR, _strip_transcoding
+except ImportError:  # pragma: no cover
+    # older versions
+    from kedro.pipeline.pipeline import TRANSCODING_SEPARATOR, _strip_transcoding
+
 from packaging.version import parse
 
 from kedro_viz.constants import KEDRO_VERSION

--- a/package/kedro_viz/integrations/kedro/hooks.py
+++ b/package/kedro_viz/integrations/kedro/hooks.py
@@ -11,7 +11,13 @@ from typing import Any, Union
 from kedro.framework.hooks import hook_impl
 from kedro.io import DataCatalog
 from kedro.io.core import get_filepath_str
-from kedro.pipeline.pipeline import TRANSCODING_SEPARATOR, _strip_transcoding
+
+try:
+    # kedro 0.19.4 onwards
+    from kedro.pipeline._transcoding import TRANSCODING_SEPARATOR, _strip_transcoding
+except ImportError:  # pragma: no cover
+    # older versions
+    from kedro.pipeline.pipeline import TRANSCODING_SEPARATOR, _strip_transcoding
 
 logger = logging.getLogger(__name__)
 

--- a/package/kedro_viz/models/flowchart.py
+++ b/package/kedro_viz/models/flowchart.py
@@ -11,7 +11,14 @@ from types import FunctionType
 from typing import Any, Dict, List, Optional, Set, Union, cast
 
 from kedro.pipeline.node import Node as KedroNode
-from kedro.pipeline.pipeline import TRANSCODING_SEPARATOR, _strip_transcoding
+
+try:
+    # kedro 0.19.4 onwards
+    from kedro.pipeline._transcoding import TRANSCODING_SEPARATOR, _strip_transcoding
+except ImportError:  # pragma: no cover
+    # older versions
+    from kedro.pipeline.pipeline import TRANSCODING_SEPARATOR, _strip_transcoding
+
 from pydantic import (
     BaseModel,
     ConfigDict,


### PR DESCRIPTION
## Description

Resolves #1865 

## Development notes

With the PR - https://github.com/kedro-org/kedro/pull/3812/files
TRANSCODING_SEPARATOR has been moved from kedro/pipeline/pipeline.py to kedro/pipeline/_transcoding.py. Since kedro-viz imports these, we need to handle the import error before the latest kedro release.

## QA notes

* All tests should pass

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes
