### PR TITLE
Hot Fix: Added missing wheel package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,9 @@ jobs:
       - name: Setup Tests
         uses: "./.github/actions/setup_tests"
 
+      - name: Install wheel
+        run: pip install wheel
+
       - name: Make Python package
         run: make package
 


### PR DESCRIPTION
## Description

Hot fix for the releases 9.1.0: Adding missing python package `wheel` for publishing Kedro-Viz to PyPi via Github actions.   

## Development notes

Added a `pip install wheel` as step in release.yml workflow. 

## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes
