### PR TITLE
Doc build fix: Demo site experiment tracking url updated

### DIFF
--- a/docs/source/experiment_tracking.md
+++ b/docs/source/experiment_tracking.md
@@ -346,7 +346,7 @@ Parallel coordinates displays all metrics on a single graph, with each vertical 
 When in comparison view, comparing runs highlights your selections on the respective chart types, improving readability even in the event there is a multitude of data points.
 
 ```{note}
-The following graphic is taken from the [Kedro-Viz experiment tracking demo](https://demo.kedro.org/experiment-tracking) (it is not a visualisation from the example code you created above).
+The following graphic is taken from the [Kedro-Viz experiment tracking demo](https://demo.kedro.org/#/experiment-tracking) (it is not a visualisation from the example code you created above).
 ```
 
 ![](./images/experiment-tracking-metrics-comparison.gif)

--- a/docs/source/experiment_tracking.md
+++ b/docs/source/experiment_tracking.md
@@ -346,7 +346,7 @@ Parallel coordinates displays all metrics on a single graph, with each vertical 
 When in comparison view, comparing runs highlights your selections on the respective chart types, improving readability even in the event there is a multitude of data points.
 
 ```{note}
-The following graphic is taken from the [Kedro-Viz experiment tracking demo](https://demo.kedro.org/#/experiment-tracking) (it is not a visualisation from the example code you created above).
+The following graphic is taken from the [Kedro-Viz experiment tracking demo](https://demo.kedro.org/) (it is not a visualisation from the example code you created above).
 ```
 
 ![](./images/experiment-tracking-metrics-comparison.gif)


### PR DESCRIPTION
## Description

Resolves https://github.com/kedro-org/kedro-viz/issues/2050

After we moved demo site to Github pages, it doesn’t support routers that use the HTML5 pushState history API. So accessing the URL https://demo.kedro.org/experiment-tracking directly in the browser leads in 404.

This leads to broken build for the read the docs. https://readthedocs.org/projects/kedro-viz/builds/25360375/   

## Development notes

- As a workaround, we are updating broken link to https://demo.kedro.org/#/experiment-tracking to avoid CI build failure. 
- On updated link clicks on docs, user will be redirected to the home page. 


## Checklist

- [X] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes
