### PR TITLE
Use uv for GitPod, speedup the setup time

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -14,16 +14,17 @@ tasks:
   - name: backend
     before: echo PIP_USER=no >> ~/.bashrc && export PIP_USER=no
     init: |
-      pip install "pip==23.3.1" --user
-      pip install -r package/test_requirements.txt -r demo-project/src/docker_requirements.txt --user
+      | pip install uv
+      uv pip install "pip==23.3.1" --system
+      uv pip install -r package/test_requirements.txt -r demo-project/src/docker_requirements.txt --system
       # Install latest kedro and all its dependencies.
-      pip install https://github.com/kedro-org/kedro/archive/main.zip --user
+      uv pip install https://github.com/kedro-org/kedro/archive/main.zip --system
       # force-reinstall kedro to ensure that the latest version from main is installed even when 
       # its version number is the same as that specified in docker_requirements.txt.
-      pip install https://github.com/kedro-org/kedro/archive/main.zip --user --force-reinstall --no-deps
+      uv pip install https://github.com/kedro-org/kedro/archive/main.zip --force-reinstall --no-deps --system
     command: | 
       gp sync-await build_complete
-      pip install -e package --no-deps
+      uv pip install -e package --no-deps --system
       gp sync-done kedro_installed
       make run
       

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -14,7 +14,7 @@ tasks:
   - name: backend
     before: echo PIP_USER=no >> ~/.bashrc && export PIP_USER=no
     init: |
-      | pip install uv
+      pip install uv
       uv pip install "pip==23.3.1" --system
       uv pip install -r package/test_requirements.txt -r demo-project/src/docker_requirements.txt --system
       # Install latest kedro and all its dependencies.


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->
I discover the GitPod setup is very slow while reviewing some PRs. `kedro` has switched to `uv` a few months ago. It's mostly a drop in replacement for `pip`.




## Development notes

<!-- What have you changed? Consider adding a screenshot or GIF. -->

Use `uv` to replace `pip`, GitPod setup is very slow at installing packages. This is now 10x faster.
## QA notes

<!-- How has the expected behaviour changed? What testing strategies have you used? -->

## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes
