### PR TITLE
Refactor api tests for modular pipelines change

### DIFF
--- a/cypress/tests/ui/flowchart/menu.cy.js
+++ b/cypress/tests/ui/flowchart/menu.cy.js
@@ -136,10 +136,18 @@ describe('Flowchart Menu', () => {
     ).click();
 
     // Assert after action
-    cy.__checkForText__(
-      '.pipeline-node--active > .pipeline-node__text',
-      prettifyName(nodeToFocusText)
+    cy.get('.pipeline-node--active > .pipeline-node__text')
+      .invoke('text')
+      .then((focusedNodesText) =>
+        expect(focusedNodesText.toLowerCase()).to.contains(
+          prettifyName(nodeToFocusText).toLowerCase()
+        )
+      );
+    cy.get('.pipeline-node--active > .pipeline-node__text').should(
+      'have.length',
+      5
     );
+
     cy.get('.pipeline-node').should('have.length', 5);
   });
 

--- a/package/tests/test_api/expected_modular_pipeline_tree_for_edge_cases
+++ b/package/tests/test_api/expected_modular_pipeline_tree_for_edge_cases
@@ -1,0 +1,344 @@
+{
+  "__root__": {
+    "id": "__root__",
+    "name": "__root__",
+    "inputs": [],
+    "outputs": [],
+    "children": [
+      {
+        "id": "main_pipeline",
+        "type": "modularPipeline"
+      },
+      {
+        "id": "cleaned_transaction_data",
+        "type": "data"
+      },
+      {
+        "id": "main_pipeline.raw_car_data",
+        "type": "data"
+      },
+      {
+        "id": "uk.data_science.model",
+        "type": "data"
+      },
+      {
+        "id": "uk",
+        "type": "modularPipeline"
+      },
+      {
+        "id": "uk.data_processing.raw_data",
+        "type": "data"
+      },
+      {
+        "id": "validation_node: <lambda>([raw_transaction_data;cleaned_transaction_data]) -> [validated_transaction_data]",
+        "type": "task"
+      },
+      {
+        "id": "validated_transaction_data",
+        "type": "data"
+      },
+      {
+        "id": "enrichment_data",
+        "type": "data"
+      },
+      {
+        "id": "aggregated_data",
+        "type": "data"
+      },
+      {
+        "id": "main_pipeline.raw_customer_data",
+        "type": "data"
+      },
+      {
+        "id": "initial_customer_data",
+        "type": "data"
+      },
+      {
+        "id": "report_data",
+        "type": "data"
+      },
+      {
+        "id": "main_pipeline.validated_additional_data",
+        "type": "data"
+      },
+      {
+        "id": "final_report",
+        "type": "data"
+      },
+      {
+        "id": "enhanced_transaction_data",
+        "type": "data"
+      },
+      {
+        "id": "enhancement_node: <lambda>([validated_transaction_data;enrichment_data]) -> [enhanced_transaction_data]",
+        "type": "task"
+      },
+      {
+        "id": "final_customer_data_insights",
+        "type": "data"
+      },
+      {
+        "id": "customer_lifecycle_processing",
+        "type": "modularPipeline"
+      },
+      {
+        "id": "raw_transaction_data",
+        "type": "data"
+      },
+      {
+        "id": "namespace_prefix_1",
+        "type": "modularPipeline"
+      },
+      {
+        "id": "analysis_data",
+        "type": "data"
+      },
+      {
+        "id": "final_car_report",
+        "type": "data"
+      },
+      {
+        "id": "final_transaction_report",
+        "type": "data"
+      }
+    ]
+  },
+  "customer_lifecycle_processing": {
+    "id": "customer_lifecycle_processing",
+    "name": "customer_lifecycle_processing",
+    "inputs": [
+      "initial_customer_data"
+    ],
+    "outputs": [
+      "final_customer_data_insights"
+    ],
+    "children": [
+      {
+        "id": "customer_lifecycle_processing.first_processing_step",
+        "type": "modularPipeline"
+      },
+      {
+        "id": "customer_lifecycle_processing.processed_customer_data",
+        "type": "data"
+      },
+      {
+        "id": "customer_lifecycle_processing.second_processing_step",
+        "type": "modularPipeline"
+      }
+    ]
+  },
+  "customer_lifecycle_processing.first_processing_step": {
+    "id": "customer_lifecycle_processing.first_processing_step",
+    "name": "customer_lifecycle_processing.first_processing_step",
+    "inputs": [
+      "initial_customer_data"
+    ],
+    "outputs": [
+      "customer_lifecycle_processing.processed_customer_data"
+    ],
+    "children": [
+      {
+        "id": "generic_processing_node: <lambda>([initial_customer_data]) -> [customer_lifecycle_processing.processed_customer_data]",
+        "type": "task"
+      }
+    ]
+  },
+  "customer_lifecycle_processing.second_processing_step": {
+    "id": "customer_lifecycle_processing.second_processing_step",
+    "name": "customer_lifecycle_processing.second_processing_step",
+    "inputs": [
+      "customer_lifecycle_processing.processed_customer_data"
+    ],
+    "outputs": [
+      "final_customer_data_insights"
+    ],
+    "children": [
+      {
+        "id": "generic_processing_node: <lambda>([customer_lifecycle_processing.processed_customer_data]) -> [final_customer_data_insights]",
+        "type": "task"
+      }
+    ]
+  },
+  "main_pipeline": {
+    "id": "main_pipeline",
+    "name": "main_pipeline",
+    "inputs": [
+      "main_pipeline.raw_car_data",
+      "main_pipeline.raw_customer_data"
+    ],
+    "outputs": [
+      "final_report",
+      "main_pipeline.validated_additional_data",
+      "final_car_report"
+    ],
+    "children": [
+      {
+        "id": "main_pipeline.cleaned_car_data",
+        "type": "data"
+      },
+      {
+        "id": "data_validation: <lambda>([main_pipeline.raw_customer_data]) -> [main_pipeline.validated_customer_data]",
+        "type": "task"
+      },
+      {
+        "id": "main_pipeline.validated_customer_data",
+        "type": "data"
+      },
+      {
+        "id": "reporting_step: <lambda>([analyzed_car_data]) -> [final_car_report]",
+        "type": "task"
+      },
+      {
+        "id": "additional_validation: <lambda>([main_pipeline.validated_customer_data]) -> [main_pipeline.validated_additional_data]",
+        "type": "task"
+      },
+      {
+        "id": "main_pipeline.transformed_car_data",
+        "type": "data"
+      },
+      {
+        "id": "analyzed_car_data",
+        "type": "data"
+      },
+      {
+        "id": "analysis_step: <lambda>([main_pipeline.transformed_car_data]) -> [analyzed_car_data]",
+        "type": "task"
+      },
+      {
+        "id": "final_customer_data",
+        "type": "data"
+      },
+      {
+        "id": "report_generation: <lambda>([final_customer_data]) -> [final_report]",
+        "type": "task"
+      },
+      {
+        "id": "transformation_step: <lambda>([main_pipeline.cleaned_car_data]) -> [main_pipeline.transformed_car_data]",
+        "type": "task"
+      },
+      {
+        "id": "main_pipeline.sub_pipeline",
+        "type": "modularPipeline"
+      },
+      {
+        "id": "cleaning_step: <lambda>([main_pipeline.raw_car_data]) -> [main_pipeline.cleaned_car_data]",
+        "type": "task"
+      }
+    ]
+  },
+  "main_pipeline.sub_pipeline": {
+    "id": "main_pipeline.sub_pipeline",
+    "name": "main_pipeline.sub_pipeline",
+    "inputs": [
+      "main_pipeline.validated_customer_data"
+    ],
+    "outputs": [
+      "final_customer_data"
+    ],
+    "children": [
+      {
+        "id": "data_finalization: <lambda>([main_pipeline.sub_pipeline.enriched_customer_data]) -> [final_customer_data]",
+        "type": "task"
+      },
+      {
+        "id": "data_enrichment: <lambda>([main_pipeline.validated_customer_data]) -> [main_pipeline.sub_pipeline.enriched_customer_data]",
+        "type": "task"
+      },
+      {
+        "id": "main_pipeline.sub_pipeline.enriched_customer_data",
+        "type": "data"
+      }
+    ]
+  },
+  "namespace_prefix_1": {
+    "id": "namespace_prefix_1",
+    "name": "namespace_prefix_1",
+    "inputs": [
+      "report_data",
+      "enhanced_transaction_data",
+      "aggregated_data",
+      "analysis_data"
+    ],
+    "outputs": [
+      "final_transaction_report"
+    ],
+    "children": [
+      {
+        "id": "analyzed_transaction_data",
+        "type": "data"
+      },
+      {
+        "id": "prepared_transaction_data",
+        "type": "data"
+      },
+      {
+        "id": "analysis_node: <lambda>([prepared_transaction_data;analysis_data]) -> [analyzed_transaction_data]",
+        "type": "task"
+      },
+      {
+        "id": "preparation_node: <lambda>([enhanced_transaction_data;aggregated_data]) -> [prepared_transaction_data]",
+        "type": "task"
+      },
+      {
+        "id": "reporting_node: <lambda>([analyzed_transaction_data;report_data]) -> [final_transaction_report]",
+        "type": "task"
+      }
+    ]
+  },
+  "uk": {
+    "id": "uk",
+    "name": "uk",
+    "inputs": [
+      "uk.data_processing.raw_data"
+    ],
+    "outputs": [
+      "uk.data_science.model"
+    ],
+    "children": [
+      {
+        "id": "uk.data_science",
+        "type": "modularPipeline"
+      },
+      {
+        "id": "model_inputs",
+        "type": "data"
+      },
+      {
+        "id": "uk.data_processing",
+        "type": "modularPipeline"
+      }
+    ]
+  },
+  "uk.data_processing": {
+    "id": "uk.data_processing",
+    "name": "uk.data_processing",
+    "inputs": [
+      "uk.data_processing.raw_data"
+    ],
+    "outputs": [
+      "model_inputs"
+    ],
+    "children": [
+      {
+        "id": "process_data: <lambda>([uk.data_processing.raw_data]) -> [model_inputs]",
+        "type": "task"
+      }
+    ]
+  },
+  "uk.data_science": {
+    "id": "uk.data_science",
+    "name": "uk.data_science",
+    "inputs": [
+      "model_inputs"
+    ],
+    "outputs": [
+      "uk.data_science.model"
+    ],
+    "children": [
+      {
+        "id": "train_model: <lambda>([model_inputs]) -> [uk.data_science.model]",
+        "type": "task"
+      }
+    ]
+  }
+}

--- a/package/tests/test_api/main
+++ b/package/tests/test_api/main
@@ -6,7 +6,7 @@
       "tags": ["split"],
       "pipelines": ["data_processing", "__default__"],
       "type": "task",
-      "modular_pipelines": ["uk", "uk.data_processing"],
+      "modular_pipelines": ["uk.data_processing"],
       "parameters": { "uk.data_processing.train_test_split": 0.1 }
     },
     {
@@ -15,7 +15,7 @@
       "tags": ["split"],
       "pipelines": ["data_processing", "__default__"],
       "type": "parameters",
-      "modular_pipelines": ["uk", "uk.data_processing"],
+      "modular_pipelines": null,
       "layer": null,
       "dataset_type": null
     },
@@ -35,7 +35,7 @@
       "tags": ["split", "train"],
       "pipelines": ["data_processing", "__default__", "data_science"],
       "type": "data",
-      "modular_pipelines": [],
+      "modular_pipelines": null,
       "layer": "model_inputs",
       "dataset_type": "pandas.csv_dataset.CSVDataset"
     },
@@ -45,7 +45,7 @@
       "tags": ["train"],
       "pipelines": ["__default__", "data_science"],
       "type": "task",
-      "modular_pipelines": ["uk", "uk.data_science"],
+      "modular_pipelines": ["uk.data_science"],
       "parameters": { "train_test_split": 0.1, "num_epochs": 1000 }
     },
     {
@@ -54,7 +54,7 @@
       "tags": ["train"],
       "pipelines": ["__default__", "data_science"],
       "type": "parameters",
-      "modular_pipelines": [],
+      "modular_pipelines": null,
       "layer": null,
       "dataset_type": null
     },
@@ -135,8 +135,7 @@
       "outputs": [],
       "children": [
         { "id": "f1f1425b", "type": "parameters" },
-        { "id": "uk", "type": "modularPipeline" },
-        { "id": "0ecea0de", "type": "data" }
+        { "id": "uk", "type": "modularPipeline" }
       ]
     },
     "uk.data_processing": {

--- a/package/tests/test_api/test_rest/test_responses.py
+++ b/package/tests/test_api/test_rest/test_responses.py
@@ -582,6 +582,18 @@ class TestMainEndpoint:
             {"id": "data_processing", "name": "data_processing"},
         ]
 
+    def test_endpoint_main_for_edge_case_pipelines(
+        self,
+        example_api_for_edge_case_pipelines,
+        expected_modular_pipeline_tree_for_edge_cases,
+    ):
+        client = TestClient(example_api_for_edge_case_pipelines)
+        response = client.get("/api/main")
+        actual_modular_pipelines_tree = response.json()["modular_pipelines"]
+        assert_modular_pipelines_tree_equal(
+            actual_modular_pipelines_tree, expected_modular_pipeline_tree_for_edge_cases
+        )
+
 
 class TestTranscodedDataset:
     """Test a viz API created from a Kedro project."""

--- a/package/tests/test_api/test_rest/test_responses.py
+++ b/package/tests/test_api/test_rest/test_responses.py
@@ -58,7 +58,15 @@ def assert_nodes_equal(response_nodes, expected_nodes):
 
         response_node_pipelines = response_node.pop("pipelines")
         expected_node_pipelines = expected_node.pop("pipelines")
+
         assert sorted(response_node_pipelines) == sorted(expected_node_pipelines)
+
+        # sort modular pipelines
+        if response_node["modular_pipelines"]:
+            response_node["modular_pipelines"].sort()
+        if expected_node["modular_pipelines"]:
+            expected_node["modular_pipelines"].sort()
+
         assert response_node == expected_node
 
 
@@ -98,7 +106,6 @@ def assert_example_data(response_data):
         {"source": "uk.data_science", "target": "d5a8b994"},
         {"source": "0ecea0de", "target": "uk.data_science"},
         {"source": "uk", "target": "d5a8b994"},
-        {"source": "uk", "target": "0ecea0de"},
     ]
     assert_dict_list_equal(
         response_data.pop("edges"), expected_edges, sort_keys=("source", "target")
@@ -110,7 +117,7 @@ def assert_example_data(response_data):
             "name": "process_data",
             "tags": ["split"],
             "pipelines": ["__default__", "data_processing"],
-            "modular_pipelines": ["uk", "uk.data_processing"],
+            "modular_pipelines": ["uk.data_processing"],
             "type": "task",
             "parameters": {"uk.data_processing.train_test_split": 0.1},
         },
@@ -130,7 +137,7 @@ def assert_example_data(response_data):
             "name": "params:uk.data_processing.train_test_split",
             "tags": ["split"],
             "pipelines": ["__default__", "data_processing"],
-            "modular_pipelines": ["uk", "uk.data_processing"],
+            "modular_pipelines": None,
             "type": "parameters",
             "layer": None,
             "dataset_type": None,
@@ -141,7 +148,7 @@ def assert_example_data(response_data):
             "name": "model_inputs",
             "tags": ["train", "split"],
             "pipelines": ["__default__", "data_science", "data_processing"],
-            "modular_pipelines": [],
+            "modular_pipelines": ["uk.data_science", "uk.data_processing"],
             "type": "data",
             "layer": "model_inputs",
             "dataset_type": "pandas.csv_dataset.CSVDataset",
@@ -152,7 +159,7 @@ def assert_example_data(response_data):
             "name": "train_model",
             "tags": ["train"],
             "pipelines": ["__default__", "data_science"],
-            "modular_pipelines": ["uk", "uk.data_science"],
+            "modular_pipelines": ["uk.data_science"],
             "type": "task",
             "parameters": {
                 "train_test_split": 0.1,
@@ -164,7 +171,7 @@ def assert_example_data(response_data):
             "name": "parameters",
             "tags": ["train"],
             "pipelines": ["__default__", "data_science"],
-            "modular_pipelines": [],
+            "modular_pipelines": None,
             "type": "parameters",
             "layer": None,
             "dataset_type": None,
@@ -220,46 +227,42 @@ def assert_example_data(response_data):
     # compare modular pipelines
     expected_modular_pipelines = {
         "__root__": {
+            "id": "__root__",
+            "name": "__root__",
+            "inputs": [],
+            "outputs": [],
             "children": [
-                {"id": "0ecea0de", "type": "data"},
+                {"id": "d5a8b994", "type": "data"},
+                {"id": "13399a82", "type": "data"},
                 {"id": "f1f1425b", "type": "parameters"},
                 {"id": "f0ebef01", "type": "parameters"},
                 {"id": "uk", "type": "modularPipeline"},
             ],
-            "id": "__root__",
-            "inputs": [],
-            "name": "__root__",
-            "outputs": [],
         },
         "uk": {
-            "children": [
-                {"id": "uk.data_science", "type": "modularPipeline"},
-                {"id": "uk.data_processing", "type": "modularPipeline"},
-            ],
             "id": "uk",
-            "inputs": ["f0ebef01", "13399a82", "f1f1425b", "0ecea0de"],
             "name": "uk",
-            "outputs": ["d5a8b994", "0ecea0de"],
+            "inputs": ["f1f1425b", "f0ebef01", "13399a82"],
+            "outputs": ["d5a8b994"],
+            "children": [
+                {"id": "uk.data_processing", "type": "modularPipeline"},
+                {"id": "uk.data_science", "type": "modularPipeline"},
+                {"id": "0ecea0de", "type": "data"},
+            ],
         },
         "uk.data_processing": {
-            "children": [
-                {"id": "13399a82", "type": "data"},
-                {"id": "782e4a43", "type": "task"},
-            ],
             "id": "uk.data_processing",
-            "inputs": ["f0ebef01", "13399a82"],
             "name": "uk.data_processing",
+            "inputs": ["f0ebef01", "13399a82"],
             "outputs": ["0ecea0de"],
+            "children": [{"id": "782e4a43", "type": "task"}],
         },
         "uk.data_science": {
-            "children": [
-                {"id": "f2b25286", "type": "task"},
-                {"id": "d5a8b994", "type": "data"},
-            ],
             "id": "uk.data_science",
-            "inputs": ["0ecea0de", "f1f1425b"],
             "name": "uk.data_science",
+            "inputs": ["0ecea0de", "f1f1425b"],
             "outputs": ["d5a8b994"],
+            "children": [{"id": "f2b25286", "type": "task"}],
         },
     }
     assert_modular_pipelines_tree_equal(
@@ -309,7 +312,7 @@ def assert_example_data_from_file(response_data):
             "name": "process_data",
             "tags": ["split"],
             "pipelines": ["__default__", "data_processing"],
-            "modular_pipelines": ["uk", "uk.data_processing"],
+            "modular_pipelines": ["uk.data_processing"],
             "type": "task",
             "parameters": {"uk.data_processing.train_test_split": 0.1},
         },
@@ -328,7 +331,7 @@ def assert_example_data_from_file(response_data):
             "name": "params:uk.data_processing.train_test_split",
             "tags": ["split"],
             "pipelines": ["__default__", "data_processing"],
-            "modular_pipelines": ["uk", "uk.data_processing"],
+            "modular_pipelines": None,
             "type": "parameters",
             "layer": None,
             "dataset_type": None,
@@ -338,7 +341,7 @@ def assert_example_data_from_file(response_data):
             "name": "model_inputs",
             "tags": ["train", "split"],
             "pipelines": ["__default__", "data_science", "data_processing"],
-            "modular_pipelines": [],
+            "modular_pipelines": None,
             "type": "data",
             "layer": "model_inputs",
             "dataset_type": "pandas.csv_dataset.CSVDataset",
@@ -348,7 +351,7 @@ def assert_example_data_from_file(response_data):
             "name": "train_model",
             "tags": ["train"],
             "pipelines": ["__default__", "data_science"],
-            "modular_pipelines": ["uk", "uk.data_science"],
+            "modular_pipelines": ["uk.data_science"],
             "type": "task",
             "parameters": {
                 "train_test_split": 0.1,
@@ -360,7 +363,7 @@ def assert_example_data_from_file(response_data):
             "name": "parameters",
             "tags": ["train"],
             "pipelines": ["__default__", "data_science"],
-            "modular_pipelines": [],
+            "modular_pipelines": None,
             "type": "parameters",
             "layer": None,
             "dataset_type": None,
@@ -412,7 +415,6 @@ def assert_example_data_from_file(response_data):
     expected_modular_pipelines = {
         "__root__": {
             "children": [
-                {"id": "0ecea0de", "type": "data"},
                 {"id": "f1f1425b", "type": "parameters"},
                 {"id": "uk", "type": "modularPipeline"},
             ],
@@ -491,7 +493,7 @@ def assert_example_transcoded_data(response_data):
             "tags": ["split"],
             "pipelines": ["data_processing", "__default__"],
             "type": "task",
-            "modular_pipelines": [],
+            "modular_pipelines": None,
             "parameters": {"uk.data_processing.train_test_split": 0.1},
         },
         {
@@ -500,7 +502,7 @@ def assert_example_transcoded_data(response_data):
             "tags": ["split"],
             "pipelines": ["data_processing", "__default__"],
             "type": "data",
-            "modular_pipelines": [],
+            "modular_pipelines": None,
             "layer": None,
             "dataset_type": "io.memory_dataset.MemoryDataset",
             "stats": None,
@@ -511,7 +513,7 @@ def assert_example_transcoded_data(response_data):
             "tags": ["split"],
             "pipelines": ["data_processing", "__default__"],
             "type": "parameters",
-            "modular_pipelines": ["uk", "uk.data_processing"],
+            "modular_pipelines": None,
             "layer": None,
             "dataset_type": None,
             "stats": None,
@@ -522,7 +524,7 @@ def assert_example_transcoded_data(response_data):
             "tags": ["train", "split"],
             "pipelines": ["data_processing", "__default__"],
             "type": "data",
-            "modular_pipelines": [],
+            "modular_pipelines": None,
             "layer": None,
             "dataset_type": None,
             "stats": None,
@@ -533,7 +535,7 @@ def assert_example_transcoded_data(response_data):
             "tags": ["train"],
             "pipelines": ["data_processing", "__default__"],
             "type": "task",
-            "modular_pipelines": [],
+            "modular_pipelines": None,
             "parameters": {"train_test_split": 0.1, "num_epochs": 1000},
         },
         {
@@ -542,7 +544,7 @@ def assert_example_transcoded_data(response_data):
             "tags": ["train"],
             "pipelines": ["data_processing", "__default__"],
             "type": "parameters",
-            "modular_pipelines": [],
+            "modular_pipelines": None,
             "layer": None,
             "dataset_type": None,
             "stats": None,
@@ -553,7 +555,7 @@ def assert_example_transcoded_data(response_data):
             "tags": ["train"],
             "pipelines": ["data_processing", "__default__"],
             "type": "data",
-            "modular_pipelines": [],
+            "modular_pipelines": None,
             "layer": None,
             "dataset_type": "io.memory_dataset.MemoryDataset",
             "stats": None,
@@ -612,8 +614,8 @@ class TestNodeMetadataEndpoint:
         response = client.get("/api/nodes/782e4a43")
         metadata = response.json()
         assert (
-            metadata["code"].lstrip()
-            == "def process_data(raw_data, train_test_split):\n        ...\n"
+            metadata["code"].replace(" ", "")
+            == "defprocess_data(raw_data,train_test_split):\n...\n"
         )
         assert metadata["parameters"] == {"uk.data_processing.train_test_split": 0.1}
         assert metadata["inputs"] == [
@@ -688,7 +690,7 @@ class TestSinglePipelineEndpoint:
                 "name": "model_inputs",
                 "tags": ["train", "split"],
                 "pipelines": ["__default__", "data_science", "data_processing"],
-                "modular_pipelines": [],
+                "modular_pipelines": ["uk.data_science", "uk.data_processing"],
                 "type": "data",
                 "layer": "model_inputs",
                 "dataset_type": "pandas.csv_dataset.CSVDataset",
@@ -699,7 +701,7 @@ class TestSinglePipelineEndpoint:
                 "name": "train_model",
                 "tags": ["train"],
                 "pipelines": ["__default__", "data_science"],
-                "modular_pipelines": ["uk", "uk.data_science"],
+                "modular_pipelines": ["uk.data_science"],
                 "type": "task",
                 "parameters": {
                     "train_test_split": 0.1,
@@ -711,7 +713,7 @@ class TestSinglePipelineEndpoint:
                 "name": "parameters",
                 "tags": ["train"],
                 "pipelines": ["__default__", "data_science"],
-                "modular_pipelines": [],
+                "modular_pipelines": None,
                 "type": "parameters",
                 "layer": None,
                 "dataset_type": None,
@@ -759,6 +761,7 @@ class TestSinglePipelineEndpoint:
                     {"id": "f1f1425b", "type": "parameters"},
                     {"id": "0ecea0de", "type": "data"},
                     {"id": "uk", "type": "modularPipeline"},
+                    {"id": "d5a8b994", "type": "data"},
                 ],
                 "id": "__root__",
                 "inputs": [],
@@ -776,7 +779,6 @@ class TestSinglePipelineEndpoint:
             },
             "uk.data_science": {
                 "children": [
-                    {"id": "d5a8b994", "type": "data"},
                     {"id": "f2b25286", "type": "task"},
                 ],
                 "id": "uk.data_science",


### PR DESCRIPTION
## Description

Partially resolves #1899 

## Development notes
* Updated cypress tests as the menu now shows the inputs/outputs datasets for a focussed modular pipeline
* Update conftest fixtures with edges case pipeline scenarios mentioned in -
    - https://github.com/kedro-org/kedro-viz/pull/1651
    - https://github.com/kedro-org/kedro-viz/issues/1814
* Updated REST API responses as the modular pipeline mapping changed 

## QA notes
- This PR is part of a bigger refactor (https://github.com/kedro-org/kedro-viz/pull/1897) of modular pipelines and is created to ease review process.
- The CI build might fail as this PR is not self-sufficient

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [x] Added tests to cover my changes
