### PR TITLE
telemetry/add kedro_Viz_version to heaps

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -24,6 +24,7 @@ Please follow the established format:
 - Refactor `DatasetStatsHook` to avoid showing error when dataset doesn't have file size info (#2174)
 - Fix 404 error when accessing the experiment tracking page on the demo site (#2179)
 - Add check for port availability before starting Kedro Viz to prevent unintended browser redirects when the port is already in use (#2176)
+- Include kedro_viz_version in telemetry. (#2194)
 
 
 # Release 10.0.0

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -24,7 +24,7 @@ Please follow the established format:
 - Refactor `DatasetStatsHook` to avoid showing error when dataset doesn't have file size info (#2174)
 - Fix 404 error when accessing the experiment tracking page on the demo site (#2179)
 - Add check for port availability before starting Kedro Viz to prevent unintended browser redirects when the port is already in use (#2176)
-- Include kedro_viz_version in telemetry. (#2194)
+- Include Kedro Viz version in telemetry.. (#2194)
 
 
 # Release 10.0.0

--- a/package/kedro_viz/api/apps.py
+++ b/package/kedro_viz/api/apps.py
@@ -92,7 +92,7 @@ def create_api_app_from_project(
         env = Environment(loader=FileSystemLoader(_HTML_DIR))
         if should_add_telemetry:
             telemetry_content = env.get_template("telemetry.html").render(
-                heap_app_id=heap_app_id, 
+                heap_app_id=heap_app_id,
                 heap_user_identity=heap_user_identity,
                 kedro_viz_version=__version__
             )

--- a/package/kedro_viz/api/apps.py
+++ b/package/kedro_viz/api/apps.py
@@ -92,7 +92,9 @@ def create_api_app_from_project(
         env = Environment(loader=FileSystemLoader(_HTML_DIR))
         if should_add_telemetry:
             telemetry_content = env.get_template("telemetry.html").render(
-                heap_app_id=heap_app_id, heap_user_identity=heap_user_identity
+                heap_app_id=heap_app_id, 
+                heap_user_identity=heap_user_identity,
+                kedro_viz_version=__version__
             )
             injected_head_content.append(telemetry_content)
 

--- a/package/kedro_viz/api/apps.py
+++ b/package/kedro_viz/api/apps.py
@@ -94,7 +94,7 @@ def create_api_app_from_project(
             telemetry_content = env.get_template("telemetry.html").render(
                 heap_app_id=heap_app_id,
                 heap_user_identity=heap_user_identity,
-                kedro_viz_version=__version__
+                kedro_viz_version=__version__,
             )
             injected_head_content.append(telemetry_content)
 

--- a/package/kedro_viz/integrations/deployment/base_deployer.py
+++ b/package/kedro_viz/integrations/deployment/base_deployer.py
@@ -51,7 +51,9 @@ class BaseDeployer(abc.ABC):
         if should_add_telemetry:
             logger.debug("Ingesting heap analytics.")
             telemetry_content = env.get_template("telemetry.html").render(
-                heap_app_id=heap_app_id, heap_user_identity=heap_user_identity
+                heap_app_id=heap_app_id,
+                heap_user_identity=heap_user_identity,
+                kedro_viz_version=__version__,
             )
             injected_head_content.append(telemetry_content)
 

--- a/public/telemetry.html
+++ b/public/telemetry.html
@@ -2,5 +2,8 @@
   window.heap=window.heap||[],heap.load=function(e,t){window.heap.appid=e,window.heap.config=t=t||{};var r=document.createElement("script");r.type="text/javascript",r.async=!0,r.src="https://cdn.heapanalytics.com/js/heap-"+e+".js";var a=document.getElementsByTagName("script")[0];a.parentNode.insertBefore(r,a);for(var n=function(e){return function(){heap.push([e].concat(Array.prototype.slice.call(arguments,0)))}},p=["addEventProperties","addUserProperties","clearEventProperties","identify","resetIdentity","removeEventProperty","setEventProperties","track","unsetEventProperty"],o=0;o<p.length;o++)heap[p[o]]=n(p[o])};
   heap.load("{{ heap_app_id }}"); 
   heap.identify("{{ heap_user_identity }}");
+  heap.addEventProperties({
+    kedro_viz_version: "{{ kedro_viz_version }}",
+  });
 </script>
 </head>

--- a/public/telemetry.html
+++ b/public/telemetry.html
@@ -2,8 +2,6 @@
   window.heap=window.heap||[],heap.load=function(e,t){window.heap.appid=e,window.heap.config=t=t||{};var r=document.createElement("script");r.type="text/javascript",r.async=!0,r.src="https://cdn.heapanalytics.com/js/heap-"+e+".js";var a=document.getElementsByTagName("script")[0];a.parentNode.insertBefore(r,a);for(var n=function(e){return function(){heap.push([e].concat(Array.prototype.slice.call(arguments,0)))}},p=["addEventProperties","addUserProperties","clearEventProperties","identify","resetIdentity","removeEventProperty","setEventProperties","track","unsetEventProperty"],o=0;o<p.length;o++)heap[p[o]]=n(p[o])};
   heap.load("{{ heap_app_id }}"); 
   heap.identify("{{ heap_user_identity }}");
-  heap.addEventProperties({
-    kedro_viz_version: "{{ kedro_viz_version }}",
-  });
+  heap.addEventProperties("{{ kedro_viz_version }}");
 </script>
 </head>

--- a/public/telemetry.html
+++ b/public/telemetry.html
@@ -2,6 +2,8 @@
   window.heap=window.heap||[],heap.load=function(e,t){window.heap.appid=e,window.heap.config=t=t||{};var r=document.createElement("script");r.type="text/javascript",r.async=!0,r.src="https://cdn.heapanalytics.com/js/heap-"+e+".js";var a=document.getElementsByTagName("script")[0];a.parentNode.insertBefore(r,a);for(var n=function(e){return function(){heap.push([e].concat(Array.prototype.slice.call(arguments,0)))}},p=["addEventProperties","addUserProperties","clearEventProperties","identify","resetIdentity","removeEventProperty","setEventProperties","track","unsetEventProperty"],o=0;o<p.length;o++)heap[p[o]]=n(p[o])};
   heap.load("{{ heap_app_id }}"); 
   heap.identify("{{ heap_user_identity }}");
-  heap.addEventProperties("{{ kedro_viz_version }}");
+  heap.addEventProperties({
+    kedro_viz_version: "{{ kedro_viz_version }}",
+  });
 </script>
 </head>


### PR DESCRIPTION
## Description

Fixes https://github.com/kedro-org/kedro-plugins/issues/923

To include kedro_viz_version when user interacts with viz

## Development notes

When test this locally, ensure you enable `consent: true` in `project-demo telemetry`, and in the heap dash board development environment, it should show kedro_viz_version as one of the property
![Screenshot 2024-11-15 at 13 17 39](https://github.com/user-attachments/assets/a7a5f279-1de7-4544-b8da-779e5fb4b239)

## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes
