### PR TITLE
update packages to be compatible with Ubuntu 24.04

### DIFF
--- a/.github/workflows/javascript-lint-and-tests.yml
+++ b/.github/workflows/javascript-lint-and-tests.yml
@@ -43,7 +43,7 @@ jobs:
             run: |-
               sudo sed -i 's/archive.ubuntu.com/us-east-1.ec2.archive.ubuntu.com/g' /etc/apt/sources.list
               sudo apt-get update
-              sudo apt-get install libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb          
+              sudo apt-get install libgtk2.0-0t64 libgtk-3-0t64 libgbm-dev libnotify-dev libnss3 libxss1 libasound2t64 libxtst6 xauth xvfb
 
           - name: Test lib transpilation
             run: npm run lib


### PR DESCRIPTION
## Description

With the latest Ubuntu 24.04 update, the current Cypress test setup has failed due to incompatibilities. Updates to other packages are needed to ensure compatibility

## Development notes

Changes include in `.github/workflows/javascript-lint-and-tests.yml`

```
sudo apt-get install libgtk2.0-0t64 libgtk-3-0t64 libgbm-dev libnotify-dev libnss3 libxss1 libasound2t64 libxtst6 xauth xvfb
```

## QA notes

The PR workflow should pass with this change

## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes
