### PR TITLE
Feat/add deprecation et

### DIFF
--- a/src/components/deprecation-banner/deprecation-banner.js
+++ b/src/components/deprecation-banner/deprecation-banner.js
@@ -20,10 +20,21 @@ export const DeprecationBanner = ({ visible }) => {
     window.open('https://github.com/kedro-org/kedro-viz/issues/2247', '_blank');
   };
 
+  const renderLink = (url, text) => (
+    <a
+      href={url}
+      className="deprecation-banner-modal__link"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      {text}
+    </a>
+  );
+
   return (
     <Modal
       className="deprecation-banner-modal"
-      title={'Experiment tracking will be disabled soon.'}
+      title="Experiment tracking will be disabled soon."
       visible={showModal}
     >
       <div className="deprecation-banner-modal__message-wrapper">
@@ -34,37 +45,21 @@ export const DeprecationBanner = ({ visible }) => {
 
         <p className="deprecation-banner-modal__secondary-text">
           More information behind Kedro’s decision can be found on{' '}
-          <a
-            href="https://example.com/blog-post"
-            className="deprecation-banner-modal__link"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            this blog post
-          </a>
-          .
+          {renderLink('https://example.com/blog-post', 'this blog post')}.
         </p>
 
         <p className="deprecation-banner-modal__secondary-text">
           To support current experiment tracking users, please read Kedro’s
           documentation on{' '}
-          <a
-            href="https://google.com"
-            className="deprecation-banner-modal__link"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            how to continue using Kedro with other experiment tracking tools
-          </a>
+          {renderLink(
+            'https://google.com',
+            'how to continue using Kedro with other experiment tracking tools'
+          )}
           , and{' '}
-          <a
-            href="https://google.com"
-            className="deprecation-banner-modal__link"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            how to migrate your existing Kedro project
-          </a>
+          {renderLink(
+            'https://google.com',
+            'how to migrate your existing Kedro project'
+          )}
           .
         </p>
 
@@ -81,7 +76,7 @@ export const DeprecationBanner = ({ visible }) => {
           onClick={handleProvideFeedbackClick}
           size="small"
           className="deprecation-banner-modal__provide-feedback-btn"
-          dataTest={'deprecation-banner-modal__provide-feedback-btn'}
+          dataTest="deprecation-banner-modal__provide-feedback-btn"
         >
           Provide feedback
         </Button>
@@ -89,7 +84,7 @@ export const DeprecationBanner = ({ visible }) => {
           size="small"
           onClick={handleAcknowledgeAndDismiss}
           className="deprecation-banner-modal--acknowledge-and-dismiss-btn"
-          dataTest={'deprecation-banner-modal--acknowledge-and-dismiss-btn'}
+          dataTest="deprecation-banner-modal--acknowledge-and-dismiss-btn"
         >
           Acknowledge and dismiss
         </Button>

--- a/src/components/deprecation-banner/deprecation-banner.js
+++ b/src/components/deprecation-banner/deprecation-banner.js
@@ -1,11 +1,20 @@
-import React from 'react';
+import React, { useState } from 'react';
 import Modal from '../ui/modal';
 import Button from '../ui/button';
+import { localStorageDeprecationBannerSeen } from '../../config';
+import { saveLocalStorage } from '../../store/helpers';
 
 import './deprecation-banner.scss';
 
 export const DeprecationBanner = ({ visible }) => {
-  const handleAcknowledgeAndDismiss = () => {};
+  const [showModal, setShowModal] = useState(visible);
+
+  const handleAcknowledgeAndDismiss = () => {
+    saveLocalStorage(localStorageDeprecationBannerSeen, {
+      'experiment-tracking': true,
+    });
+    setShowModal(false);
+  };
 
   const handleProvideFeedbackClick = () => {
     window.open('https://github.com/kedro-org/kedro-viz/issues/2247', '_blank');
@@ -14,9 +23,8 @@ export const DeprecationBanner = ({ visible }) => {
   return (
     <Modal
       className="deprecation-banner-modal"
-      closeModal={handleAcknowledgeAndDismiss}
       title={'Experiment tracking will be disabled soon.'}
-      visible={visible}
+      visible={showModal}
     >
       <div className="deprecation-banner-modal__message-wrapper">
         <p>

--- a/src/components/deprecation-banner/deprecation-banner.js
+++ b/src/components/deprecation-banner/deprecation-banner.js
@@ -1,0 +1,91 @@
+import React from 'react';
+import Modal from '../ui/modal';
+import Button from '../ui/button';
+
+import './deprecation-banner.scss';
+
+export const DeprecationBanner = ({ visible }) => {
+  const handleAcknowledgeAndDismiss = () => {};
+
+  const handleProvideFeedbackClick = () => {
+    window.open('https://github.com/kedro-org/kedro-viz/issues/2247', '_blank');
+  };
+
+  return (
+    <Modal
+      className="deprecation-banner-modal"
+      closeModal={handleAcknowledgeAndDismiss}
+      title={'Experiment tracking will be disabled soon.'}
+      visible={visible}
+    >
+      <div className="deprecation-banner-modal__message-wrapper">
+        <p>
+          The Kedro team have decided to deprecate the native experiment
+          tracking feature on 99 Feb 2025.
+        </p>
+
+        <p className="deprecation-banner-modal__secondary-text">
+          More information behind Kedro’s decision can be found on{' '}
+          <a
+            href="https://example.com/blog-post"
+            className="deprecation-banner-modal__link"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            this blog post
+          </a>
+          .
+        </p>
+
+        <p className="deprecation-banner-modal__secondary-text">
+          To support current experiment tracking users, please read Kedro’s
+          documentation on{' '}
+          <a
+            href="https://google.com"
+            className="deprecation-banner-modal__link"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            how to continue using Kedro with other experiment tracking tools
+          </a>
+          , and{' '}
+          <a
+            href="https://google.com"
+            className="deprecation-banner-modal__link"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            how to migrate your existing Kedro project
+          </a>
+          .
+        </p>
+
+        <p className="deprecation-banner-modal__secondary-text">
+          We sincerely thank our users that have utilised Kedro’s experiment
+          tracking feature. If you have any further feedback for us, please feel
+          free to share your thoughts below.
+        </p>
+      </div>
+
+      <div className="deprecation-banner-modal__button-wrapper">
+        <Button
+          mode="secondary"
+          onClick={handleProvideFeedbackClick}
+          size="small"
+          className="deprecation-banner-modal__provide-feedback-btn"
+          dataTest={'deprecation-banner-modal__provide-feedback-btn'}
+        >
+          Provide feedback
+        </Button>
+        <Button
+          size="small"
+          onClick={handleAcknowledgeAndDismiss}
+          className="deprecation-banner-modal--acknowledge-and-dismiss-btn"
+          dataTest={'deprecation-banner-modal--acknowledge-and-dismiss-btn'}
+        >
+          Acknowledge and dismiss
+        </Button>
+      </div>
+    </Modal>
+  );
+};

--- a/src/components/deprecation-banner/deprecation-banner.scss
+++ b/src/components/deprecation-banner/deprecation-banner.scss
@@ -23,7 +23,7 @@ $text-margin: 24px;
   }
 
   .modal__wrapper {
-    width: 446px;
+    width: $modal-width;
     padding: 0;
     margin: $modal-margin;
   }
@@ -32,53 +32,53 @@ $text-margin: 24px;
     text-align: left;
     margin-bottom: 0;
   }
-}
 
-.deprecation-banner-modal__message-wrapper {
-  p {
-    font-size: 14px;
-    font-style: normal;
-    font-weight: 400;
-    line-height: 20px;
-    margin-bottom: 0;
-    margin-top: $text-margin;
-    text-align: left;
+  .deprecation-banner-modal__message-wrapper {
+    p {
+      font-size: 14px;
+      font-style: normal;
+      font-weight: 400;
+      line-height: 20px;
+      margin-bottom: 0;
+      margin-top: $text-margin;
+      text-align: left;
+    }
+
+    .deprecation-banner-modal__secondary-text {
+      color: var(--secondary-text-color);
+    }
   }
 
-  .deprecation-banner-modal__secondary-text {
+  .deprecation-banner-modal__button-wrapper {
+    align-items: center;
+    display: flex;
+    justify-content: space-between;
+    margin-top: $modal-margin;
+    width: 100%;
+
+    .button__btn--secondary {
+      padding-left: 0;
+      text-decoration: underline;
+      text-underline-offset: 3px;
+
+      &:hover::after {
+        background-color: transparent;
+      }
+    }
+
+    .button__btn--primary {
+      border-color: var(--primary-button-background);
+
+      &:hover {
+        background-color: var(--primary-button-background);
+        color: var(--primary-button-text-color);
+      }
+    }
+  }
+
+  .deprecation-banner-modal__link {
     color: var(--secondary-text-color);
-  }
-}
-
-.deprecation-banner-modal__button-wrapper {
-  align-items: center;
-  display: flex;
-  justify-content: space-between;
-  margin-top: $modal-margin;
-  width: 100%;
-
-  .button__btn--secondary {
-    padding-left: 0;
     text-decoration: underline;
     text-underline-offset: 3px;
-
-    &:hover::after {
-      background-color: transparent;
-    }
   }
-
-  .button__btn--primary {
-    border-color: var(--primary-button-background);
-
-    &:hover {
-      background-color: var(--primary-button-background);
-      color: var(--primary-button-text-color);
-    }
-  }
-}
-
-.deprecation-banner-modal__link {
-  color: var(--secondary-text-color);
-  text-decoration: underline;
-  text-underline-offset: 3px;
 }

--- a/src/components/deprecation-banner/deprecation-banner.scss
+++ b/src/components/deprecation-banner/deprecation-banner.scss
@@ -1,0 +1,84 @@
+@use '../../styles/variables' as variables;
+
+$modal-height: 416px;
+$modal-margin: 48px;
+$modal-width: 446px;
+$text-margin: 24px;
+
+.kui-theme--light {
+  --secondary-text-color: #{variables.$black-500};
+  --primary-button-background: #{variables.$black-900};
+  --primary-button-text-color: #{variables.$white-0};
+}
+
+.kui-theme--dark {
+  --secondary-text-color: #{variables.$white-900};
+  --primary-button-background: #{variables.$white-0};
+  --primary-button-text-color: #{variables.$black-900};
+}
+
+.deprecation-banner-modal {
+  .modal__content {
+    max-width: calc(#{$modal-width} + 2 * #{$modal-margin});
+  }
+
+  .modal__wrapper {
+    width: 446px;
+    padding: 0;
+    margin: $modal-margin;
+  }
+
+  .modal__title {
+    text-align: left;
+    margin-bottom: 0;
+  }
+}
+
+.deprecation-banner-modal__message-wrapper {
+  p {
+    font-size: 14px;
+    font-style: normal;
+    font-weight: 400;
+    line-height: 20px;
+    margin-bottom: 0;
+    margin-top: $text-margin;
+    text-align: left;
+  }
+
+  .deprecation-banner-modal__secondary-text {
+    color: var(--secondary-text-color);
+  }
+}
+
+.deprecation-banner-modal__button-wrapper {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+  margin-top: $modal-margin;
+  width: 100%;
+
+  .button__btn--secondary {
+    padding-left: 0;
+    text-decoration: underline;
+    text-underline-offset: 3px;
+
+    &:hover::after {
+      background-color: transparent;
+    }
+  }
+
+  .button__btn--primary {
+    border-color: var(--primary-button-background);
+
+    &:hover {
+      background-color: var(--primary-button-background);
+      color: var(--primary-button-text-color);
+    }
+  }
+}
+
+.deprecation-banner-modal__link {
+  color: var(--secondary-text-color);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}

--- a/src/components/wrapper/wrapper.js
+++ b/src/components/wrapper/wrapper.js
@@ -31,9 +31,8 @@ export const Wrapper = ({ displayGlobalNavigation, theme }) => {
   });
   const [isOutdated, setIsOutdated] = useState(false);
   const [latestVersion, setLatestVersion] = useState(null);
-  const [showDeprecationBannerForET, setShowDeprecationBannerForET] = useState(
-    loadLocalStorage(localStorageDeprecationBannerSeen)
-  );
+  const [showDeprecationBannerForET, setShowDeprecationBannerForET] =
+    useState(false);
 
   useEffect(() => {
     if (versionData) {
@@ -44,13 +43,13 @@ export const Wrapper = ({ displayGlobalNavigation, theme }) => {
 
   useEffect(() => {
     const bannerSeen = loadLocalStorage(localStorageDeprecationBannerSeen);
-    if (bannerSeen['experiment-tracking'] === undefined) {
-      setShowDeprecationBannerForET(true);
-    } else {
-      setShowDeprecationBannerForET(!bannerSeen);
-    }
-  }, [showDeprecationBannerForET]);
+    const shouldShowBanner =
+      bannerSeen['experiment-tracking'] === undefined ||
+      bannerSeen['experiment-tracking'] === false;
+    setShowDeprecationBannerForET(shouldShowBanner);
+  }, []);
 
+  console.log(showDeprecationBannerForET, 'showDeprecationBannerForET');
   return (
     <div
       className={classnames('kedro-pipeline kedro', {

--- a/src/components/wrapper/wrapper.js
+++ b/src/components/wrapper/wrapper.js
@@ -15,6 +15,7 @@ import ExperimentWrapper from '../experiment-wrapper';
 import SettingsModal from '../settings-modal';
 import UpdateReminder from '../update-reminder';
 import ShareableUrlModal from '../shareable-url-modal';
+import { DeprecationBanner } from '../deprecation-banner/deprecation-banner';
 
 import './wrapper.scss';
 
@@ -53,6 +54,7 @@ export const Wrapper = ({ displayGlobalNavigation, theme }) => {
               latestVersion={latestVersion}
             />
             {isRunningLocally() ? <ShareableUrlModal /> : null}
+            {<DeprecationBanner visible={true} />}
             {versionData && (
               <UpdateReminder
                 isOutdated={isOutdated}

--- a/src/components/wrapper/wrapper.js
+++ b/src/components/wrapper/wrapper.js
@@ -7,6 +7,8 @@ import { useApolloQuery } from '../../apollo/utils';
 import { client } from '../../apollo/config';
 import { GraphQLProvider } from '../provider/provider';
 import { GET_VERSIONS } from '../../apollo/queries';
+import { localStorageDeprecationBannerSeen } from '../../config';
+import { loadLocalStorage } from '../../store/helpers';
 
 import FeatureHints from '../feature-hints';
 import GlobalToolbar from '../global-toolbar';
@@ -29,6 +31,9 @@ export const Wrapper = ({ displayGlobalNavigation, theme }) => {
   });
   const [isOutdated, setIsOutdated] = useState(false);
   const [latestVersion, setLatestVersion] = useState(null);
+  const [showDeprecationBannerForET, setShowDeprecationBannerForET] = useState(
+    loadLocalStorage(localStorageDeprecationBannerSeen)
+  );
 
   useEffect(() => {
     if (versionData) {
@@ -36,6 +41,15 @@ export const Wrapper = ({ displayGlobalNavigation, theme }) => {
       setLatestVersion(versionData.version.latest);
     }
   }, [versionData]);
+
+  useEffect(() => {
+    const bannerSeen = loadLocalStorage(localStorageDeprecationBannerSeen);
+    if (bannerSeen['experiment-tracking'] === undefined) {
+      setShowDeprecationBannerForET(true);
+    } else {
+      setShowDeprecationBannerForET(!bannerSeen);
+    }
+  }, [showDeprecationBannerForET]);
 
   return (
     <div
@@ -54,7 +68,9 @@ export const Wrapper = ({ displayGlobalNavigation, theme }) => {
               latestVersion={latestVersion}
             />
             {isRunningLocally() ? <ShareableUrlModal /> : null}
-            {<DeprecationBanner visible={true} />}
+            {showDeprecationBannerForET ? (
+              <DeprecationBanner visible={showDeprecationBannerForET} />
+            ) : null}
             {versionData && (
               <UpdateReminder
                 isOutdated={isOutdated}

--- a/src/config.js
+++ b/src/config.js
@@ -7,6 +7,8 @@ export const localStorageRunsMetadata = 'KedroViz-runs-metadata';
 export const localStorageShareableUrl = 'KedroViz-shareable-url';
 export const localStorageFeedbackSeen = 'KedroViz-feedback-seen';
 export const localStorageBannerStatus = 'KedroViz-banners';
+export const localStorageDeprecationBannerSeen =
+  'KedroViz-deprecation-banner-seen';
 
 export const linkToFlowchartInitialVal = {
   fromURL: null,


### PR DESCRIPTION
## Description
Fixes #2238, to add a deprecation warning banner to the Kedro-Viz experiment tracking page 

## Development notes

<!-- What have you changed? Consider adding a screenshot or GIF. -->

## QA notes

Whether you test locally or via gitpod, the first time it should aways the show warning popup, once the user clicks "acknowledge and dismiss", the warning popup will go away and never be shown again, unless user clear their local storage or use on different browser. 

## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes
