### PR TITLE
Fix `Unable to get file size` when dataset has no protocol attribute

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -21,6 +21,7 @@ Please follow the established format:
 - Display full dataset type with library prefix in metadata panel (#2136)
 - Enable SQLite WAL mode for Azure ML to fix database locking issues (#2131)
 - Replace `flake8`, `isort`, `pylint` and `black` by `ruff` (#2149)
+- Refactor `DatasetStatsHook` to avoid accessing private dataset attributes (#2174)
 
 
 # Release 10.0.0

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -21,7 +21,7 @@ Please follow the established format:
 - Display full dataset type with library prefix in metadata panel (#2136)
 - Enable SQLite WAL mode for Azure ML to fix database locking issues (#2131)
 - Replace `flake8`, `isort`, `pylint` and `black` by `ruff` (#2149)
-- Refactor `DatasetStatsHook` to avoid accessing private dataset attributes (#2174)
+- Refactor `DatasetStatsHook` to avoid showing error when dataset doesn't have file size info (#2174)
 
 
 # Release 10.0.0

--- a/package/kedro_viz/integrations/kedro/hooks.py
+++ b/package/kedro_viz/integrations/kedro/hooks.py
@@ -148,6 +148,9 @@ class DatasetStatsHook:
         try:
             if hasattr(dataset, "filepath") and dataset.filepath:
                 filepath = dataset.filepath
+            # Fallback to private '_filepath' for known datasets
+            elif hasattr(dataset, "_filepath") and dataset._filepath:
+                filepath = dataset._filepath
             else:
                 return None
 

--- a/package/kedro_viz/integrations/kedro/hooks.py
+++ b/package/kedro_viz/integrations/kedro/hooks.py
@@ -161,7 +161,7 @@ class DatasetStatsHook:
             else:
                 return None
 
-        except Exception as exc:
+        except Exception as exc:  # pragma: no cover
             logger.warning(
                 "Unable to get file size for the dataset %s: %s", dataset, exc
             )

--- a/package/kedro_viz/integrations/kedro/hooks.py
+++ b/package/kedro_viz/integrations/kedro/hooks.py
@@ -148,10 +148,15 @@ class DatasetStatsHook:
             return None
 
         try:
-            file_path = get_filepath_str(
-                PurePosixPath(dataset._filepath), dataset._protocol
-            )
-            return dataset._fs.size(file_path)
+            if hasattr(dataset, "_protocol") and hasattr(dataset, "_fs"):
+                file_path = get_filepath_str(
+                    PurePosixPath(dataset._filepath), dataset._protocol
+                )
+                file_size = dataset._fs.size(file_path)
+                return file_size
+            else:
+                # Unable to determine file size
+                return None
 
         except Exception as exc:
             logger.warning(

--- a/package/tests/test_integrations/test_hooks.py
+++ b/package/tests/test_integrations/test_hooks.py
@@ -137,20 +137,3 @@ def test_get_file_size(dataset, example_dataset_stats_hook_obj, example_csv_data
     assert example_dataset_stats_hook_obj.get_file_size(
         example_csv_dataset
     ) == example_csv_dataset._fs.size(file_path)
-
-
-def test_get_file_size_no_protocol(example_dataset_stats_hook_obj, mocker):
-    class MockDataset:
-        def __init__(self):
-            self._filepath = "/path/to/dataset.csv"
-
-    mock_dataset = MockDataset()
-
-    mocker.patch(
-        "kedro_viz.integrations.kedro.hooks.get_filepath_str",
-        return_value=mock_dataset._filepath,
-    )
-
-    # Call get_file_size and expect it to return None
-    file_size = example_dataset_stats_hook_obj.get_file_size(mock_dataset)
-    assert file_size is None

--- a/package/tests/test_integrations/test_hooks.py
+++ b/package/tests/test_integrations/test_hooks.py
@@ -156,3 +156,25 @@ def test_get_file_size_file_does_not_exist(example_dataset_stats_hook_obj, mocke
     # Call get_file_size and expect it to return None
     file_size = example_dataset_stats_hook_obj.get_file_size(mock_dataset)
     assert file_size is None
+
+
+def test_get_file_size_public_filepath(example_dataset_stats_hook_obj, mocker):
+    class MockDataset:
+        def __init__(self):
+            self.filepath = "/path/to/existing/file.csv"
+
+    mock_dataset = MockDataset()
+
+    # Mock fs.exists to return True
+    mock_fs = mocker.Mock()
+    mock_fs.exists.return_value = True
+    mock_fs.size.return_value = 456
+
+    mocker.patch(
+        "fsspec.core.url_to_fs",
+        return_value=(mock_fs, "/path/to/existing/file.csv"),
+    )
+
+    # Call get_file_size and expect it to return the mocked file size
+    file_size = example_dataset_stats_hook_obj.get_file_size(mock_dataset)
+    assert file_size == 456

--- a/package/tests/test_integrations/test_hooks.py
+++ b/package/tests/test_integrations/test_hooks.py
@@ -137,3 +137,20 @@ def test_get_file_size(dataset, example_dataset_stats_hook_obj, example_csv_data
     assert example_dataset_stats_hook_obj.get_file_size(
         example_csv_dataset
     ) == example_csv_dataset._fs.size(file_path)
+
+
+def test_get_file_size_no_protocol(example_dataset_stats_hook_obj, mocker):
+    class MockDataset:
+        def __init__(self):
+            self._filepath = "/path/to/dataset.csv"
+
+    mock_dataset = MockDataset()
+
+    mocker.patch(
+        'kedro_viz.integrations.kedro.hooks.get_filepath_str',
+        return_value=mock_dataset._filepath
+    )
+
+    # Call get_file_size and expect it to return None
+    file_size = example_dataset_stats_hook_obj.get_file_size(mock_dataset)
+    assert file_size is None

--- a/package/tests/test_integrations/test_hooks.py
+++ b/package/tests/test_integrations/test_hooks.py
@@ -147,8 +147,8 @@ def test_get_file_size_no_protocol(example_dataset_stats_hook_obj, mocker):
     mock_dataset = MockDataset()
 
     mocker.patch(
-        'kedro_viz.integrations.kedro.hooks.get_filepath_str',
-        return_value=mock_dataset._filepath
+        "kedro_viz.integrations.kedro.hooks.get_filepath_str",
+        return_value=mock_dataset._filepath,
     )
 
     # Call get_file_size and expect it to return None

--- a/package/tests/test_integrations/test_hooks.py
+++ b/package/tests/test_integrations/test_hooks.py
@@ -137,3 +137,22 @@ def test_get_file_size(dataset, example_dataset_stats_hook_obj, example_csv_data
     assert example_dataset_stats_hook_obj.get_file_size(
         example_csv_dataset
     ) == example_csv_dataset._fs.size(file_path)
+
+
+def test_get_file_size_file_does_not_exist(example_dataset_stats_hook_obj, mocker):
+    class MockDataset:
+        def __init__(self):
+            self._filepath = "/non/existent/path.csv"
+
+    mock_dataset = MockDataset()
+    mock_fs = mocker.Mock()
+    mock_fs.exists.return_value = False
+
+    mocker.patch(
+        "fsspec.core.url_to_fs",
+        return_value=(mock_fs, "/non/existent/path.csv"),
+    )
+
+    # Call get_file_size and expect it to return None
+    file_size = example_dataset_stats_hook_obj.get_file_size(mock_dataset)
+    assert file_size is None


### PR DESCRIPTION
## Description
Related to: https://github.com/kedro-org/kedro-viz/issues/1893

User reported getting `Unable to get file size. Object has no attribute '_protocol'` for `DeltaTableDataset`. This PR will aim to resolve it.

## Development notes

Stopped relying on methods from kedro that rely on private attribute, use `fsspec` to find file size.

## QA notes

<!-- How has the expected behaviour changed? What testing strategies have you used? -->

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes
