### PR TITLE
Extra Disclaimer word removed

### DIFF
--- a/src/components/shareable-url-modal/main-view/main-view.js
+++ b/src/components/shareable-url-modal/main-view/main-view.js
@@ -43,8 +43,8 @@ const renderTextContent = (isPreviewEnabled, setIsPreviewEnabled) => {
         Disclaimer{' '}
       </h2>
       <p className="shareable-url-modal__content-description">
-        Disclaimer Kedro-Viz contains preview data for multiple datasets. You
-        can enable or disable all previews when publishing Kedro-Viz.
+        Kedro-Viz contains preview data for multiple datasets. You can enable or
+        disable all previews when publishing Kedro-Viz.
       </p>
       <div className="shareable-url-modal__content-preview-dataset">
         All dataset previews


### PR DESCRIPTION
## Description

Resolves https://github.com/kedro-org/kedro-viz/issues/2107

In the Publish & Shareable-Viz modal. 'Disclaimer' is mentioned twice, it should only be the title and not in the description text.

## QA notes
<img width="374" alt="Screenshot 2024-09-26 at 1 56 33 p m" src="https://github.com/user-attachments/assets/df2f97d3-2639-4131-8090-75c89cdc9bfb">



## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes
