### PR TITLE
Disable slicing feature in embedded mode

### DIFF
--- a/src/components/flowchart/flowchart.js
+++ b/src/components/flowchart/flowchart.js
@@ -794,7 +794,7 @@ export class FlowChart extends Component {
       visibleSidebar,
       clickedNode,
       modularPipelineIds,
-      isSlicingDisable,
+      isSlicingDisabled,
     } = this.props;
     const { outerWidth = 0, outerHeight = 0 } = chartSize;
     const { showSlicingNotification } = this.state;
@@ -864,7 +864,7 @@ export class FlowChart extends Component {
           })}
           ref={this.layerNamesRef}
         />
-        {showSlicingNotification && !isSlicingDisable && (
+        {showSlicingNotification && !isSlicingDisabled && (
           <SlicedPipelineNotification
             notification={
               'Hold Shift + Click on another node to slice pipeline'
@@ -940,7 +940,7 @@ export const mapStateToProps = (state, ownProps) => ({
   visibleMetaSidebar: getVisibleMetaSidebar(state),
   slicedPipeline: getSlicedPipeline(state),
   isSlicingPipelineApplied: state.slice.apply,
-  isSlicingDisable: state.disableSlicing,
+  isSlicingDisabled: state.disableSlicing,
   runCommand: getRunCommand(state),
   ...ownProps,
 });

--- a/src/components/flowchart/flowchart.js
+++ b/src/components/flowchart/flowchart.js
@@ -794,6 +794,7 @@ export class FlowChart extends Component {
       visibleSidebar,
       clickedNode,
       modularPipelineIds,
+      isSlicingDisable,
     } = this.props;
     const { outerWidth = 0, outerHeight = 0 } = chartSize;
     const { showSlicingNotification } = this.state;
@@ -863,7 +864,7 @@ export class FlowChart extends Component {
           })}
           ref={this.layerNamesRef}
         />
-        {showSlicingNotification && (
+        {showSlicingNotification && !isSlicingDisable && (
           <SlicedPipelineNotification
             notification={
               'Hold Shift + Click on another node to slice pipeline'
@@ -939,6 +940,7 @@ export const mapStateToProps = (state, ownProps) => ({
   visibleMetaSidebar: getVisibleMetaSidebar(state),
   slicedPipeline: getSlicedPipeline(state),
   isSlicingPipelineApplied: state.slice.apply,
+  isSlicingDisable: state.disableSlicing,
   runCommand: getRunCommand(state),
   ...ownProps,
 });

--- a/src/components/flowchart/flowchart.js
+++ b/src/components/flowchart/flowchart.js
@@ -794,7 +794,7 @@ export class FlowChart extends Component {
       visibleSidebar,
       clickedNode,
       modularPipelineIds,
-      isSlicingDisabled,
+      visibleSlicing,
     } = this.props;
     const { outerWidth = 0, outerHeight = 0 } = chartSize;
     const { showSlicingNotification } = this.state;
@@ -864,7 +864,7 @@ export class FlowChart extends Component {
           })}
           ref={this.layerNamesRef}
         />
-        {showSlicingNotification && !isSlicingDisabled && (
+        {showSlicingNotification && visibleSlicing && (
           <SlicedPipelineNotification
             notification={
               'Hold Shift + Click on another node to slice pipeline'
@@ -940,7 +940,7 @@ export const mapStateToProps = (state, ownProps) => ({
   visibleMetaSidebar: getVisibleMetaSidebar(state),
   slicedPipeline: getSlicedPipeline(state),
   isSlicingPipelineApplied: state.slice.apply,
-  isSlicingDisabled: state.disableSlicing,
+  visibleSlicing: state.visible.slicing,
   runCommand: getRunCommand(state),
   ...ownProps,
 });

--- a/src/components/flowchart/flowchart.test.js
+++ b/src/components/flowchart/flowchart.test.js
@@ -491,7 +491,7 @@ describe('FlowChart', () => {
       isSlicingPipelineApplied: expect.any(Boolean),
       runCommand: expect.any(Object),
       modularPipelineIds: expect.any(Object),
-      isSlicingDisable: expect.any(Boolean),
+      isSlicingDisabled: expect.any(Boolean),
     };
     expect(mapStateToProps(mockState.spaceflights)).toEqual(expectedResult);
   });

--- a/src/components/flowchart/flowchart.test.js
+++ b/src/components/flowchart/flowchart.test.js
@@ -491,6 +491,7 @@ describe('FlowChart', () => {
       isSlicingPipelineApplied: expect.any(Boolean),
       runCommand: expect.any(Object),
       modularPipelineIds: expect.any(Object),
+      isSlicingDisable: expect.any(Boolean),
     };
     expect(mapStateToProps(mockState.spaceflights)).toEqual(expectedResult);
   });

--- a/src/components/flowchart/flowchart.test.js
+++ b/src/components/flowchart/flowchart.test.js
@@ -491,7 +491,7 @@ describe('FlowChart', () => {
       isSlicingPipelineApplied: expect.any(Boolean),
       runCommand: expect.any(Object),
       modularPipelineIds: expect.any(Object),
-      isSlicingDisabled: expect.any(Boolean),
+      visibleSlicing: expect.any(Boolean),
     };
     expect(mapStateToProps(mockState.spaceflights)).toEqual(expectedResult);
   });

--- a/src/components/global-toolbar/global-toolbar.test.js
+++ b/src/components/global-toolbar/global-toolbar.test.js
@@ -55,6 +55,7 @@ describe('GlobalToolbar', () => {
         settingsModal: false,
         shareableUrlModal: false,
         sidebar: true,
+        slicing: true,
       },
     };
     expect(mapStateToProps(mockState.spaceflights)).toEqual(expectedResult);

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -88,7 +88,6 @@ const combinedReducer = combineReducers({
   // These props don't have any actions associated with them
   display: createReducer(null),
   dataSource: createReducer(null),
-  disableSlicing: createReducer(null),
   edge: createReducer({}),
   // These props have very simple non-nested actions
   chartSize: createReducer({}, UPDATE_CHART_SIZE, 'chartSize'),

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -88,6 +88,7 @@ const combinedReducer = combineReducers({
   // These props don't have any actions associated with them
   display: createReducer(null),
   dataSource: createReducer(null),
+  disableSlicing: createReducer(null),
   edge: createReducer({}),
   // These props have very simple non-nested actions
   chartSize: createReducer({}, UPDATE_CHART_SIZE, 'chartSize'),

--- a/src/store/initial-state.js
+++ b/src/store/initial-state.js
@@ -57,6 +57,7 @@ export const createInitialState = () => ({
   },
   zoom: {},
   runsMetadata: {},
+  disableSlicing: false,
 });
 
 const parseUrlParameters = () => {

--- a/src/store/initial-state.js
+++ b/src/store/initial-state.js
@@ -43,6 +43,7 @@ export const createInitialState = () => ({
     settingsModal: false,
     shareableUrlModal: false,
     sidebar: window.innerWidth > sidebarWidth.breakpoint,
+    slicing: true,
   },
   display: {
     globalNavigation: true,
@@ -57,7 +58,6 @@ export const createInitialState = () => ({
   },
   zoom: {},
   runsMetadata: {},
-  disableSlicing: false,
 });
 
 const parseUrlParameters = () => {


### PR DESCRIPTION
## Description

Resolves https://github.com/kedro-org/kedro-viz/pull/2036#issuecomment-2318462807

We are disabling slicing feature when using kedro-viz as a React Component to avoid some UI related to [issue](https://github.com/kedro-org/kedro-viz/pull/2036#issuecomment-2318462807) just for Kedro VSCode extension `0.0.2` release.

**Note:** In this PR we are disabling just node click notification and not entire slicing feature.

## Development notes

- To disable notifications, set the `disableSlicing` prop to true in the Redux state. 
- In `flowchart.js`, when the `disableSlicing` prop is enabled, node click notifications will be disabled.

## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes
