### PR TITLE
Update intersphinx_mapping of kedro-datasets

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -54,7 +54,7 @@ myst_heading_anchors = 2
 
 intersphinx_mapping = {
     "kedro": ("https://docs.kedro.org/en/stable/", None),
-    "kedro-datasets": ("https://docs.kedro.org/projects/kedro-datasets/en/kedro-datasets-1.7.1/", None),
+    "kedro-datasets": ("https://docs.kedro.org/projects/kedro-datasets/en/kedro-datasets-3.0.0/", None),
 }
 
 # -- Options for HTML output -------------------------------------------------


### PR DESCRIPTION
## Description
kedro-datasets 1.7.1 docs have been dropped and causing the builds to fail. We need to update the intersphinx mapping to the latest kedro-datasets docs version.

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes
