### PR TITLE
Introduce `preview` props in Kedro-Viz react component 

### DIFF
--- a/src/components/app/app.js
+++ b/src/components/app/app.js
@@ -105,10 +105,15 @@ App.propTypes = {
    */
   display: PropTypes.shape({
     globalToolbar: PropTypes.bool,
-    sidebar: PropTypes.bool,
     miniMap: PropTypes.bool,
     expandAllPipelines: PropTypes.bool,
   }),
+  /**
+   * Determines if the app is being run as a standalone preview mode,
+   * this is the flowchart only mode with no other elements displayed
+   * except metadata panel when user clicks on a node
+   */
+  preview: PropTypes.bool,
 };
 
 export default App;

--- a/src/components/experiment-tracking/experiment-primary-toolbar/experiment-primary-toolbar.js
+++ b/src/components/experiment-tracking/experiment-primary-toolbar/experiment-primary-toolbar.js
@@ -17,7 +17,6 @@ import {
 const duration = 300;
 
 export const ExperimentPrimaryToolbar = ({
-  displaySidebar,
   enableComparisonView,
   enableShowChanges,
   selectedRunData,
@@ -38,7 +37,6 @@ export const ExperimentPrimaryToolbar = ({
 
   return (
     <PrimaryToolbar
-      displaySidebar={displaySidebar}
       onToggleSidebar={setSidebarVisible}
       visible={{ sidebar: sidebarVisible }}
     >

--- a/src/components/flowchart-primary-toolbar/flowchart-primary-toolbar.js
+++ b/src/components/flowchart-primary-toolbar/flowchart-primary-toolbar.js
@@ -25,7 +25,6 @@ import { useGeneratePathname } from '../../utils/hooks/use-generate-pathname';
  */
 export const FlowchartPrimaryToolbar = ({
   disableLayerBtn,
-  displaySidebar,
   onToggleExportModal,
   onToggleLayers,
   onToggleSidebar,
@@ -46,11 +45,7 @@ export const FlowchartPrimaryToolbar = ({
 
   return (
     <>
-      <PrimaryToolbar
-        displaySidebar={displaySidebar}
-        onToggleSidebar={onToggleSidebar}
-        visible={visible}
-      >
+      <PrimaryToolbar onToggleSidebar={onToggleSidebar} visible={visible}>
         <IconButton
           active={textLabels}
           ariaLabel={`${textLabels ? 'Hide' : 'Show'} text labels`}
@@ -106,7 +101,6 @@ export const FlowchartPrimaryToolbar = ({
 
 export const mapStateToProps = (state) => ({
   disableLayerBtn: !state.layer.ids.length,
-  displaySidebar: state.display.sidebar,
   textLabels: state.textLabels,
   visible: state.visible,
   visibleLayers: Boolean(getVisibleLayerIDs(state).length),

--- a/src/components/flowchart-primary-toolbar/flowchart-primary-toolbar.test.js
+++ b/src/components/flowchart-primary-toolbar/flowchart-primary-toolbar.test.js
@@ -54,7 +54,6 @@ describe('PrimaryToolbar', () => {
     (selector, callback) => {
       const mockFn = jest.fn();
       const props = {
-        displaySidebar: true,
         textLabels: mockState.spaceflights.textLabels,
         visible: mockState.spaceflights.visible,
         [callback]: mockFn,
@@ -71,7 +70,6 @@ describe('PrimaryToolbar', () => {
       disableLayerBtn: expect.any(Boolean),
       textLabels: expect.any(Boolean),
       expandedPipelines: expect.any(Boolean),
-      displaySidebar: true,
       visible: expect.objectContaining({
         exportBtn: expect.any(Boolean),
         exportModal: expect.any(Boolean),

--- a/src/components/flowchart/flowchart.js
+++ b/src/components/flowchart/flowchart.js
@@ -596,8 +596,13 @@ export class FlowChart extends Component {
    * Render React elements
    */
   render() {
-    const { chartSize, layers, visibleGraph, displayGlobalToolbar } =
-      this.props;
+    const {
+      chartSize,
+      layers,
+      visibleGraph,
+      displayGlobalToolbar,
+      displayPrimaryToolbar,
+    } = this.props;
     const { outerWidth = 0, outerHeight = 0 } = chartSize;
 
     return (
@@ -657,6 +662,8 @@ export class FlowChart extends Component {
             'pipeline-flowchart__layer-names--visible': layers.length,
             'pipeline-flowchart__layer-names--no-global-toolbar':
               !displayGlobalToolbar,
+            'pipeline-flowchart__layer-names--no-primary-toolbar':
+              !displayPrimaryToolbar,
           })}
           ref={this.layerNamesRef}
         />
@@ -690,6 +697,7 @@ export const mapStateToProps = (state, ownProps) => ({
   chartSize: getChartSize(state),
   chartZoom: getChartZoom(state),
   displayGlobalToolbar: state.display.globalToolbar,
+  displayPrimaryToolbar: state.display.primaryToolbar,
   edges: state.graph.edges || emptyEdges,
   focusMode: state.visible.modularPipelineFocusMode,
   graphSize: state.graph.size || emptyGraphSize,

--- a/src/components/flowchart/flowchart.test.js
+++ b/src/components/flowchart/flowchart.test.js
@@ -486,6 +486,7 @@ describe('FlowChart', () => {
       inputOutputDataEdges: expect.any(Object),
       focusMode: expect.any(Object),
       displayGlobalToolbar: expect.any(Boolean),
+      displayPrimaryToolbar: expect.any(Boolean),
     };
     expect(mapStateToProps(mockState.spaceflights)).toEqual(expectedResult);
   });

--- a/src/components/flowchart/styles/_layers.scss
+++ b/src/components/flowchart/styles/_layers.scss
@@ -46,6 +46,10 @@
     left: -#{variables.$global-toolbar-width};
   }
 
+  &--no-primary-toolbar {
+    left: 0;
+  }
+
   @media print {
     display: none;
   }

--- a/src/components/sidebar/sidebar.js
+++ b/src/components/sidebar/sidebar.js
@@ -18,7 +18,7 @@ import './sidebar.scss';
 export const Sidebar = ({
   disableRunSelection,
   displayGlobalToolbar,
-  displaySidebar,
+  displayPrimaryToolbar,
   enableComparisonView,
   enableShowChanges,
   isDisplayingMetrics = false,
@@ -60,7 +60,6 @@ export const Sidebar = ({
           </div>
           <nav className="pipeline-toolbar">
             <ExperimentPrimaryToolbar
-              displaySidebar={displaySidebar}
               enableComparisonView={enableComparisonView}
               enableShowChanges={enableShowChanges}
               runMetadata={runMetadata}
@@ -80,22 +79,24 @@ export const Sidebar = ({
   } else {
     return (
       <>
-        <div
-          className={classnames('pipeline-sidebar', {
-            'pipeline-sidebar--visible': visible,
-            'pipeline-sidebar--no-global-toolbar': !displayGlobalToolbar,
-          })}
-        >
-          <div className="pipeline-ui">
-            <PipelineList onToggleOpen={togglePipeline} />
-            <NodeList faded={pipelineIsOpen} />
+        {displayPrimaryToolbar && (
+          <div
+            className={classnames('pipeline-sidebar', {
+              'pipeline-sidebar--visible': visible,
+              'pipeline-sidebar--no-global-toolbar': !displayGlobalToolbar,
+            })}
+          >
+            <div className="pipeline-ui">
+              <PipelineList onToggleOpen={togglePipeline} />
+              <NodeList faded={pipelineIsOpen} />
+            </div>
+            <nav className="pipeline-toolbar">
+              <FlowchartPrimaryToolbar />
+              <MiniMapToolbar />
+            </nav>
+            <MiniMap />
           </div>
-          <nav className="pipeline-toolbar">
-            <FlowchartPrimaryToolbar />
-            <MiniMapToolbar />
-          </nav>
-          <MiniMap />
-        </div>
+        )}
       </>
     );
   }
@@ -103,7 +104,7 @@ export const Sidebar = ({
 
 const mapStateToProps = (state) => ({
   displayGlobalToolbar: state.display.globalToolbar,
-  displaySidebar: state.display.sidebar,
+  displayPrimaryToolbar: state.display.primaryToolbar,
   visible: state.visible.sidebar,
 });
 

--- a/src/components/sidebar/sidebar.test.js
+++ b/src/components/sidebar/sidebar.test.js
@@ -7,6 +7,7 @@ const mockProps = {
   theme: mockState.spaceflights.theme,
   onToggle: () => {},
   visible: true,
+  displayPrimaryToolbar: true,
 };
 
 describe('Sidebar', () => {

--- a/src/selectors/layout.js
+++ b/src/selectors/layout.js
@@ -17,6 +17,8 @@ const getVisibleCode = (state) => state.visible.code;
 const getIgnoreLargeWarning = (state) => state.ignoreLargeWarning;
 const getGraphHasNodes = (state) => Boolean(state.graph?.nodes?.length);
 const getChartSizeState = (state) => state.chartSize;
+const getDisplayPrimaryToolbar = (state) => state.display.primaryToolbar;
+const getDisplayGlobalToolbar = (state) => state.display.globalToolbar;
 
 /**
  * Show the large graph warning only if there are sufficient nodes + edges,
@@ -70,15 +72,32 @@ export const getSidebarWidth = (visible, { open, closed }) =>
  * and add some useful new ones
  */
 export const getChartSize = createSelector(
-  [getVisibleSidebar, getVisibleMetaSidebar, getVisibleCode, getChartSizeState],
-  (visibleSidebar, visibleMetaSidebar, visibleCodeSidebar, chartSize) => {
+  [
+    getVisibleSidebar,
+    getVisibleMetaSidebar,
+    getVisibleCode,
+    getChartSizeState,
+    getDisplayPrimaryToolbar,
+    getDisplayGlobalToolbar,
+  ],
+  (
+    visibleSidebar,
+    visibleMetaSidebar,
+    visibleCodeSidebar,
+    chartSize,
+    displayPrimaryToolbar,
+    displayGlobalToolbar
+  ) => {
     const { left, top, width, height } = chartSize;
     if (!width || !height) {
       return {};
     }
 
     // Get the actual sidebar width
-    const sidebarWidthActual = getSidebarWidth(visibleSidebar, sidebarWidth);
+    const sidebarWidthActual =
+      displayPrimaryToolbar || displayGlobalToolbar
+        ? getSidebarWidth(visibleSidebar, sidebarWidth)
+        : 0;
     const metaSidebarWidthActual = getSidebarWidth(
       visibleMetaSidebar,
       metaSidebarWidth

--- a/src/store/initial-state.js
+++ b/src/store/initial-state.js
@@ -48,6 +48,7 @@ export const createInitialState = () => ({
   },
   display: {
     globalToolbar: true,
+    primaryToolbar: true,
     sidebar: true,
     miniMap: true,
     expandAllPipelines: false,
@@ -218,9 +219,21 @@ export const preparePipelineState = (
 export const prepareNonPipelineState = (props, urlParams) => {
   let state = mergeLocalStorage(createInitialState());
   let newVisibleProps = {};
+  let newDisplayProps = {};
 
-  if (props.display?.sidebar === false || state.display.sidebar === false) {
-    newVisibleProps['sidebar'] = false;
+  if (props.preview) {
+    const visiblePropsKeys = [
+      'labelBtn',
+      'layerBtn',
+      'exportBtn',
+      'pipelineBtn',
+      'sidebar',
+      'miniMap',
+    ];
+    const displayPropsKeys = ['globalToolbar', 'primaryToolbar'];
+
+    visiblePropsKeys.forEach((key) => (newVisibleProps[key] = false));
+    displayPropsKeys.forEach((key) => (newDisplayProps[key] = false));
   }
 
   if (props.display?.minimap === false || state.display.miniMap === false) {
@@ -236,7 +249,7 @@ export const prepareNonPipelineState = (props, urlParams) => {
     flags: { ...state.flags, ...getFlagsFromUrl() },
     theme: props.theme || state.theme,
     visible: { ...state.visible, ...props.visible, ...newVisibleProps },
-    display: { ...state.display, ...props.display },
+    display: { ...state.display, ...props.display, ...newDisplayProps },
   };
 };
 


### PR DESCRIPTION
Resolves https://github.com/kedro-org/kedro-viz/issues/1745

This PR addresses a requirement for cases where users of Kedro-Viz as a React component in embedded mode want to see only the flowchart view, hiding all other components such as the global toolbar, sidebar, primary toolbar, and other action buttons.

<img width="550" alt="Screenshot 2024-06-19 at 10 46 04 p m" src="https://github.com/kedro-org/kedro-viz/assets/38945204/2a14d86e-ced3-4878-afc0-5658e329172f">


## Development notes

```
<KedroViz data={data} preview />
```
- Removed redundant `display.sidebar` props as `visible.sidebar` is doing the same things
- New internal props/state `display.primaryToolbar` added
- when `preview` is true internally all the props from `display` & `visible` set to `false`


## QA notes

- As redundant `display.sidebar` props is removed, need to test
- All the test need to pass.

## Checklist

- [X] Read the [contributing](/CONTRIBUTING.md) guidelines
- [X] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes
