### PR TITLE
Fix FE when `tag` name is `undefined`

### DIFF
--- a/src/selectors/tags.js
+++ b/src/selectors/tags.js
@@ -1,5 +1,6 @@
 import { createSelector } from 'reselect';
 import { getPipelineTagIDs } from './pipeline';
+import { prettifyName } from '../utils';
 
 const getNodeTags = (state) => state.node.tags;
 const getTagName = (state) => state.tag.name;
@@ -14,7 +15,7 @@ export const getTagData = createSelector(
   (tagIDs, tagName, tagActive, tagEnabled) =>
     tagIDs.sort().map((id) => ({
       id,
-      name: tagName[id] || id,
+      name: tagName[id] || prettifyName(id),
       active: Boolean(tagActive[id]),
       enabled: Boolean(tagEnabled[id]),
     }))

--- a/src/selectors/tags.js
+++ b/src/selectors/tags.js
@@ -14,7 +14,7 @@ export const getTagData = createSelector(
   (tagIDs, tagName, tagActive, tagEnabled) =>
     tagIDs.sort().map((id) => ({
       id,
-      name: tagName[id],
+      name: tagName[id] || id,
       active: Boolean(tagActive[id]),
       enabled: Boolean(tagEnabled[id]),
     }))

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -120,7 +120,7 @@ export const stripNamespace = (str) => {
  * @param {String} str The string to check
  * @returns {String} The string with or without replaced values
  */
-export const prettifyName = (str) => {
+export const prettifyName = (str = '') => {
   const replacedString = str
     .replace(/-/g, ' ')
     .replace(/_/g, ' ')

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -120,7 +120,10 @@ export const stripNamespace = (str) => {
  * @param {String} str The string to check
  * @returns {String} The string with or without replaced values
  */
-export const prettifyName = (str = '') => {
+export const prettifyName = (str) => {
+  if (!str) {
+    return '';
+  }
   const replacedString = str
     .replace(/-/g, ' ')
     .replace(/_/g, ' ')


### PR DESCRIPTION
## Description

Partly resolves #2106 

## Development notes

In the user's pipeline, one of the nodes was tagged as `validation`. While this tag was mentioned in the `{ node: { tags: [] } }` response, it wasn't somehow mentioned in the `{ tags: {} }` response which caused the flowchart to break. We were unable to reproduce this issue on the backend, which would have been the optimal place to address it.

As a workaround, we fixed this on the frontend. When a tag is not defined  correctly in the backend, the frontend cannot link the tag to the corresponding tag name. Since the tag name and ID are the same, we added a fallback. If the tag name is undefined (due to an error we still need to investigate), we use the tag ID itself as a fallback. This prevents Kedro-Viz from breaking and ensures the flowchart runs correctly.


## QA notes

To test this fix using the demo project:

Run `kedro viz --save-file=test`. This will create a test folder with an api folder inside.
Move the `api` folder into the `kedro-viz/public` directory.
Remove 'company' dict from `tags:` in `api/main` folder
Run `npm run start:dev`.
Before this PR, you will see the app breaking with the error message the user encountered. After applying the PR, the issue will be fixed.


## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes
