### PR TITLE
update reference to home page and kedro datasets docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -114,7 +114,7 @@ extra_javascript:
 
 
 nav:
-  - Home: index.md
+  - Home: https://docs.kedro.org/en/develop
   - Kedro: https://docs.kedro.org/en/develop/pages/getting-started/course/
   - Kedro-Viz: 
     - Overview: pages/index.md
@@ -136,4 +136,4 @@ nav:
         - Migration from Kedro-Viz native experiment tracking to kedro-mlflow: pages/migrate_experiment_tracking.md
     - Other Documentation:
         - Kedro-Viz CLI reference: pages/cli-docs.md
-  - Kedro-Datasets: https://docs.kedro.org/projects/kedro-datasets
+  - Kedro-Datasets: https://docs.kedro.org/projects/kedro-datasets/en/feature-8.0/pages/api/kedro_datasets/


### PR DESCRIPTION
## Description

I’ve created a feature branch for kedro-datasets, `feature/8.0`, so this PR updates the reference to point to the correct version in RTD.  To maintain consistency, the homepage now also points to a single entry point from the Kedro documentation

## Development notes

<!-- What have you changed? Consider adding a screenshot or GIF. -->

## QA notes

<!-- How has the expected behaviour changed? What testing strategies have you used? -->

## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes
