### PR TITLE
Add port in use check to prevent browser redirecting incorrectly for kedro viz

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -21,6 +21,7 @@ Please follow the established format:
 - Display full dataset type with library prefix in metadata panel (#2136)
 - Enable SQLite WAL mode for Azure ML to fix database locking issues (#2131)
 - Replace `flake8`, `isort`, `pylint` and `black` by `ruff` (#2149)
+- Add check for port availability before starting Kedro Viz to prevent unintended browser redirects when the port is already in use (#2176)
 
 
 # Release 10.0.0

--- a/package/kedro_viz/launchers/cli/run.py
+++ b/package/kedro_viz/launchers/cli/run.py
@@ -189,7 +189,7 @@ def run(
                 target=run_server, daemon=False, kwargs={**run_server_kwargs}
             )
 
-        display_cli_message(f"Starting Kedro Viz on port {port}...", "green")
+        display_cli_message("Starting Kedro Viz ...", "green")
         viz_process.start()
 
         _VIZ_PROCESSES[port] = viz_process

--- a/package/kedro_viz/launchers/cli/run.py
+++ b/package/kedro_viz/launchers/cli/run.py
@@ -116,6 +116,7 @@ def run(
         _PYPROJECT,
         _check_viz_up,
         _find_kedro_project,
+        _is_port_in_use,
         _start_browser,
         _wait_for,
         display_cli_message,
@@ -145,6 +146,18 @@ def run(
             "https://github.com/kedro-org/kedro-viz/releases.",
             "yellow",
         )
+
+    # Check if the port is already in use
+    if _is_port_in_use(host, port):
+        display_cli_message(
+            f"Error: Port {port} is already in use. Kedro Viz could not start.",
+            "red",
+        )
+        display_cli_message(
+            "Please specify a different port using the '--port' option.",
+            "red",
+        )
+        return
     try:
         if port in _VIZ_PROCESSES and _VIZ_PROCESSES[port].is_alive():
             _VIZ_PROCESSES[port].terminate()

--- a/package/kedro_viz/launchers/cli/run.py
+++ b/package/kedro_viz/launchers/cli/run.py
@@ -115,8 +115,8 @@ def run(
     from kedro_viz.launchers.utils import (
         _PYPROJECT,
         _check_viz_up,
+        _find_available_port,
         _find_kedro_project,
-        _is_port_in_use,
         _start_browser,
         _wait_for,
         display_cli_message,
@@ -147,17 +147,8 @@ def run(
             "yellow",
         )
 
-    # Check if the port is already in use
-    if _is_port_in_use(host, port):
-        display_cli_message(
-            f"Error: Port {port} is already in use. Kedro Viz could not start.",
-            "red",
-        )
-        display_cli_message(
-            "Please specify a different port using the '--port' option.",
-            "red",
-        )
-        return
+    port = _find_available_port(host, port)
+
     try:
         if port in _VIZ_PROCESSES and _VIZ_PROCESSES[port].is_alive():
             _VIZ_PROCESSES[port].terminate()
@@ -198,8 +189,7 @@ def run(
                 target=run_server, daemon=False, kwargs={**run_server_kwargs}
             )
 
-        display_cli_message("Starting Kedro Viz ...", "green")
-
+        display_cli_message(f"Starting Kedro Viz on port {port}...", "green")
         viz_process.start()
 
         _VIZ_PROCESSES[port] = viz_process

--- a/package/kedro_viz/launchers/utils.py
+++ b/package/kedro_viz/launchers/utils.py
@@ -3,6 +3,7 @@ used in the `kedro_viz.launchers` package."""
 
 import logging
 import socket
+import sys
 import webbrowser
 from pathlib import Path
 from time import sleep, time
@@ -84,6 +85,28 @@ def _check_viz_up(host: str, port: int):
 def _is_port_in_use(host: str, port: int):
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
         return s.connect_ex((host, port)) == 0
+
+
+def _find_available_port(host: str, start_port: int, max_attempts: int = 5) -> int:
+    max_port = start_port + max_attempts - 1
+    port = start_port
+    while port <= max_port:
+        if not _is_port_in_use(host, port):
+            return port
+        display_cli_message(
+            f"Port {port} is already in use. Trying the next port...",
+            "yellow",
+        )
+        port += 1
+    display_cli_message(
+        f"Error: All ports in the range {start_port}-{max_port} are in use.",
+        "red",
+    )
+    display_cli_message(
+        "Please specify a different port using the '--port' option.",
+        "red",
+    )
+    sys.exit(1)
 
 
 def _is_localhost(host: str) -> bool:

--- a/package/kedro_viz/launchers/utils.py
+++ b/package/kedro_viz/launchers/utils.py
@@ -2,6 +2,7 @@
 used in the `kedro_viz.launchers` package."""
 
 import logging
+import socket
 import webbrowser
 from pathlib import Path
 from time import sleep, time
@@ -78,6 +79,11 @@ def _check_viz_up(host: str, port: int):
         return False
 
     return response.status_code == 200
+
+
+def _is_port_in_use(host: str, port: int):
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        return s.connect_ex((host, port)) == 0
 
 
 def _is_localhost(host: str) -> bool:

--- a/package/tests/test_launchers/test_cli/test_run.py
+++ b/package/tests/test_launchers/test_cli/test_run.py
@@ -10,7 +10,7 @@ from kedro_viz import __version__
 from kedro_viz.autoreload_file_filter import AutoreloadFileFilter
 from kedro_viz.launchers.cli import main
 from kedro_viz.launchers.cli.run import _VIZ_PROCESSES
-from kedro_viz.launchers.utils import _PYPROJECT
+from kedro_viz.launchers.utils import _PYPROJECT, _find_available_port
 from kedro_viz.server import run_server
 
 
@@ -394,3 +394,17 @@ class TestCliRunViz:
             kwargs={**run_process_kwargs},
         )
         assert run_process_kwargs["kwargs"]["port"] in _VIZ_PROCESSES
+
+    # Test case to simulate port occupation and check available port selection
+    def test_find_available_port_with_occupied_ports(self, mocker):
+        mock_is_port_in_use = mocker.patch("kedro_viz.launchers.utils._is_port_in_use")
+
+        # Mock ports 4141, 4142 being occupied and 4143 is free
+        mock_is_port_in_use.side_effect = [True, True, False]
+
+        available_port = _find_available_port("127.0.0.1", 4141)
+
+        # Assert that the function returns the first free port, 4143
+        assert (
+            available_port == 4143
+        ), "Expected port 4143 to be returned as the available port"

--- a/package/tests/test_launchers/test_cli/test_run.py
+++ b/package/tests/test_launchers/test_cli/test_run.py
@@ -217,6 +217,9 @@ class TestCliRunViz:
             "kedro_viz.launchers.utils._wait_for.__defaults__", (True, 1, True, 1)
         )
 
+        # Mock _is_port_in_use to speed up test.
+        mocker.patch("kedro_viz.launchers.utils._is_port_in_use", return_value=False)
+
         # Mock finding kedro project
         mocker.patch(
             "kedro_viz.launchers.utils._find_kedro_project",


### PR DESCRIPTION
## Description
Related to: https://github.com/kedro-org/kedro-viz/issues/2052

If there is an existing Kedro Viz server running, kedro viz run will redirect the browser to that one when a second instance of kedro viz is launched using the same port and the error message from uvicorn is missed.

## Development notes

Check that the port is in use before running the server and increment it until a max 5 times to find an alternative free port, if none are found send error message to users no free ports available and suggest them to use `--port`.

## QA notes

<!-- How has the expected behaviour changed? What testing strategies have you used? -->

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [x] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes
