### PR TITLE
Update `isRunningLocally` Function to Recognise Private IP Addresses for Consistent GUI Rendering

### DIFF
--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -188,22 +188,38 @@ export const formatNumberWithCommas = (number) => {
 };
 
 /**
- * Test if Kedro-Viz is running on our known local ports.
+ * Test if Kedro-Viz is running on our known local ports or private IP ranges.
  * @returns {Boolean} True if the app is running locally.
  */
 export const isRunningLocally = () => {
   const hosts = [
     'localhost',
     '127.0.0.1',
+    '0.0.0.0',
     'demo.kedro.org',
     'gitpod',
     'kedro-org',
   ];
-  const itemFound = hosts.some((host) =>
-    window.location.hostname.includes(host)
-  );
 
-  return itemFound;
+  const hostname = window.location.hostname;
+
+  // Check if hostname matches known hosts
+  if (hosts.some((host) => hostname.includes(host))) {
+    return true;
+  }
+
+  // Regular expressions for private IP ranges
+  const privateIpRanges = [
+    // 10.0.0.0 – 10.255.255.255
+    /^10\.\d{1,3}\.\d{1,3}\.\d{1,3}$/,
+    // 172.16.0.0 – 172.31.255.255
+    /^172\.(1[6-9]|2[0-9]|3[0-1])\.\d{1,3}\.\d{1,3}$/,
+    // 192.168.0.0 – 192.168.255.255
+    /^192\.168\.\d{1,3}\.\d{1,3}$/,
+  ];
+
+  // Check if hostname is a private IP address
+  return privateIpRanges.some((regex) => regex.test(hostname));
 };
 
 /**

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -201,7 +201,7 @@ export const isRunningLocally = () => {
     'kedro-org',
   ];
 
-  const hostname = window.location.hostname;
+  const hostname = window.location.hostname.toLowerCase();
 
   // Check if hostname matches known hosts
   if (hosts.some((host) => hostname.includes(host))) {


### PR DESCRIPTION
## Description

Related to: https://github.com/kedro-org/kedro-viz/issues/2198

This PR addresses an issue where Kedro-Viz does not display the full GUI when accessed via local private IP addresses (e.g., 192.168.x.x). We will update the `isRunningLocally` function to include private IP ranges defined in RFC 1918, to ensure consistent GUI rendering when accessing Kedro-Viz on local networks.

## Development notes

Regular expressions have been added to match the following private IP ranges:
```
10.0.0.0 – 10.255.255.255
172.16.0.0 – 172.31.255.255
192.168.0.0 – 192.168.255.255
```

## QA Notes

Local Access via localhost:

**Run Kedro-Viz:**

- `kedro viz run --host=0.0.0.0 --port=1008`
- Open http://localhost:1008 or http://127.0.0.1:1008 on your machine.
- Expected: All local-only features (like the Experiment Tracking tab) should be visible and functional.

**Local Access via IP:**

- Find your machine’s local IP (e.g., 192.168.1.40).
- On the same machine, access http://192.168.1.40:1008.
- Expected: All local-only features appear, just as they do with localhost.

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes
