### PR TITLE
Refactor flowchart models for modular pipelines change

### DIFF
--- a/package/kedro_viz/models/flowchart.py
+++ b/package/kedro_viz/models/flowchart.py
@@ -459,8 +459,8 @@ class TaskNodeMetadata(GraphNodeMetadata):
         # if a node doesn't have a user-supplied `_name` attribute,
         # a human-readable run command `kedro run --to-nodes/nodes` is not available
         if cls.kedro_node._name is not None:
-            if cls.kedro_node.namespace is not None:
-                return f"kedro run --to-nodes={cls.kedro_node.namespace}.{cls.kedro_node._name}"
+            if cls.task_node.namespace is not None:
+                return f"kedro run --to-nodes={cls.task_node.namespace}.{cls.kedro_node._name}"
             return f"kedro run --to-nodes={cls.kedro_node._name}"
 
         return None

--- a/package/kedro_viz/models/flowchart.py
+++ b/package/kedro_viz/models/flowchart.py
@@ -161,7 +161,6 @@ class GraphNode(BaseModel, abc.ABC):
             tags=set(node.tags),
             kedro_obj=node,
             modular_pipelines=modular_pipelines,
-            namespace=node.namespace,
         )
 
     @classmethod
@@ -300,9 +299,6 @@ class TaskNode(GraphNode):
     # The type for Task node
     type: str = GraphNodeType.TASK.value
 
-    # In Kedro, modular pipeline is implemented by declaring namespace on a node.
-    # For example, node(func, namespace="uk.de") means this node belongs
-    # to the modular pipeline "uk" and "uk.de"
     namespace: Optional[str] = Field(
         default=None,
         validate_default=True,

--- a/package/kedro_viz/models/flowchart.py
+++ b/package/kedro_viz/models/flowchart.py
@@ -1,8 +1,7 @@
 """`kedro_viz.models.flowchart` defines data models to represent Kedro entities in a viz graph."""
 
-# pylint: disable=protected-access, missing-function-docstring, too-many-lines
+# pylint: disable=protected-access, missing-function-docstring
 import abc
-import hashlib
 import inspect
 import logging
 from enum import Enum
@@ -118,8 +117,8 @@ class GraphNode(BaseModel, abc.ABC):
                 for each graph node, if any. Defaults to `None`.
         pipelines (Set[str]): The set of registered pipeline IDs this
                 node belongs to. Defaults to `set()`.
-        namespace (Optional[str]): The original namespace on this node. Defaults to `None`.
-        modular_pipelines (Optional[List[str]]): The list of modular pipeline this node belongs to.
+        modular_pipelines (Optional[Set(str)]): A set of modular pipeline names
+                this node belongs to.
 
     """
 
@@ -136,94 +135,50 @@ class GraphNode(BaseModel, abc.ABC):
         set(), description="The set of registered pipeline IDs this node belongs to"
     )
 
-    # In Kedro, modular pipeline is implemented by declaring namespace on a node.
-    # For example, node(func, namespace="uk.de") means this node belongs
-    # to the modular pipeline "uk" and "uk.de"
-    namespace: Optional[str] = Field(
-        default=None,
-        validate_default=True,
-        description="The original namespace on this node",
-    )
-    modular_pipelines: Optional[List[str]] = Field(
+    modular_pipelines: Optional[Set[str]] = Field(
         default=None,
         validate_default=True,
         description="The modular_pipelines this node belongs to",
     )
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
-    @staticmethod
-    def _hash(value: str):
-        return hashlib.sha1(value.encode("UTF-8")).hexdigest()[:8]
-
-    @staticmethod
-    def _get_namespace(dataset_name: str) -> Optional[str]:
-        """Extract the namespace from the dataset/parameter name.
-        Args:
-            dataset_name: The name of the dataset.
-        Returns:
-            The namespace of this dataset, if available.
-        Example:
-            >>> GraphNode._get_namespace("pipeline.dataset")
-            'pipeline'
-        """
-        if "." not in dataset_name:
-            return None
-
-        return dataset_name.rsplit(".", 1)[0]
-
-    @staticmethod
-    def _expand_namespaces(namespace: Optional[str]) -> List[str]:
-        """Expand a node's namespace to the list of modular pipelines
-        that this node belongs to.
-        Args:
-            namespace: The namespace of the node.
-        Returns:
-            The list of modular pipelines that this node belongs to.
-        Example:
-            >>> GraphNode._expand_namespaces("pipeline1.data_science")
-            ['pipeline1', 'pipeline1.data_science']
-        """
-        if not namespace:
-            return []
-        namespace_list = []
-        namespace_chunks = namespace.split(".")
-        prefix = ""
-        for chunk in namespace_chunks:
-            if prefix:
-                prefix = f"{prefix}.{chunk}"
-            else:
-                prefix = chunk
-            namespace_list.append(prefix)
-        return namespace_list
-
     @classmethod
-    def create_task_node(cls, node: KedroNode) -> "TaskNode":
+    def create_task_node(
+        cls, node: KedroNode, node_id: str, modular_pipelines: Optional[Set[str]]
+    ) -> "TaskNode":
         """Create a graph node of type task for a given Kedro Node instance.
         Args:
             node: A node in a Kedro pipeline.
+            node_id: Id of the task node.
+            modular_pipelines: A set of modular_pipeline_ids the node belongs to.
         Returns:
             An instance of TaskNode.
         """
         node_name = node._name or node._func_name
         return TaskNode(
-            id=cls._hash(str(node)),
+            id=node_id,
             name=node_name,
             tags=set(node.tags),
             kedro_obj=node,
+            modular_pipelines=modular_pipelines,
+            namespace=node.namespace,
         )
 
     @classmethod
     def create_data_node(
         cls,
+        dataset_id: str,
         dataset_name: str,
         layer: Optional[str],
         tags: Set[str],
         dataset: AbstractDataset,
         stats: Optional[Dict],
+        modular_pipelines: Optional[Set[str]],
         is_free_input: bool = False,
     ) -> Union["DataNode", "TranscodedDataNode"]:
         """Create a graph node of type data for a given Kedro Dataset instance.
         Args:
+            dataset_id: A hashed id for the dataset node
             dataset_name: The name of the dataset, including namespace, e.g.
                 data_science.master_table.
             layer: The optional layer that the dataset belongs to.
@@ -232,6 +187,7 @@ class GraphNode(BaseModel, abc.ABC):
             dataset: A dataset in a Kedro pipeline.
             stats: The dictionary of dataset statistics, e.g.
                 {"rows":2, "columns":3, "file_size":100}
+            modular_pipelines: A set of modular_pipeline_ids the node belongs to.
             is_free_input: Whether the dataset is a free input in the pipeline
         Returns:
             An instance of DataNode.
@@ -240,49 +196,56 @@ class GraphNode(BaseModel, abc.ABC):
         if is_transcoded_dataset:
             name = _strip_transcoding(dataset_name)
             return TranscodedDataNode(
-                id=cls._hash(name),
+                id=dataset_id,
                 name=name,
                 tags=tags,
                 layer=layer,
                 is_free_input=is_free_input,
                 stats=stats,
+                modular_pipelines=modular_pipelines,
             )
 
         return DataNode(
-            id=cls._hash(dataset_name),
+            id=dataset_id,
             name=dataset_name,
             tags=tags,
             layer=layer,
             kedro_obj=dataset,
             is_free_input=is_free_input,
             stats=stats,
+            modular_pipelines=modular_pipelines,
         )
 
     @classmethod
     def create_parameters_node(
         cls,
+        dataset_id: str,
         dataset_name: str,
         layer: Optional[str],
         tags: Set[str],
         parameters: AbstractDataset,
+        modular_pipelines: Optional[Set[str]],
     ) -> "ParametersNode":
         """Create a graph node of type parameters for a given Kedro parameters dataset instance.
         Args:
+            dataset_id: A hashed id for the parameters node
             dataset_name: The name of the dataset, including namespace, e.g.
                 data_science.test_split_ratio
             layer: The optional layer that the parameters belong to.
             tags: The set of tags assigned to assign to the graph representation
                 of this dataset. N.B. currently it's derived from the node's tags.
             parameters: A parameters dataset in a Kedro pipeline.
+            modular_pipelines: A set of modular_pipeline_ids the node belongs to.
         Returns:
             An instance of ParametersNode.
         """
         return ParametersNode(
-            id=cls._hash(dataset_name),
+            id=dataset_id,
             name=dataset_name,
             tags=tags,
             layer=layer,
             kedro_obj=parameters,
+            modular_pipelines=modular_pipelines,
         )
 
     @classmethod
@@ -330,17 +293,21 @@ class TaskNode(GraphNode):
         AssertionError: If kedro_obj is not supplied during instantiation
     """
 
-    modular_pipelines: List[str] = Field(
-        default=[],
-        validate_default=True,
-        description="The modular pipelines this node belongs to",
-    )
     parameters: Dict = Field(
         {}, description="A dictionary of parameter values for the task node"
     )
 
     # The type for Task node
     type: str = GraphNodeType.TASK.value
+
+    # In Kedro, modular pipeline is implemented by declaring namespace on a node.
+    # For example, node(func, namespace="uk.de") means this node belongs
+    # to the modular pipeline "uk" and "uk.de"
+    namespace: Optional[str] = Field(
+        default=None,
+        validate_default=True,
+        description="The original namespace on this node",
+    )
 
     @model_validator(mode="before")
     @classmethod
@@ -352,11 +319,6 @@ class TaskNode(GraphNode):
     @classmethod
     def set_namespace(cls, _, info: ValidationInfo):
         return info.data["kedro_obj"].namespace
-
-    @field_validator("modular_pipelines")
-    @classmethod
-    def set_modular_pipelines(cls, _, info: ValidationInfo):
-        return cls._expand_namespaces(info.data["kedro_obj"].namespace)
 
 
 def _extract_wrapped_func(func: FunctionType) -> FunctionType:
@@ -378,7 +340,7 @@ class ModularPipelineNode(GraphNode):
     # in the same sense as other types of GraphNode do.
     # Therefore it's default to None.
     # The parent-child relationship between modular pipeline themselves is modelled explicitly.
-    modular_pipelines: Optional[List[str]] = None
+    modular_pipelines: Optional[Set[str]] = None
 
     # Model the modular pipelines tree using a child-references representation of a tree.
     # See: https://docs.mongodb.com/manual/tutorial/model-tree-structures-with-child-references/
@@ -389,50 +351,16 @@ class ModularPipelineNode(GraphNode):
         set(), description="The children for the modular pipeline node"
     )
 
-    # Keep track of a modular pipeline's inputs and outputs, both internal and external.
-    # Internal inputs/outputs are IDs of the datasets not connected to any nodes external
-    # to the pipeline.External inputs/outputs are IDs of the datasets used to connect
-    # this modular pipeline to other modular pipelines in the whole registered pipeline.
-    # In practical term, external inputs/outputs are the ones explicitly specified
-    # when using the pipeline() factory function.
-    # More information can be found here:
-    # https://kedro.readthedocs.io/en/latest/06_nodes_and_pipelines/03_modular_pipelines.html#how-to-connect-existing-pipelines
-    internal_inputs: Set[str] = Field(
-        set(), description="The dataset inputs within the modular pipeline node"
+    inputs: Set[str] = Field(
+        set(), description="The input datasets to the modular pipeline node"
     )
-    internal_outputs: Set[str] = Field(
-        set(), description="The dataset outputs within the modular pipeline node"
-    )
-    external_inputs: Set[str] = Field(
-        set(),
-        description="""The dataset inputs connecting the modular
-        pipeline node with other modular pipelines""",
-    )
-    external_outputs: Set[str] = Field(
-        set(),
-        description="""The dataset outputs connecting the modular
-        pipeline node with other modular pipelines""",
+
+    outputs: Set[str] = Field(
+        set(), description="The output datasets from the modular pipeline node"
     )
 
     # The type for Modular Pipeline Node
     type: str = GraphNodeType.MODULAR_PIPELINE.value
-
-    @property
-    def inputs(self) -> Set[str]:
-        """Return a set of inputs for this modular pipeline.
-        Visually, these are inputs displayed as the inputs of the modular pipeline,
-        both when collapsed and focused.
-        Intuitively, the set of inputs for this modular pipeline is the set of all
-        external and internal inputs, excluding the ones also serving as outputs.
-        """
-        return (self.external_inputs | self.internal_inputs) - self.internal_outputs
-
-    @property
-    def outputs(self) -> Set[str]:
-        """Return a set of inputs for this modular pipeline.
-        Follow the same logic as the inputs calculation.
-        """
-        return self.external_outputs | (self.internal_outputs - self.internal_inputs)
 
 
 class TaskNodeMetadata(GraphNodeMetadata):
@@ -531,8 +459,8 @@ class TaskNodeMetadata(GraphNodeMetadata):
         # if a node doesn't have a user-supplied `_name` attribute,
         # a human-readable run command `kedro run --to-nodes/nodes` is not available
         if cls.kedro_node._name is not None:
-            if cls.task_node.namespace is not None:
-                return f"kedro run --to-nodes={cls.task_node.namespace}.{cls.kedro_node._name}"
+            if cls.kedro_node.namespace is not None:
+                return f"kedro run --to-nodes={cls.kedro_node.namespace}.{cls.kedro_node._name}"
             return f"kedro run --to-nodes={cls.kedro_node._name}"
 
         return None
@@ -575,12 +503,6 @@ class DataNode(GraphNode):
         description="The concrete type of the underlying kedro_obj",
     )
 
-    modular_pipelines: List[str] = Field(
-        default=[],
-        validate_default=True,
-        description="The modular pipelines this node belongs to",
-    )
-
     viz_metadata: Optional[Dict] = Field(
         default=None, validate_default=True, description="The metadata for data node"
     )
@@ -603,26 +525,6 @@ class DataNode(GraphNode):
     def set_dataset_type(cls, _, info: ValidationInfo):
         kedro_obj = cast(AbstractDataset, info.data.get("kedro_obj"))
         return get_dataset_type(kedro_obj)
-
-    @field_validator("namespace")
-    @classmethod
-    def set_namespace(cls, _, info: ValidationInfo):
-        assert "name" in info.data
-
-        # the modular pipelines that a data node belongs to
-        # are derived from its namespace, which in turn
-        # is derived from the dataset's name.
-        name = info.data.get("name")
-        return cls._get_namespace(str(name))
-
-    @field_validator("modular_pipelines")
-    @classmethod
-    def set_modular_pipelines(cls, _, info: ValidationInfo):
-        assert "name" in info.data
-
-        name = info.data.get("name")
-        namespace = cls._get_namespace(str(name))
-        return cls._expand_namespaces(namespace)
 
     @field_validator("viz_metadata")
     @classmethod
@@ -675,12 +577,6 @@ class TranscodedDataNode(GraphNode):
         None, description="The original name for the generated run command"
     )
 
-    modular_pipelines: List[str] = Field(
-        default=[],
-        validate_default=True,
-        description="The modular pipelines this node belongs to",
-    )
-
     run_command: Optional[str] = Field(
         None, description="The command to run the pipeline to this node"
     )
@@ -691,26 +587,6 @@ class TranscodedDataNode(GraphNode):
 
     # The type for data node
     type: str = GraphNodeType.DATA.value
-
-    @field_validator("namespace")
-    @classmethod
-    def set_namespace(cls, _, info: ValidationInfo):
-        assert "name" in info.data
-
-        # the modular pipelines that a data node belongs to
-        # are derived from its namespace, which in turn
-        # is derived from the dataset's name.
-        name = info.data.get("name")
-        return cls._get_namespace(str(name))
-
-    @field_validator("modular_pipelines")
-    @classmethod
-    def set_modular_pipelines(cls, _, info: ValidationInfo):
-        assert "name" in info.data
-
-        name = info.data.get("name")
-        namespace = cls._get_namespace(str(name))
-        return cls._expand_namespaces(namespace)
 
     def has_metadata(self) -> bool:
         return True
@@ -964,10 +840,6 @@ class ParametersNode(GraphNode):
         None, description="The layer that this parameters node belongs to"
     )
 
-    modular_pipelines: List[str] = Field(
-        [], description="The modular pipelines this node belongs to"
-    )
-
     # The type for Parameters Node
     type: str = GraphNodeType.PARAMETERS.value
 
@@ -977,18 +849,6 @@ class ParametersNode(GraphNode):
         assert "kedro_obj" in values
         assert "name" in values
         return values
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-        if self.is_all_parameters():
-            self.namespace = None
-            self.modular_pipelines = []
-        else:
-            self.namespace = self._get_namespace(self.parameter_name)
-            self.modular_pipelines = self._expand_namespaces(
-                self._get_namespace(self.parameter_name)
-            )
 
     def is_all_parameters(self) -> bool:
         """Check whether the graph node represent all parameters in the pipeline"""

--- a/package/tests/test_models/test_flowchart.py
+++ b/package/tests/test_models/test_flowchart.py
@@ -91,6 +91,7 @@ class TestGraphNodeCreation:
         assert task_node.tags == {"tag"}
         assert task_node.pipelines == set()
         assert task_node.modular_pipelines == expected_modular_pipelines
+        assert task_node.namespace == namespace
 
     @pytest.mark.parametrize(
         "dataset_name, expected_modular_pipelines",

--- a/package/tests/test_models/test_flowchart.py
+++ b/package/tests/test_models/test_flowchart.py
@@ -60,14 +60,16 @@ class TestGraphNodeCreation:
     @pytest.mark.parametrize(
         "namespace,expected_modular_pipelines",
         [
-            (None, []),
+            (None, set()),
             (
                 "uk.data_science.model_training",
-                [
-                    "uk",
-                    "uk.data_science",
-                    "uk.data_science.model_training",
-                ],
+                set(
+                    [
+                        "uk",
+                        "uk.data_science",
+                        "uk.data_science.model_training",
+                    ]
+                ),
             ),
         ],
     )
@@ -80,10 +82,11 @@ class TestGraphNodeCreation:
             tags={"tag"},
             namespace=namespace,
         )
-        task_node = GraphNode.create_task_node(kedro_node)
+        task_node = GraphNode.create_task_node(
+            kedro_node, "identity_node", expected_modular_pipelines
+        )
         assert isinstance(task_node, TaskNode)
         assert task_node.kedro_obj is kedro_node
-        assert task_node.id == GraphNode._hash(str(kedro_node))
         assert task_node.name == "identity_node"
         assert task_node.tags == {"tag"}
         assert task_node.pipelines == set()
@@ -92,29 +95,33 @@ class TestGraphNodeCreation:
     @pytest.mark.parametrize(
         "dataset_name, expected_modular_pipelines",
         [
-            ("dataset", []),
+            ("dataset", set()),
             (
                 "uk.data_science.model_training.dataset",
-                [
-                    "uk",
-                    "uk.data_science",
-                    "uk.data_science.model_training",
-                ],
+                set(
+                    [
+                        "uk",
+                        "uk.data_science",
+                        "uk.data_science.model_training",
+                    ]
+                ),
             ),
         ],
     )
     def test_create_data_node(self, dataset_name, expected_modular_pipelines):
         kedro_dataset = CSVDataset(filepath="foo.csv")
         data_node = GraphNode.create_data_node(
+            dataset_id=dataset_name,
             dataset_name=dataset_name,
             layer="raw",
             tags=set(),
             dataset=kedro_dataset,
             stats={"rows": 10, "columns": 5, "file_size": 1024},
+            modular_pipelines=set(expected_modular_pipelines),
         )
         assert isinstance(data_node, DataNode)
         assert data_node.kedro_obj is kedro_dataset
-        assert data_node.id == GraphNode._hash(dataset_name)
+        assert data_node.id == dataset_name
         assert data_node.name == dataset_name
         assert data_node.layer == "raw"
         assert data_node.tags == set()
@@ -137,14 +144,16 @@ class TestGraphNodeCreation:
     def test_create_transcoded_data_node(self, transcoded_dataset_name, original_name):
         kedro_dataset = CSVDataset(filepath="foo.csv")
         data_node = GraphNode.create_data_node(
+            dataset_id=original_name,
             dataset_name=transcoded_dataset_name,
             layer="raw",
             tags=set(),
             dataset=kedro_dataset,
             stats={"rows": 10, "columns": 2, "file_size": 1048},
+            modular_pipelines=set(),
         )
         assert isinstance(data_node, TranscodedDataNode)
-        assert data_node.id == GraphNode._hash(original_name)
+        assert data_node.id == original_name
         assert data_node.name == original_name
         assert data_node.layer == "raw"
         assert data_node.tags == set()
@@ -158,14 +167,16 @@ class TestGraphNodeCreation:
             data={"test_split_ratio": 0.3, "num_epochs": 1000}
         )
         parameters_node = GraphNode.create_parameters_node(
+            dataset_id="parameters",
             dataset_name="parameters",
             layer=None,
             tags=set(),
             parameters=parameters_dataset,
+            modular_pipelines=set(),
         )
         assert isinstance(parameters_node, ParametersNode)
         assert parameters_node.kedro_obj is parameters_dataset
-        assert parameters_node.id == GraphNode._hash("parameters")
+        assert parameters_node.id == "parameters"
         assert parameters_node.is_all_parameters()
         assert not parameters_node.is_single_parameter()
         assert parameters_node.parameter_value == {
@@ -177,10 +188,10 @@ class TestGraphNodeCreation:
     @pytest.mark.parametrize(
         "dataset_name,expected_modular_pipelines",
         [
-            ("params:test_split_ratio", []),
+            ("params:test_split_ratio", set()),
             (
                 "params:uk.data_science.model_training.test_split_ratio",
-                ["uk", "uk.data_science", "uk.data_science.model_training"],
+                set(["uk", "uk.data_science", "uk.data_science.model_training"]),
             ),
         ],
     )
@@ -189,10 +200,12 @@ class TestGraphNodeCreation:
     ):
         parameters_dataset = MemoryDataset(data=0.3)
         parameters_node = GraphNode.create_parameters_node(
+            dataset_id=dataset_name,
             dataset_name=dataset_name,
             layer=None,
             tags=set(),
             parameters=parameters_dataset,
+            modular_pipelines=expected_modular_pipelines,
         )
         assert isinstance(parameters_node, ParametersNode)
         assert parameters_node.kedro_obj is parameters_dataset
@@ -204,7 +217,12 @@ class TestGraphNodeCreation:
     def test_create_non_existing_parameter_node(self):
         """Test the case where ``parameters`` is equal to None"""
         parameters_node = GraphNode.create_parameters_node(
-            dataset_name="non_existing", layer=None, tags=set(), parameters=None
+            dataset_id="non_existing",
+            dataset_name="non_existing",
+            layer=None,
+            tags=set(),
+            parameters=None,
+            modular_pipelines=set(),
         )
         assert isinstance(parameters_node, ParametersNode)
         assert parameters_node.parameter_value is None
@@ -214,10 +232,12 @@ class TestGraphNodeCreation:
         """Test the case where ``parameters`` is equal to a MemoryDataset with no data"""
         parameters_dataset = MemoryDataset()
         parameters_node = GraphNode.create_parameters_node(
+            dataset_id="non_existing",
             dataset_name="non_existing",
             layer=None,
             tags=set(),
             parameters=parameters_dataset,
+            modular_pipelines=set(),
         )
         assert parameters_node.parameter_value is None
         patched_warning.assert_has_calls(
@@ -239,11 +259,13 @@ class TestGraphNodePipelines:
         another_pipeline = RegisteredPipeline(id="testing")
         kedro_dataset = CSVDataset(filepath="foo.csv")
         data_node = GraphNode.create_data_node(
+            dataset_id="dataset@transcoded",
             dataset_name="dataset@transcoded",
             layer="raw",
             tags=set(),
             dataset=kedro_dataset,
             stats={"rows": 10, "columns": 2, "file_size": 1048},
+            modular_pipelines=set(),
         )
         assert data_node.pipelines == set()
         data_node.add_pipeline(default_pipeline.id)
@@ -257,7 +279,13 @@ class TestGraphNodeMetadata:
     )
     def test_node_has_metadata(self, dataset, has_metadata):
         data_node = GraphNode.create_data_node(
-            "test_dataset", layer=None, tags=set(), dataset=dataset, stats=None
+            "test_dataset",
+            "test_dataset",
+            layer=None,
+            tags=set(),
+            dataset=dataset,
+            stats=None,
+            modular_pipelines=set(),
         )
         assert data_node.has_metadata() == has_metadata
 
@@ -270,7 +298,9 @@ class TestGraphNodeMetadata:
             tags={"tag"},
             namespace="namespace",
         )
-        task_node = GraphNode.create_task_node(kedro_node)
+        task_node = GraphNode.create_task_node(
+            kedro_node, "identity_node", set(["namespace"])
+        )
         task_node_metadata = TaskNodeMetadata(task_node=task_node)
         assert task_node_metadata.code == dedent(
             """\
@@ -295,7 +325,7 @@ class TestGraphNodeMetadata:
             name="identity_node",
             tags={"tag"},
         )
-        task_node = GraphNode.create_task_node(kedro_node)
+        task_node = GraphNode.create_task_node(kedro_node, "identity_node", set())
         task_node_metadata = TaskNodeMetadata(task_node=task_node)
         assert task_node_metadata.code == dedent(
             """\
@@ -317,7 +347,9 @@ class TestGraphNodeMetadata:
             tags={"tag"},
             namespace="namespace",
         )
-        task_node = GraphNode.create_task_node(kedro_node)
+        task_node = GraphNode.create_task_node(
+            kedro_node, "identity_node", set(["namespace"])
+        )
         task_node_metadata = TaskNodeMetadata(task_node=task_node)
         assert task_node_metadata.run_command is None
 
@@ -330,7 +362,9 @@ class TestGraphNodeMetadata:
             tags={"tag"},
             namespace="namespace",
         )
-        task_node = GraphNode.create_task_node(kedro_node)
+        task_node = GraphNode.create_task_node(
+            kedro_node, "identity_node", set(["namespace"])
+        )
         task_node_metadata = TaskNodeMetadata(task_node=task_node)
         assert task_node_metadata.code == dedent(
             """\
@@ -352,7 +386,9 @@ class TestGraphNodeMetadata:
             tags={"tag"},
             namespace="namespace",
         )
-        task_node = GraphNode.create_task_node(kedro_node)
+        task_node = GraphNode.create_task_node(
+            kedro_node, "<partial>", set(["namespace"])
+        )
         task_node_metadata = TaskNodeMetadata(task_node=task_node)
         assert task_node.name == "<partial>"
         assert task_node_metadata.code is None
@@ -364,11 +400,13 @@ class TestGraphNodeMetadata:
     def test_data_node_metadata(self):
         dataset = CSVDataset(filepath="/tmp/dataset.csv")
         data_node = GraphNode.create_data_node(
+            dataset_id="dataset",
             dataset_name="dataset",
             layer="raw",
             tags=set(),
             dataset=dataset,
             stats={"rows": 10, "columns": 2},
+            modular_pipelines=set(),
         )
         data_node_metadata = DataNodeMetadata(data_node=data_node)
         assert data_node_metadata.type == "pandas.csv_dataset.CSVDataset"
@@ -382,7 +420,13 @@ class TestGraphNodeMetadata:
         metadata = {"kedro-viz": {"preview_args": {"nrows": 3}}}
         dataset = CSVDataset(filepath="test.csv", metadata=metadata)
         data_node = GraphNode.create_data_node(
-            dataset_name="dataset", tags=set(), layer=None, dataset=dataset, stats=None
+            dataset_id="dataset",
+            dataset_name="dataset",
+            tags=set(),
+            layer=None,
+            dataset=dataset,
+            stats=None,
+            modular_pipelines=set(),
         )
         assert data_node.get_preview_args() == {"nrows": 3}
 
@@ -390,7 +434,13 @@ class TestGraphNodeMetadata:
         metadata = {"kedro-viz": {"preview": False}}
         dataset = CSVDataset(filepath="test.csv", metadata=metadata)
         data_node = GraphNode.create_data_node(
-            dataset_name="dataset", tags=set(), layer=None, dataset=dataset, stats=None
+            dataset_id="dataset",
+            dataset_name="dataset",
+            tags=set(),
+            layer=None,
+            dataset=dataset,
+            stats=None,
+            modular_pipelines=set(),
         )
         assert data_node.is_preview_enabled() is False
 
@@ -421,11 +471,13 @@ class TestGraphNodeMetadata:
         empty_dataset = CSVDataset(filepath="temp.csv")
         dataset_name = "dataset"
         empty_data_node = GraphNode.create_data_node(
+            dataset_id=dataset_name,
             dataset_name=dataset_name,
             tags=set(),
             layer=None,
             dataset=empty_dataset,
             stats=None,
+            modular_pipelines=set(),
         )
 
         DataNodeMetadata(data_node=empty_data_node)
@@ -461,11 +513,13 @@ class TestGraphNodeMetadata:
     def test_transcoded_data_node_metadata(self):
         dataset = CSVDataset(filepath="/tmp/dataset.csv")
         transcoded_data_node = GraphNode.create_data_node(
+            dataset_id="dataset@pandas2",
             dataset_name="dataset@pandas2",
             layer="raw",
             tags=set(),
             dataset=dataset,
             stats={"rows": 10, "columns": 2},
+            modular_pipelines=set(),
         )
         transcoded_data_node.original_name = "dataset"
         transcoded_data_node.original_version = ParquetDataset(filepath="foo.parquet")
@@ -488,11 +542,13 @@ class TestGraphNodeMetadata:
     def test_partitioned_data_node_metadata(self):
         dataset = PartitionedDataset(path="partitioned/", dataset="pandas.CSVDataset")
         data_node = GraphNode.create_data_node(
+            dataset_id="dataset",
             dataset_name="dataset",
             layer="raw",
             tags=set(),
             dataset=dataset,
             stats=None,
+            modular_pipelines=set(),
         )
         data_node_metadata = DataNodeMetadata(data_node=data_node)
         assert data_node_metadata.filepath == "partitioned/"
@@ -501,10 +557,12 @@ class TestGraphNodeMetadata:
         parameters = {"test_split_ratio": 0.3, "num_epochs": 1000}
         parameters_dataset = MemoryDataset(data=parameters)
         parameters_node = GraphNode.create_parameters_node(
+            dataset_id="parameters",
             dataset_name="parameters",
             layer=None,
             tags=set(),
             parameters=parameters_dataset,
+            modular_pipelines=set(),
         )
         parameters_node_metadata = ParametersNodeMetadata(
             parameters_node=parameters_node
@@ -514,10 +572,12 @@ class TestGraphNodeMetadata:
     def test_parameters_metadata_single_parameter(self):
         parameters_dataset = MemoryDataset(data=0.3)
         parameters_node = GraphNode.create_parameters_node(
+            dataset_id="params:test_split_ratio",
             dataset_name="params:test_split_ratio",
             layer=None,
             tags=set(),
             parameters=parameters_dataset,
+            modular_pipelines=set(),
         )
         parameters_node_metadata = ParametersNodeMetadata(
             parameters_node=parameters_node


### PR DESCRIPTION
## Description

Partially resolves - #1899 

## Development notes

* Removes `namespace` property from GraphNode and retain the property only for TaskNode following Kedro Framework
* The data type of `modular pipelines` is changed to `Optional[Set(str)]`
* Updated all the `create_node` class methods like (create_task_node, create_data_node, create_parameters_node etc) to accept modular_pipelines parameter as we are populating modular pipelines before creating the nodes and associating each node with the associated modular pipeline during node creation.
* Remove `internal_inputs/outputs` and `external_inputs/outputs` from ModularPipelineNode. We will only have inputs/outputs for a ModularPipelineNode (i.e., the datasets which are free inputs/outputs as per Kedro)
* Update tests

## QA notes

* This PR is part of a bigger refactor (https://github.com/kedro-org/kedro-viz/pull/1897) of modular pipelines and is created to ease review process.
* The CI build might fail as this PR is not self-sufficient

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [x] Added tests to cover my changes
