### PR TITLE
Add favicon to kedro-viz documentation

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -15,6 +15,7 @@ Please follow the established format:
 - Conditionally move session store and stats file to .viz directory. (#1915)
 
 ## Bug fixes and other changes
+- Add favicon to kedro-viz documentation. (#1959)
 
 # Release 9.1.0
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -41,8 +41,12 @@ extensions = [
     "myst_parser",
     "notfound.extension",
     "sphinxcontrib.jquery",
+    'sphinx_favicon',
 ]
 
+favicons = [
+    "https://kedro.org/images/favicon.ico",
+]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/package/setup.py
+++ b/package/setup.py
@@ -52,7 +52,7 @@ setup(
     },
     extras_require={
         "docs": [
-            "kedro-sphinx-theme==2024.4.0",
+            "kedro-sphinx-theme @ git+https://github.com/kedro-org/kedro-sphinx-theme.git@fix-favicon",
         ],
         "aws": ["s3fs>=2021.4"],
         "azure": ["adlfs>=2021.4"],

--- a/package/setup.py
+++ b/package/setup.py
@@ -52,7 +52,7 @@ setup(
     },
     extras_require={
         "docs": [
-            "kedro-sphinx-theme @ git+https://github.com/kedro-org/kedro-sphinx-theme.git@fix-favicon",
+            "kedro-sphinx-theme==2024.4.0",
         ],
         "aws": ["s3fs>=2021.4"],
         "azure": ["adlfs>=2021.4"],


### PR DESCRIPTION
## Description
Fixes #1724 , as a part of the ticket is to add the favicon to our documentation. Ideally we should do it directly in kedro-sphinx-theme.

However @astrojuanlu pointed out that there's some issue with Sphinx theme don't normally have their own conf.py ([issue here](https://github.com/kedro-org/kedro-sphinx-theme/issues/8)), therefore the fix for now will be directly inside kedro-viz doc, and the same for kedro datasets


The favicon is now shown through the doc build https://kedro--1959.org.readthedocs.build/projects/kedro-viz/en/1959/
## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [x] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes
