### PR TITLE
Feature/slicing pipeline run command

### DIFF
--- a/src/components/flowchart/components/sliced-pipeline-action-bar/sliced-pipeline-action-bar.js
+++ b/src/components/flowchart/components/sliced-pipeline-action-bar/sliced-pipeline-action-bar.js
@@ -40,15 +40,15 @@ export const SlicedPipelineActionBar = React.forwardRef((props, ref) => {
     visibleSidebar,
   } = props;
   const { outerWidth: screenWidth } = chartSize;
-  const buffer = 200;
+  const transitionMargin = 200;
   const slicePipelineActionBarWidth =
     ref.current && ref.current.firstChild.getBoundingClientRect().width;
   const metaDataPanelWidth = displayMetadataPanel
-    ? metaSidebarWidth.open + buffer
+    ? metaSidebarWidth.open + transitionMargin
     : metaSidebarWidth.open;
   const nodeListWidth = visibleSidebar
-    ? sidebarWidth.open - buffer
-    : sidebarWidth.open - buffer / 2;
+    ? sidebarWidth.open - transitionMargin
+    : sidebarWidth.open - transitionMargin / 2;
   const minimumTransformX = visibleSidebar
     ? sidebarWidth.open
     : sidebarWidth.closed;

--- a/src/components/flowchart/flowchart.js
+++ b/src/components/flowchart/flowchart.js
@@ -506,7 +506,7 @@ export class FlowChart extends Component {
       // the hold shift only happens on clicking a node first
       // but only if no filters are currently applied.
       if (event.shiftKey && !this.props.isSlicingPipelineApplied) {
-        this.handleShiftClick(node);
+        this.handleMultipleNodesClick(node);
       }
     }
 
@@ -546,7 +546,7 @@ export class FlowChart extends Component {
     }
   };
 
-  handleShiftClick = (node) => {
+  handleMultipleNodesClick = (node) => {
     // Close meta data panel
     this.props.onLoadNodeData(null);
 


### PR DESCRIPTION
## Description
Fixes #1975 
User story: As a Kedro user, I want to view my sliced pipeline and its corresponding run command so that I can run this slice in the CLI for my Kedro project. I also want to be able to reset my sliced pipeline view so that I can go back to viewing the full Kedro pipeline

## Development:

https://github.com/user-attachments/assets/96b0f6b1-0375-4fa9-985f-2c279550f6e5



## QA notes:
When testing on your machine locally, or through gitpod, please note that this PR only covers the functionalities below:

- [x]  Filtered Nodes View: A new view should display all the filtered nodes.
- [x]  Updated Node List: The node list should reflect all the newly filtered nodes.
- [x]  CLI Command Display: A command line at the bottom should show how to run the filtered nodes in the CLI.
- [x]  Close the sliced view: Click the exit button should take the user back to viewing the full kedro pipeline

Figma: https://www.figma.com/design/3kSpvIO1veLKfy9qHxuXwF/Kedro-WIP?node-id=1469-56945&t=gAB4IcCLRWoEGtZQ-0
