### PR TITLE
Improve `kedro viz build` usage documentation 

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -12,6 +12,10 @@ Please follow the established format:
 
 - Update Kedro-Viz telemetry for opt-out model (#2022)
 
+## Bug fixes and other changes
+
+- Improve `kedro viz build` usage documentation (#2126)
+
 
 # Release 10.0.0
 

--- a/docs/source/platform_agnostic_sharing_with_kedro_viz.md
+++ b/docs/source/platform_agnostic_sharing_with_kedro_viz.md
@@ -48,9 +48,8 @@ This creates a `build` folder containing your Kedro-Viz app package in your proj
 
 ## Running Kedro-Viz Locally
 
-When you generate the build folder using the command `kedro viz build`, it creates a build directory with an `index.html` file, which serves as the entry point for visualizing your pipeline. However, simply opening `index.html` using the `file://` protocol is not supported due to Cross-Origin Resource Sharing (CORS) policies in modern browsers.
+When you generate the build folder using the command `kedro viz build`, it creates a build directory with an `index.html` file, which serves as the entry point for visualizing your pipeline.
 
-### Using a Local Server
 
 To view your pipeline visualization correctly, you need to serve `index.html` using an HTTP server. Here are a few simple ways to do this:
 
@@ -71,6 +70,9 @@ To view your pipeline visualization correctly, you need to serve `index.html` us
         http-server
         ```
 
+```{warning}
+Simply opening `index.html` using the `file://` protocol is not supported due to Cross-Origin Resource Sharing (CORS) policies in modern browsers.
+```
 
 ## Static website hosting platforms such as GitHub Pages
 

--- a/docs/source/platform_agnostic_sharing_with_kedro_viz.md
+++ b/docs/source/platform_agnostic_sharing_with_kedro_viz.md
@@ -48,7 +48,7 @@ This creates a `build` folder containing your Kedro-Viz app package in your proj
 
 ## Running Kedro-Viz Locally
 
-When you generate build folder with the command `kedro viz build`, it creates a build directory with an `index.html` file, which is the entry point for visualizing your pipeline. However, simply opening `index.html` using the file protocol `file://` is not supported due to Cross-Origin Resource Sharing Policy in modern browsers.
+When you generate the build folder using the command `kedro viz build`, it creates a build directory with an `index.html` file, which serves as the entry point for visualizing your pipeline. However, simply opening `index.html` using the `file://` protocol is not supported due to Cross-Origin Resource Sharing (CORS) policies in modern browsers.
 
 ### Using a Local Server
 

--- a/docs/source/platform_agnostic_sharing_with_kedro_viz.md
+++ b/docs/source/platform_agnostic_sharing_with_kedro_viz.md
@@ -46,6 +46,32 @@ Starting from Kedro-Viz 9.2.0, `kedro viz build` will not include dataset previe
 
 This creates a `build` folder containing your Kedro-Viz app package in your project directory. 
 
+## Running Kedro-Viz Locally
+
+When you generate build folder with the command `kedro viz build`, it creates a build directory with an `index.html` file, which is the entry point for visualizing your pipeline. However, simply opening `index.html` using the file protocol `file://` is not supported due to Cross-Origin Resource Sharing Policy in modern browsers.
+
+### Using a Local Server
+
+To view your pipeline visualization correctly, you need to serve `index.html` using an HTTP server. Here are a few simple ways to do this:
+
+1. Python's Built-in HTTP Server:
+    - Navigate to the build directory and run:
+        ```bash
+        python -m http.server
+        ```
+    - This starts a web server at `http://localhost:8000`, which you can use to view index.html.
+
+2. Node's http-server:
+    - First, install it globally:
+        ```bash
+        npm install -g http-server
+        ```
+    - Then, run it from the build directory:
+        ```bash
+        http-server
+        ```
+
+
 ## Static website hosting platforms such as GitHub Pages
 
 Follow the steps [listed in the GitHub pages documentation](https://docs.github.com/en/pages/quickstart) to create a Git repository that supports GitHub Pages. On completion, push the contents of the previously created `build` folder to this new repository. Your site will be available at the following URL: `http://<username>.github.io`


### PR DESCRIPTION
## Description

Resolves https://github.com/kedro-org/kedro-viz/issues/1918

This PR adds additional documentation to clarify why `kedro-viz` cannot be run directly from a local filesystem (`file:// `protocol) without encountering specific issues. The intention is to provide more context to users who may try to use the file protocol and run into these issues.

## Context

Currently, attempting to run `kedro-viz` by simply opening index.html through the `file://` protocol causes [CORS issues](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS/Errors/CORSRequestNotHttp?utm_source=devtools&utm_medium=firefox-cors-errors&utm_campaign=default#loading_a_local_file). Most modern browsers enforce strict CORS policies for local files to prevent security vulnerabilities.

The file protocol (`file://`) is treated differently compared to other network requests. Requests to resources from a local file context (e.g., scripts, APIs) are treated as cross-origin requests by the browser, which results in CORS errors when trying to access JavaScript assets or other dynamic resources required by kedro-viz.

Therefore, the recommendation for a proper user experience is to run kedro-viz using a local web server, which avoids CORS policy issues and guarantees that all resources are correctly served and accessed. Examples of lightweight static servers include Python's `http.server` or Node.js `http-server`, which can easily serve the generated HTML.

This PR proposes updated documentation to explain why users need to run Kedro-Viz through a server, helping prevent confusion.


## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes
