### PR TITLE
Refactor data access repositories for modular pipeline change

### DIFF
--- a/package/kedro_viz/data_access/repositories/catalog.py
+++ b/package/kedro_viz/data_access/repositories/catalog.py
@@ -144,10 +144,3 @@ class CatalogRepository:
             for dataset_name in self._catalog.list()
             if self.get_dataset(dataset_name) is not None
         }
-
-    @staticmethod
-    def is_dataset_param(dataset_name: str) -> bool:
-        """Return whether a dataset is a parameter"""
-        return (
-            dataset_name.lower().startswith("params:") or dataset_name == "parameters"
-        )

--- a/package/kedro_viz/data_access/repositories/modular_pipelines.py
+++ b/package/kedro_viz/data_access/repositories/modular_pipelines.py
@@ -1,11 +1,12 @@
 """`kedro_viz.data_access.repositories.modular_pipelines` defines
 repository to centralise access for modular pipelines data."""
 
-import hashlib
+
+from collections import defaultdict
 from typing import Dict, List, Set, Tuple, Union
 
 from kedro.pipeline import Pipeline as KedroPipeline
-from kedro.pipeline.node import Node
+from kedro.pipeline.node import Node as KedroNode
 
 from kedro_viz.constants import ROOT_MODULAR_PIPELINE_ID
 from kedro_viz.models.flowchart import (
@@ -14,20 +15,7 @@ from kedro_viz.models.flowchart import (
     ModularPipelineChild,
     ModularPipelineNode,
 )
-from kedro_viz.utils import TRANSCODING_SEPARATOR, _strip_transcoding, is_dataset_param
-
-
-def _hash(value: str):
-    return hashlib.sha1(value.encode("UTF-8")).hexdigest()[:8]
-
-
-def _hash_input_output(item: str) -> str:
-    """Hash the input/output dataset."""
-    return (
-        _hash(_strip_transcoding(item))
-        if TRANSCODING_SEPARATOR in item
-        else _hash(item)
-    )
+from kedro_viz.utils import _hash, _hash_input_output, is_dataset_param
 
 
 class ModularPipelinesRepository:
@@ -45,10 +33,7 @@ class ModularPipelinesRepository:
                 ROOT_MODULAR_PIPELINE_ID
             )
         }
-        self.node_mod_pipeline_map: Dict[
-            str, Set[str]
-        ] = {}  # Updated to map node_id to a set of modular_pipeline_ids
-
+        self.node_mod_pipeline_map = defaultdict(set)
         self.parameters = set()
 
     def populate_tree(self, pipeline: KedroPipeline) -> None:
@@ -60,29 +45,41 @@ class ModularPipelinesRepository:
         Args:
             pipeline (KedroPipeline): The Kedro pipeline to populate the tree from.
         """
+
+        # Extract namespaces from the nodes in the pipeline
         namespaces = sorted(
             {node.namespace for node in pipeline.nodes if node.namespace}
         )
 
+        # Get all modular pipeline IDs by exploding namespaces
         modular_pipeline_ids = {
             modular_pipeline_id
             for ns in namespaces
             for modular_pipeline_id in self._explode_namespace(ns)
         }
 
+        # Create and populate each modular pipeline
         for modular_pipeline_id in sorted(modular_pipeline_ids):
             self.get_or_create_modular_pipeline(modular_pipeline_id)
 
+            # Extract nodes within the current namespace to form a sub_pipeline
             sub_pipeline = pipeline.only_nodes_with_namespace(modular_pipeline_id)
             rest_of_the_pipeline = pipeline - sub_pipeline
 
+            # Identify free inputs of the sub_pipeline
             free_inputs = sub_pipeline.inputs()
+
+            # Identify free outputs of the sub_pipeline, including intermediary outputs
             free_outputs = sub_pipeline.outputs() | (
                 rest_of_the_pipeline.inputs() & sub_pipeline.all_outputs()
             )
 
+            # Add identified inputs and outputs to the modular pipeline
             self._add_inputs(modular_pipeline_id, free_inputs)
             self._add_outputs(modular_pipeline_id, free_outputs)
+
+            # Add nodes(and datasets of that node) of the sub_pipeline as
+            # children to the modular pipeline
             self._add_children(modular_pipeline_id, sub_pipeline.nodes)
 
     @staticmethod
@@ -165,162 +162,146 @@ class ModularPipelinesRepository:
         hashed_outputs = {_hash_input_output(output) for output in outputs}
         self.tree[modular_pipeline_id].outputs = hashed_outputs
 
-    def _add_children(self, modular_pipeline_id: str, kedro_nodes: List[Node]):
+    def _add_children(self, modular_pipeline_id: str, kedro_nodes: List[KedroNode]):
         """
         Add children to a modular pipeline. Here we follow the below rules
         - A kedro node is added as a child to a modular pipeline if
-          it has the namespace of that modular pipeline
+        it has the namespace of that modular pipeline
         - Inputs/Outputs of a kedro node are added as children
-          to the modular pipeline if they are not inputs/outputs
-          of that modular pipeline and are not parameter datasets
+        to the modular pipeline if they are not inputs/outputs
+        of that modular pipeline and are not parameter datasets
         - Any input/output of a modular pipeline is a child
-          of the parent pipeline unless it is an input/output
-          of that parent pipeline
+        of the parent pipeline unless it is an input/output
+        of that parent pipeline
         - Any input/output of a top-level modular pipeline is added
-          as a child to the root modular pipeline
+        as a child to the root modular pipeline
 
         Args:
             modular_pipeline_id (str): The ID of the modular pipeline to add children to.
-            kedro_nodes (List[Node]): The kedro nodes (and it's related datasets/parameters)
+            kedro_nodes (List[KedroNode]): The kedro nodes (and it's related datasets/parameters)
                     to add as children.
         """
         modular_pipeline = self.get_or_create_modular_pipeline(modular_pipeline_id)
-        modular_pipeline_inputs_outputs = set(modular_pipeline.inputs) | set(
+        modular_pipeline_inputs_outputs = set(modular_pipeline.inputs).union(
             modular_pipeline.outputs
         )
 
-        for kedro_node in kedro_nodes:
-            # add kedro node as a child to the modular pipeline
-            if kedro_node.namespace == modular_pipeline_id:
-                kedro_node_id = _hash(str(kedro_node))
-                modular_pipeline.children.add(
-                    ModularPipelineChild(id=kedro_node_id, type=GraphNodeType.TASK)
-                )
+        # Filter nodes that belong to the current modular pipeline
+        filtered_kedro_nodes = [
+            node for node in kedro_nodes if node.namespace == modular_pipeline_id
+        ]
 
-                modular_pipeline.tags.update(kedro_node.tags)
-
-                # add input/output datasets of a kedro node as a child
-                # to the modular pipeline
-                self._add_datasets_as_children(
-                    modular_pipeline, kedro_node, modular_pipeline_inputs_outputs
-                )
-
-                # update node_modular_pipeline lookup
-                if kedro_node_id not in self.node_mod_pipeline_map:
-                    self.node_mod_pipeline_map[kedro_node_id] = set()
-                self.node_mod_pipeline_map[kedro_node_id].add(modular_pipeline_id)
-
-        # The line `parent_modular_pipeline_id = ('.'.join(modular_pipeline_id.split('.')[:-1])
-        # if '.' in modular_pipeline_id else None)` is extracting the parent modular pipeline ID
-        # from the given modular pipeline ID.
-        parent_modular_pipeline_id = (
-            ".".join(modular_pipeline_id.split(".")[:-1])
-            if "." in modular_pipeline_id
-            else None
+        # Add filtered kedro nodes and their related datasets as children to the modular pipeline
+        self._add_nodes_and_datasets_as_children(
+            modular_pipeline, filtered_kedro_nodes, modular_pipeline_inputs_outputs
+        )
+        self._add_children_to_parent_pipeline(
+            modular_pipeline, modular_pipeline_id, modular_pipeline_inputs_outputs
         )
 
-        if parent_modular_pipeline_id:
-            parent_modular_pipeline = self.get_or_create_modular_pipeline(
-                parent_modular_pipeline_id
-            )
-            parent_modular_pipeline.pipelines.update(modular_pipeline.pipelines)
-            parent_modular_pipeline.tags.update(modular_pipeline.tags)
+    def _add_nodes_and_datasets_as_children(
+        self,
+        modular_pipeline: ModularPipelineNode,
+        kedro_nodes: List[KedroNode],
+        modular_pipeline_inputs_outputs: Set[str],
+    ):
+        """
+        Add Kedro nodes and their related datasets as children to the modular pipeline.
 
-            # add current modular pipeline and input/output datasets
-            # of a modular pipeline as a child to the parent modular
-            # pipeline based on the rules
-            self._add_children_to_parent_pipeline(
-                parent_modular_pipeline,
-                modular_pipeline_id,
-                modular_pipeline_inputs_outputs,
+        Datasets (inputs/outputs) are added if they are not already inputs/outputs of
+        the modular pipeline and are not parameter datasets.
+        """
+
+        for node in kedro_nodes:
+            node_id = _hash(str(node))
+            modular_pipeline.children.add(
+                ModularPipelineChild(id=node_id, type=GraphNodeType.TASK)
             )
-        else:
-            # add current modular pipeline and input/output datasets
-            # of a top-level modular pipeline as a child to ROOT modular
-            # pipeline
-            self._add_children_to_parent_pipeline(
-                self.tree[ROOT_MODULAR_PIPELINE_ID],
-                modular_pipeline_id,
-                modular_pipeline_inputs_outputs,
+            modular_pipeline.tags.update(node.tags)
+
+            hashed_io_ids = {
+                _hash_input_output(io) for io in set(node.inputs).union(node.outputs)
+            }
+
+            # Compute valid input/output IDs that are not part of the modular pipeline
+            # inputs/outputs or parameters
+            valid_io_ids = hashed_io_ids.difference(
+                modular_pipeline_inputs_outputs, self.parameters
             )
+
+            # Add each valid input/output as a child to the modular pipeline
+            for io_id in valid_io_ids:
+                modular_pipeline.children.add(
+                    ModularPipelineChild(id=io_id, type=GraphNodeType.DATA)
+                )
+                self.node_mod_pipeline_map[io_id].add(modular_pipeline.id)
+
+            self.node_mod_pipeline_map[node_id].add(modular_pipeline.id)
 
     def _add_children_to_parent_pipeline(
         self,
-        parent_node: ModularPipelineNode,
+        modular_pipeline: ModularPipelineNode,
         modular_pipeline_id: str,
         modular_pipeline_inputs_outputs: Set[str],
     ):
         """
-        Helper to add modular_pipeline children correctly to
-        parent modular pipelines in case of nesting.
+        Helper to add modular_pipeline children correctly to parent modular pipelines
+        in case of nesting.
 
         Here we follow the below rules:
-        - A modular pipeline is a child of it's parent modular pipeline
+        - A modular pipeline is a child of its parent modular pipeline
         - Any input/output of a modular pipeline is a child of the parent pipeline
-          unless it is an input/output of that parent pipeline or a parameter dataset
-        - Any input/output of a top-level modular pipeline is added as a child
-          to the root modular pipeline
+        unless it is an input/output of that parent pipeline or a parameter dataset
+        - Any input/output of a top-level modular pipeline is added as a child to
+        the root modular pipeline
 
         Args:
-            parent_node (ModularPipelineNode): The parent modular pipeline node.
+            modular_pipeline (ModularPipelineNode): The modular pipeline node.
             modular_pipeline_id (str): The ID of the modular pipeline to add as a child.
-            modular_pipeline_inputs_outputs (Set[str]): A set of inputs/outputs
-                    to/from the modular pipeline
+            modular_pipeline_inputs_outputs (Set[str]): A set of inputs/outputs to/from
+            the modular pipeline.
         """
+        # Determine the parent modular pipeline ID
+        parent_modular_pipeline_id = (
+            ".".join(modular_pipeline_id.split(".")[:-1])
+            if "." in modular_pipeline_id
+            else ROOT_MODULAR_PIPELINE_ID
+        )
 
-        parent_node.children.add(
+        # Get or create the parent modular pipeline
+        parent_modular_pipeline = self.get_or_create_modular_pipeline(
+            parent_modular_pipeline_id
+        )
+
+        # Add the modular pipeline as a child to the parent modular pipeline
+        parent_modular_pipeline.children.add(
             ModularPipelineChild(
                 id=modular_pipeline_id, type=GraphNodeType.MODULAR_PIPELINE
             )
         )
+        parent_modular_pipeline.pipelines.update(modular_pipeline.pipelines)
+        parent_modular_pipeline.tags.update(modular_pipeline.tags)
+
+        # Add input/output datasets as children to the parent modular pipeline
         for dataset in modular_pipeline_inputs_outputs:
             if (
-                dataset not in parent_node.inputs
-                and dataset not in parent_node.outputs
+                dataset not in parent_modular_pipeline.inputs
+                and dataset not in parent_modular_pipeline.outputs
                 and dataset not in self.parameters
             ):
-                parent_node.children.add(
+                parent_modular_pipeline.children.add(
                     ModularPipelineChild(id=dataset, type=GraphNodeType.DATA)
                 )
-            if dataset not in self.node_mod_pipeline_map:
-                self.node_mod_pipeline_map[dataset] = set()
             self.node_mod_pipeline_map[dataset].add(modular_pipeline_id)
-
-    def _add_datasets_as_children(
-        self,
-        modular_pipeline: ModularPipelineNode,
-        kedro_node: Node,
-        modular_pipeline_inputs_outputs: Set[str],
-    ):
-        """Helper to add datasets (not parameters) related to task nodes as children.
-
-        Here we follow the below rule:
-        - Inputs/Outputs of a task node are added as children
-          to the modular pipeline if they are not inputs/outputs
-          of that modular pipeline and are not parameter datasets
-        """
-        hashed_io_ids = {
-            _hash_input_output(io)
-            for io in set(kedro_node.inputs) | set(kedro_node.outputs)
-        }
-        for io_id in hashed_io_ids:
-            if (
-                io_id not in modular_pipeline_inputs_outputs
-                and io_id not in self.parameters
-            ):
-                modular_pipeline.children.add(
-                    ModularPipelineChild(id=io_id, type=GraphNodeType.DATA)
-                )
-                if io_id not in self.node_mod_pipeline_map:
-                    self.node_mod_pipeline_map[io_id] = set()
-                self.node_mod_pipeline_map[io_id].add(modular_pipeline.id)
 
     def get_node_and_modular_pipeline_mapping(
         self, node
     ) -> Tuple[str, Union[Set[str], None]]:
-        """Get the modular pipeline(s) to which the given node belongs."""
+        """Get the modular pipeline(s) to which the given task node/or dataset belongs."""
         node_id = (
-            _hash_input_output(node) if isinstance(node, str) else _hash(str(node))
+            _hash(str(node))
+            if isinstance(node, KedroNode)
+            else _hash_input_output(node)
         )
         return node_id, self.node_mod_pipeline_map.get(node_id)
 

--- a/package/kedro_viz/data_access/repositories/modular_pipelines.py
+++ b/package/kedro_viz/data_access/repositories/modular_pipelines.py
@@ -217,16 +217,18 @@ class ModularPipelinesRepository:
             parent_modular_pipeline.pipelines.update(modular_pipeline.pipelines)
             parent_modular_pipeline.tags.update(modular_pipeline.tags)
 
-            # add input/output datasets of a modular pipeline
-            # as a child to the parent modular pipeline
+            # add current modular pipeline and input/output datasets
+            # of a modular pipeline as a child to the parent modular
+            # pipeline based on the rules
             self._add_children_to_parent_pipeline(
                 parent_modular_pipeline,
                 modular_pipeline_id,
                 modular_pipeline_inputs_outputs,
             )
         else:
-            # add input/output datasets of a top-level modular
-            # pipeline as a child to ROOT modular pipeline
+            # add current modular pipeline and input/output datasets
+            # of a top-level modular pipeline as a child to ROOT modular
+            # pipeline
             self._add_children_to_parent_pipeline(
                 self.tree[ROOT_MODULAR_PIPELINE_ID],
                 modular_pipeline_id,

--- a/package/kedro_viz/data_access/repositories/modular_pipelines.py
+++ b/package/kedro_viz/data_access/repositories/modular_pipelines.py
@@ -41,9 +41,9 @@ class ModularPipelinesRepository:
                 ROOT_MODULAR_PIPELINE_ID
             )
         }
-        self.node_mod_pipeline_map: Dict[str, Set[str]] = (
-            {}
-        )  # Updated to map node_id to a list of modular_pipeline_ids
+        self.node_mod_pipeline_map: Dict[
+            str, Set[str]
+        ] = {}  # Updated to map node_id to a set of modular_pipeline_ids
 
         self.parameters = set()
 
@@ -87,6 +87,13 @@ class ModularPipelinesRepository:
 
         Returns:
             List[str]: A list of expanded namespaces.
+            Example:
+                >>> nested_namespace = "uk.data_processing.internal"
+                >>> modular_pipeline_repo_obj = ModularPipelinesRepository()
+                >>> expanded_namespace =
+                        modular_pipeline_repo_obj._explode_namespace(nested_namespace)
+                >>> expanded_namespace
+                ["uk", "uk.data_processing", "uk.data_processing.internal"]
         """
         if not nested_namespace or "." not in nested_namespace:
             return [nested_namespace] if nested_namespace else []
@@ -156,7 +163,7 @@ class ModularPipelinesRepository:
           it has the namespace of that modular pipeline
         - Inputs/Outputs of a kedro node are added as children
           to the modular pipeline if they are not inputs/outputs
-          of that modular pipeline
+          of that modular pipeline and are not parameter datasets
         - Any input/output of a modular pipeline is a child
           of the parent pipeline unless it is an input/output
           of that parent pipeline
@@ -174,15 +181,22 @@ class ModularPipelinesRepository:
         )
 
         for kedro_node in kedro_nodes:
+            # add kedro node as a child to the modular pipeline
             if kedro_node.namespace == modular_pipeline_id:
                 kedro_node_id = _hash(str(kedro_node))
                 modular_pipeline.children.add(
                     ModularPipelineChild(id=kedro_node_id, type=GraphNodeType.TASK)
                 )
+
                 modular_pipeline.tags.update(kedro_node.tags)
+
+                # add input/output datasets of a kedro node as a child
+                # to the modular pipeline
                 self._add_datasets_as_children(
                     modular_pipeline, kedro_node, modular_pipeline_inputs_outputs
                 )
+
+                # update node_modular_pipeline lookup
                 if kedro_node_id not in self.node_mod_pipeline_map:
                     self.node_mod_pipeline_map[kedro_node_id] = set()
                 self.node_mod_pipeline_map[kedro_node_id].add(modular_pipeline_id)
@@ -195,18 +209,24 @@ class ModularPipelinesRepository:
             if "." in modular_pipeline_id
             else None
         )
+
         if parent_modular_pipeline_id:
             parent_modular_pipeline = self.get_or_create_modular_pipeline(
                 parent_modular_pipeline_id
             )
             parent_modular_pipeline.pipelines.update(modular_pipeline.pipelines)
             parent_modular_pipeline.tags.update(modular_pipeline.tags)
+
+            # add input/output datasets of a modular pipeline
+            # as a child to the parent modular pipeline
             self._add_children_to_parent_pipeline(
                 parent_modular_pipeline,
                 modular_pipeline_id,
                 modular_pipeline_inputs_outputs,
             )
         else:
+            # add input/output datasets of a top-level modular
+            # pipeline as a child to ROOT modular pipeline
             self._add_children_to_parent_pipeline(
                 self.tree[ROOT_MODULAR_PIPELINE_ID],
                 modular_pipeline_id,
@@ -226,7 +246,7 @@ class ModularPipelinesRepository:
         Here we follow the below rules:
         - A modular pipeline is a child of it's parent modular pipeline
         - Any input/output of a modular pipeline is a child of the parent pipeline
-          unless it is an input/output of that parent pipeline
+          unless it is an input/output of that parent pipeline or a parameter dataset
         - Any input/output of a top-level modular pipeline is added as a child
           to the root modular pipeline
 
@@ -266,7 +286,7 @@ class ModularPipelinesRepository:
         Here we follow the below rule:
         - Inputs/Outputs of a task node are added as children
           to the modular pipeline if they are not inputs/outputs
-          of that modular pipeline
+          of that modular pipeline and are not parameter datasets
         """
         hashed_io_ids = {
             self._hash_input_output(io)

--- a/package/kedro_viz/utils.py
+++ b/package/kedro_viz/utils.py
@@ -1,8 +1,22 @@
 """Transcoding related utility functions."""
 
+import hashlib
 from typing import Tuple
 
 TRANSCODING_SEPARATOR = "@"
+
+
+def _hash(value: str):
+    return hashlib.sha1(value.encode("UTF-8")).hexdigest()[:8]
+
+
+def _hash_input_output(item: str) -> str:
+    """Hash the input/output dataset."""
+    return (
+        _hash(_strip_transcoding(item))
+        if TRANSCODING_SEPARATOR in item
+        else _hash(item)
+    )
 
 
 def _transcode_split(element: str) -> Tuple[str, str]:

--- a/package/kedro_viz/utils.py
+++ b/package/kedro_viz/utils.py
@@ -1,4 +1,5 @@
 """Transcoding related utility functions."""
+
 from typing import Tuple
 
 TRANSCODING_SEPARATOR = "@"
@@ -37,3 +38,8 @@ def _strip_transcoding(element: str) -> str:
         is present in the name.
     """
     return _transcode_split(element)[0]
+
+
+def is_dataset_param(dataset_name: str) -> bool:
+    """Return whether a dataset is a parameter"""
+    return dataset_name.lower().startswith("params:") or dataset_name == "parameters"

--- a/package/tests/test_data_access/test_repositories/test_graph.py
+++ b/package/tests/test_data_access/test_repositories/test_graph.py
@@ -10,7 +10,9 @@ from kedro_viz.models.flowchart import GraphEdge, GraphNode
 class TestGraphNodeRepository:
     def test_get_node_by_id(self, identity):
         repo = GraphNodesRepository()
-        task_node = GraphNode.create_task_node(node(identity, inputs="x", outputs=None))
+        task_node = GraphNode.create_task_node(
+            node(identity, inputs="x", outputs=None), "identity_node", None
+        )
         assert repo.get_node_by_id(task_node.id) is None
         repo.add_node(task_node)
         assert repo.get_node_by_id(task_node.id) is task_node
@@ -21,7 +23,9 @@ class TestGraphNodeRepository:
         task_nodes = []
         for i in range(5):
             task_node = GraphNode.create_task_node(
-                node(identity, inputs="x", outputs=None, name=f"identity_{i}")
+                node(identity, inputs="x", outputs=None, name=f"identity_{i}"),
+                f"identity_{i}",
+                None,
             )
             task_node_ids.append(task_node.id)
             task_nodes.append(task_node)
@@ -34,9 +38,11 @@ class TestGraphNodeRepository:
 
     def test_get_node_ids(self, identity):
         repo = GraphNodesRepository()
-        task_node = GraphNode.create_task_node(node(identity, inputs="x", outputs=None))
+        task_node = GraphNode.create_task_node(
+            node(identity, inputs="x", outputs=None), "identity_node", None
+        )
         repo.add_node(task_node)
-        assert repo.get_node_ids() == ["0b1b5ea2"]
+        assert repo.get_node_ids() == ["identity_node"]
 
 
 class TestGraphEdgesRepository:

--- a/package/tests/test_data_access/test_repositories/test_modular_pipelines.py
+++ b/package/tests/test_data_access/test_repositories/test_modular_pipelines.py
@@ -1,5 +1,3 @@
-import pytest
-from kedro.pipeline import node
 from kedro_datasets.pandas import CSVDataset
 
 from kedro_viz.constants import ROOT_MODULAR_PIPELINE_ID
@@ -27,59 +25,44 @@ class TestModularPipelinesRepository:
             [ROOT_MODULAR_PIPELINE_ID, "data_science"]
         )
 
-    def test_extract_from_node(self, identity):
-        task_node = GraphNode.create_task_node(
-            node(identity, inputs="x", outputs=None, namespace="data_science")
-        )
-        modular_pipelines = ModularPipelinesRepository()
-        assert not modular_pipelines.has_modular_pipeline("data_science")
-        modular_pipelines.extract_from_node(task_node)
-        assert modular_pipelines.has_modular_pipeline("data_science")
-
-    def test_add_input(self):
+    def test_add_inputs(self):
         kedro_dataset = CSVDataset(filepath="foo.csv")
         modular_pipelines = ModularPipelinesRepository()
         data_science_pipeline = modular_pipelines.get_or_create_modular_pipeline(
             "data_science"
         )
         data_node = GraphNode.create_data_node(
+            dataset_id="data_science.model",
             dataset_name="data_science.model",
             layer="model",
             tags=set(),
             dataset=kedro_dataset,
             stats=None,
+            modular_pipelines={"data_science"},
         )
-        modular_pipelines.add_input("data_science", data_node)
-        assert data_node.id in data_science_pipeline.inputs
+        modular_pipelines.add_inputs("data_science", set(["data_science.model"]))
+        assert (
+            modular_pipelines._hash_input_output(data_node.id)
+            in data_science_pipeline.inputs
+        )
 
-    def test_add_output(self):
+    def test_add_outputs(self):
         kedro_dataset = CSVDataset(filepath="foo.csv")
         modular_pipelines = ModularPipelinesRepository()
         data_science_pipeline = modular_pipelines.get_or_create_modular_pipeline(
             "data_science"
         )
         data_node = GraphNode.create_data_node(
+            dataset_id="data_science.model",
             dataset_name="data_science.model",
             layer="model",
             tags=set(),
             dataset=kedro_dataset,
             stats=None,
+            modular_pipelines={"data_science"},
         )
-        modular_pipelines.add_output("data_science", data_node)
-        assert data_node.id in data_science_pipeline.outputs
-
-    def test_add_input_should_raise_if_adding_non_data_node(self, identity):
-        task_node = GraphNode.create_task_node(
-            node(identity, inputs="x", outputs=None, namespace="data_science")
+        modular_pipelines.add_outputs("data_science", set(["data_science.model"]))
+        assert (
+            modular_pipelines._hash_input_output(data_node.id)
+            in data_science_pipeline.outputs
         )
-        modular_pipelines = ModularPipelinesRepository()
-        with pytest.raises(ValueError):
-            modular_pipelines.add_input("data_science", task_node)
-
-    def test_add_output_should_raise_if_adding_non_data_node(self, identity):
-        task_node = GraphNode.create_task_node(
-            node(identity, inputs="x", outputs=None, namespace="data_science")
-        )
-        modular_pipelines = ModularPipelinesRepository()
-        with pytest.raises(ValueError):
-            modular_pipelines.add_output("data_science", task_node)

--- a/package/tests/test_data_access/test_repositories/test_modular_pipelines.py
+++ b/package/tests/test_data_access/test_repositories/test_modular_pipelines.py
@@ -1,3 +1,4 @@
+import pytest
 from kedro_datasets.pandas import CSVDataset
 
 from kedro_viz.constants import ROOT_MODULAR_PIPELINE_ID
@@ -65,4 +66,32 @@ class TestModularPipelinesRepository:
         assert (
             modular_pipelines._hash_input_output(data_node.id)
             in data_science_pipeline.outputs
+        )
+
+    @pytest.mark.parametrize(
+        "nested_namespace, expected_expanded_namespace",
+        [
+            (
+                "uk.data_science.internal",
+                ["uk", "uk.data_science", "uk.data_science.internal"],
+            ),
+            (
+                "uk.data_processing.internal.process",
+                [
+                    "uk",
+                    "uk.data_processing",
+                    "uk.data_processing.internal",
+                    "uk.data_processing.internal.process",
+                ],
+            ),
+            ("main_pipeline", ["main_pipeline"]),
+            ("", []),
+            (None, []),
+        ],
+    )
+    def test_explode_namespace(self, nested_namespace, expected_expanded_namespace):
+        modular_pipeline_repo_obj = ModularPipelinesRepository()
+        assert (
+            modular_pipeline_repo_obj._explode_namespace(nested_namespace)
+            == expected_expanded_namespace
         )


### PR DESCRIPTION
## Description

Partially resolves #1899 

## Development notes

* Create a dictionary of node and modular pipeline mapping for faster search
* Add parameters set to keep track of parameters (As parameter nodes do not have modular pipelines)
* Add `populate_tree` method which takes care of inputs/outputs and children for all the modular pipelines within a registered pipeline
* Add `explode_namespace` method which takes care of expanding a nested namespace.
* Modify add_inputs and add_outputs methods to take a `Set[str]` of inputs and outputs that are calculated in `populate_tree` method
* Add `add_children` method which resolves the modular pipeline child nodes
* Add `_add_children_to_parent_pipeline` method which resolves adding children to parent modular pipeline in-case of nesting
* Add `_add_datasets_as_children` method which adds datasets as children to the modular pipeline
* Update tests

## QA notes

- This PR is part of a bigger refactor (https://github.com/kedro-org/kedro-viz/pull/1897) of modular pipelines and is created to ease review process.
- The CI build might fail as this PR is not self-sufficient

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [x] Added tests to cover my changes
