### PR TITLE
Switch `_transcoding` to `transcoding`

### DIFF
--- a/package/kedro_viz/data_access/repositories/catalog.py
+++ b/package/kedro_viz/data_access/repositories/catalog.py
@@ -9,7 +9,7 @@ from kedro.io import DataCatalog
 
 try:
     # kedro 0.19.4 onwards
-    from kedro.pipeline._transcoding import TRANSCODING_SEPARATOR, _strip_transcoding
+    from kedro.pipeline.transcoding import TRANSCODING_SEPARATOR, _strip_transcoding
 except ImportError:  # pragma: no cover
     # older versions
     from kedro.pipeline.pipeline import TRANSCODING_SEPARATOR, _strip_transcoding  # type: ignore

--- a/package/kedro_viz/integrations/kedro/hooks.py
+++ b/package/kedro_viz/integrations/kedro/hooks.py
@@ -14,7 +14,7 @@ from kedro.io.core import get_filepath_str
 
 try:
     # kedro 0.19.4 onwards
-    from kedro.pipeline._transcoding import TRANSCODING_SEPARATOR, _strip_transcoding
+    from kedro.pipeline.transcoding import TRANSCODING_SEPARATOR, _strip_transcoding
 except ImportError:  # pragma: no cover
     # older versions
     from kedro.pipeline.pipeline import (  # type: ignore

--- a/package/kedro_viz/models/flowchart.py
+++ b/package/kedro_viz/models/flowchart.py
@@ -14,7 +14,7 @@ from kedro.pipeline.node import Node as KedroNode
 
 try:
     # kedro 0.19.4 onwards
-    from kedro.pipeline._transcoding import TRANSCODING_SEPARATOR, _strip_transcoding
+    from kedro.pipeline.transcoding import TRANSCODING_SEPARATOR, _strip_transcoding
 except ImportError:  # pragma: no cover
     # older versions
     from kedro.pipeline.pipeline import TRANSCODING_SEPARATOR, _strip_transcoding  # type: ignore


### PR DESCRIPTION
## Description
I noticed the kedro-viz was throwing deprecation warnings for `TRANSCODING_SEPARATOR` when trying it with Kedro from the main branch - This is due to this PR https://github.com/kedro-org/kedro/pull/3826 This change will be released in Kedro 0.19.6 

## Development notes

<!-- What have you changed? Consider adding a screenshot or GIF. -->

## QA notes

<!-- How has the expected behaviour changed? What testing strategies have you used? -->

## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes
