### PR TITLE
Display Dataset Type with Library Prefix in Metadata Panel

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -16,6 +16,7 @@ Please follow the established format:
 
 - Improve `kedro viz build` usage documentation (#2126)
 - Fix unserializable parameters value (#2122)
+- Display full dataset type with library prefix in metadata panel (#2136)
 
 
 # Release 10.0.0

--- a/src/components/metadata/metadata.js
+++ b/src/components/metadata/metadata.js
@@ -123,10 +123,11 @@ const MetaData = ({
     const isList = Array.isArray(value);
     // Extract the library (first part) and the dataset type (last part)
     const getQualifier = (val) => {
-      const parts = val.split('.');
-      if (parts.length > 1) {
+      if (typeof val === 'string' && val.includes('.')) {
+        const parts = val.split('.');
         return `${parts[0]}.${parts.pop()}`;
       }
+      // If val is not a string or does not include a dot return as is
       return val;
     };
 

--- a/src/components/metadata/metadata.js
+++ b/src/components/metadata/metadata.js
@@ -121,10 +121,16 @@ const MetaData = ({
 
   const shortenDatasetType = (value) => {
     const isList = Array.isArray(value);
+    // Extract the library (first part) and the dataset type (last part)
+    const getQualifier = (val) => {
+      const parts = val.split('.');
+      if (parts.length > 1) {
+        return `${parts[0]}.${parts.pop()}`;
+      }
+      return val;
+    };
 
-    return isList
-      ? value.map((val) => val.split('.').pop())
-      : value?.split('.').pop();
+    return isList ? value.map(getQualifier) : getQualifier(value);
   };
 
   return (

--- a/src/components/metadata/metadata.test.js
+++ b/src/components/metadata/metadata.test.js
@@ -303,7 +303,7 @@ describe('MetaData', () => {
         mockMetadata: nodeData,
       });
       const row = rowByLabel(wrapper, 'Dataset Type:');
-      expect(textOf(rowValue(row))).toEqual(['CSVDataset']);
+      expect(textOf(rowValue(row))).toEqual(['pandas.CSVDataset']);
     });
 
     it('shows the node filepath', () => {
@@ -402,7 +402,7 @@ describe('MetaData', () => {
           mockMetadata: nodeTranscodedData,
         });
         const row = rowByLabel(wrapper, 'Original Type:');
-        expect(textOf(rowValue(row))).toEqual(['SparkDataset']);
+        expect(textOf(rowValue(row))).toEqual(['spark.SparkDataset']);
       });
 
       it('shows the node transcoded type', () => {
@@ -411,7 +411,7 @@ describe('MetaData', () => {
           mockMetadata: nodeTranscodedData,
         });
         const row = rowByLabel(wrapper, 'Transcoded Types:');
-        expect(textOf(rowValue(row))).toEqual(['ParquetDataset']);
+        expect(textOf(rowValue(row))).toEqual(['pandas.ParquetDataset']);
       });
     });
     describe('Metrics dataset nodes', () => {


### PR DESCRIPTION
## Description

Related to: https://github.com/kedro-org/kedro-viz/issues/2071

The dataset type in the metadata panel was not clear for example, If I have a `polars.CSVDataset` and a `pandas.CSVDataset`, both display just `CSVDataset`.

## Development notes

Updated the logic to include the library name as a prefix (e.g., `pandas.CSVDataset`), making it clearer to differentiate between datasets.

<img width="1247" alt="image" src="https://github.com/user-attachments/assets/39ad3020-86c7-4669-bcbe-18838a1b07a1">


## QA notes

Tested manually with various dataset types (e.g., pandas, polars) to ensure proper display.

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes
