### PR TITLE
Run status: New run status indicator (Yellow dot)

### DIFF
--- a/src/components/global-toolbar/global-toolbar.js
+++ b/src/components/global-toolbar/global-toolbar.js
@@ -46,6 +46,7 @@ export const GlobalToolbar = ({
   useEffect(() => {
     if (view === VIEW.WORKFLOW) {
       setLocalStorageLastRunEndTime(runStatusPipelineInfo.endTime);
+      setIsLatestRun(false);
     }
   }, [view, runStatusPipelineInfo.endTime]);
 

--- a/src/components/global-toolbar/global-toolbar.js
+++ b/src/components/global-toolbar/global-toolbar.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { connect } from 'react-redux';
 import { NavLink } from 'react-router-dom';
 import {
@@ -19,7 +19,7 @@ import { VIEW } from '../../config';
 import './global-toolbar.scss';
 import { getPipelineRunData } from '../../selectors/run-status';
 import {
-  handleLatestRunStatus,
+  isNewRun,
   setLocalStorageLastRunEndTime,
 } from '../../utils/run-status';
 
@@ -37,10 +37,10 @@ export const GlobalToolbar = ({
   runStatusPipelineInfo,
   view,
 }) => {
-  const [isLatestRun, setIsLatestRun] = React.useState(false);
+  const [isLatestRun, setIsLatestRun] = useState(false);
 
   useEffect(() => {
-    setIsLatestRun(handleLatestRunStatus(runStatusPipelineInfo.endTime));
+    setIsLatestRun(isNewRun(runStatusPipelineInfo.endTime));
   }, [isLatestRun, runStatusPipelineInfo.endTime]);
 
   useEffect(() => {

--- a/src/components/global-toolbar/global-toolbar.js
+++ b/src/components/global-toolbar/global-toolbar.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
 import { NavLink } from 'react-router-dom';
 import {
@@ -15,7 +15,13 @@ import SettingsIcon from '../icons/settings';
 import ThemeIcon from '../icons/theme';
 import TreeIcon from '../icons/tree';
 import WorkflowIcon from '../icons/workflow';
+import { VIEW } from '../../config';
 import './global-toolbar.scss';
+import { getPipelineRunData } from '../../selectors/run-status';
+import {
+  handleLatestRunStatus,
+  setLocalStorageLastRunEndTime,
+} from '../../utils/run-status';
 
 /**
  * Main controls for filtering the chart data
@@ -28,7 +34,21 @@ export const GlobalToolbar = ({
   onToggleShareableUrlModal,
   onToggleTheme,
   theme,
+  runStatusPipelineInfo,
+  view,
 }) => {
+  const [isLatestRun, setIsLatestRun] = React.useState(false);
+
+  useEffect(() => {
+    setIsLatestRun(handleLatestRunStatus(runStatusPipelineInfo.endTime));
+  }, [isLatestRun, runStatusPipelineInfo.endTime]);
+
+  useEffect(() => {
+    if (view === VIEW.WORKFLOW) {
+      setLocalStorageLastRunEndTime(runStatusPipelineInfo.endTime);
+    }
+  }, [view, runStatusPipelineInfo.endTime]);
+
   return (
     <div className="pipeline-global-toolbar">
       <ul className="pipeline-global-routes-toolbar kedro">
@@ -49,7 +69,11 @@ export const GlobalToolbar = ({
             labelText="Flowchart"
           />
         </NavLink>
-        <NavLink exact to={{ pathname: `${sanitizedPathname()}workflow` }}>
+        <NavLink
+          className="run-status-nav-wrapper"
+          exact
+          to={{ pathname: `${sanitizedPathname()}workflow` }}
+        >
           <IconButton
             ariaLabel="View your workflow"
             dataTest="global-toolbar-workflow-btn"
@@ -58,6 +82,9 @@ export const GlobalToolbar = ({
             icon={WorkflowIcon}
             labelText="Workflow"
           />
+          {view === VIEW.FLOWCHART && isLatestRun && (
+            <span className="run-status-dot"></span>
+          )}
         </NavLink>
       </ul>
       <ul className="pipeline-global-control-toolbar kedro">
@@ -100,6 +127,8 @@ export const GlobalToolbar = ({
 export const mapStateToProps = (state) => ({
   theme: state.theme,
   visible: state.visible,
+  runStatusPipelineInfo: getPipelineRunData(state),
+  view: state.view,
 });
 
 export const mapDispatchToProps = (dispatch) => ({

--- a/src/components/global-toolbar/global-toolbar.scss
+++ b/src/components/global-toolbar/global-toolbar.scss
@@ -59,7 +59,7 @@
   opacity: 1;
 }
 
-.update-reminder-dot {
+%update-reminder-dot {
   background-color: variables.$yellow-300;
   border-radius: 50%;
   height: 8px;
@@ -69,12 +69,17 @@
   width: 8px;
 }
 
+.update-reminder-dot {
+  @extend %update-reminder-dot;
+}
+
 .run-status-nav-wrapper {
   position: relative;
 }
 
 .run-status-dot {
-  @extend .update-reminder-dot;
+  @extend %update-reminder-dot;
+
   right: 20px;
   top: 25px;
 }

--- a/src/components/global-toolbar/global-toolbar.scss
+++ b/src/components/global-toolbar/global-toolbar.scss
@@ -68,3 +68,13 @@
   top: 31px;
   width: 8px;
 }
+
+.run-status-nav-wrapper {
+  position: relative;
+}
+
+.run-status-dot {
+  @extend .update-reminder-dot;
+  right: 20px;
+  top: 25px;
+}

--- a/src/components/global-toolbar/global-toolbar.test.js
+++ b/src/components/global-toolbar/global-toolbar.test.js
@@ -32,6 +32,8 @@ describe('GlobalToolbar', () => {
       const props = {
         theme: mockState.spaceflights.theme,
         visible: mockState.spaceflights.visible,
+        runStatusPipelineInfo: {},
+        view: 'flowchart',
         [callback]: mockFn,
       };
 
@@ -63,6 +65,8 @@ describe('GlobalToolbar', () => {
         sidebar: true,
         slicing: true,
       },
+      view: 'flowchart',
+      runStatusPipelineInfo: {},
     };
     expect(mapStateToProps(mockState.spaceflights)).toEqual(expectedResult);
   });

--- a/src/components/workflow/workflow-utils/format.js
+++ b/src/components/workflow/workflow-utils/format.js
@@ -33,25 +33,6 @@ export function formatSize(bytes) {
   return `${megabytes % 1 === 0 ? megabytes : megabytes.toFixed(2)}MB`;
 }
 
-export function normalizeTimestamp(timestamp) {
-  // Normalize the timestamp format
-  let timestampStr = timestamp;
-
-  if (typeof timestampStr === 'string') {
-    // Replace dots with colons in the time portion (e.g., "09.54.33" -> "09:54:33")
-    timestampStr = timestampStr.replace(
-      /T(\d{2})\.(\d{2})\.(\d{2})/,
-      'T$1:$2:$3'
-    );
-
-    // Ensure the timestamp is treated as UTC if no timezone is present
-    if (!/[zZ]|[+-]\d{2}:?\d{2}$/.test(timestampStr)) {
-      timestampStr += 'Z';
-    }
-  }
-  return timestampStr;
-}
-
 export function formatTimestamp(timestamp) {
   if (!timestamp) {
     return 'N/A';
@@ -60,10 +41,7 @@ export function formatTimestamp(timestamp) {
   // Pads a number to 2 digits with a leading zero if needed (e.g., 3 -> '03', 12 -> '12')
   const pad2 = (num) => num.toString().padStart(2, '0');
 
-  // Normalize the timestamp format
-  let timestampStr = normalizeTimestamp(timestamp);
-
-  const date = new Date(timestampStr);
+  const date = new Date(timestamp);
   const day = pad2(date.getUTCDate());
   const month = pad2(date.getUTCMonth() + 1);
   const year = date.getUTCFullYear();

--- a/src/components/workflow/workflow-utils/format.js
+++ b/src/components/workflow/workflow-utils/format.js
@@ -37,9 +37,6 @@ export function normalizeTimestamp(timestamp) {
   // Normalize the timestamp format
   let timestampStr = timestamp;
 
-  if (!timestamp) {
-    return null;
-  }
   if (typeof timestampStr === 'string') {
     // Replace dots with colons in the time portion (e.g., "09.54.33" -> "09:54:33")
     timestampStr = timestampStr.replace(
@@ -65,11 +62,6 @@ export function formatTimestamp(timestamp) {
 
   // Normalize the timestamp format
   let timestampStr = normalizeTimestamp(timestamp);
-
-  // Ensure the timestamp is treated as UTC if no timezone is present
-  if (!/[zZ]|[+-]\d{2}:?\d{2}$/.test(timestampStr)) {
-    timestampStr += 'Z';
-  }
 
   const date = new Date(timestampStr);
   const day = pad2(date.getUTCDate());

--- a/src/components/workflow/workflow-utils/format.js
+++ b/src/components/workflow/workflow-utils/format.js
@@ -33,6 +33,28 @@ export function formatSize(bytes) {
   return `${megabytes % 1 === 0 ? megabytes : megabytes.toFixed(2)}MB`;
 }
 
+export function normalizeTimestamp(timestamp) {
+  // Normalize the timestamp format
+  let timestampStr = timestamp;
+
+  if (!timestamp) {
+    return null;
+  }
+  if (typeof timestampStr === 'string') {
+    // Replace dots with colons in the time portion (e.g., "09.54.33" -> "09:54:33")
+    timestampStr = timestampStr.replace(
+      /T(\d{2})\.(\d{2})\.(\d{2})/,
+      'T$1:$2:$3'
+    );
+
+    // Ensure the timestamp is treated as UTC if no timezone is present
+    if (!/[zZ]|[+-]\d{2}:?\d{2}$/.test(timestampStr)) {
+      timestampStr += 'Z';
+    }
+  }
+  return timestampStr;
+}
+
 export function formatTimestamp(timestamp) {
   if (!timestamp) {
     return 'N/A';
@@ -42,15 +64,11 @@ export function formatTimestamp(timestamp) {
   const pad2 = (num) => num.toString().padStart(2, '0');
 
   // Normalize the timestamp format
-  let timestampStr = timestamp;
-  if (typeof timestampStr === 'string') {
-    // Replace dots with colons in the time portion (e.g., "09.54.33" -> "09:54:33")
-    timestampStr = timestampStr.replace(/T(\d{2})\.(\d{2})\.(\d{2})/, 'T$1:$2:$3');
+  let timestampStr = normalizeTimestamp(timestamp);
 
-    // Ensure the timestamp is treated as UTC if no timezone is present
-    if (!/[zZ]|[+-]\d{2}:?\d{2}$/.test(timestampStr)) {
-      timestampStr += 'Z';
-    }
+  // Ensure the timestamp is treated as UTC if no timezone is present
+  if (!/[zZ]|[+-]\d{2}:?\d{2}$/.test(timestampStr)) {
+    timestampStr += 'Z';
   }
 
   const date = new Date(timestampStr);

--- a/src/components/workflow/workflow-utils/format.test.js
+++ b/src/components/workflow/workflow-utils/format.test.js
@@ -37,7 +37,7 @@ describe('formatSize', () => {
 
 describe('formatTimestamp', () => {
   it('formats ISO timestamp to dd.mm.yyyy - hh:mm:ss UTC', () => {
-    expect(formatTimestamp('2025-05-22T15:54:08.696715')).toBe(
+    expect(formatTimestamp('2025-05-22T15:54:08.696715Z')).toBe(
       '22.05.2025 - 15:54:08 UTC'
     );
   });

--- a/src/config.js
+++ b/src/config.js
@@ -5,7 +5,7 @@ export const localStorageFlowchartLink = 'KedroViz-link-to-flowchart';
 export const localStorageShareableUrl = 'KedroViz-shareable-url';
 export const localStorageFeedbackSeen = 'KedroViz-feedback-seen';
 export const localStorageBannerStatus = 'KedroViz-banners';
-export const localStorageLastRunEndTime = 'KedroViz-last-run-end-time';
+export const localStorageLastRunEndTime = 'KedroViz-workflow-last-run-end-time';
 
 export const linkToFlowchartInitialVal = {
   fromURL: null,

--- a/src/config.js
+++ b/src/config.js
@@ -5,6 +5,7 @@ export const localStorageFlowchartLink = 'KedroViz-link-to-flowchart';
 export const localStorageShareableUrl = 'KedroViz-shareable-url';
 export const localStorageFeedbackSeen = 'KedroViz-feedback-seen';
 export const localStorageBannerStatus = 'KedroViz-banners';
+export const localStorageLastRunEndTime = 'KedroViz-last-run-end-time';
 
 export const linkToFlowchartInitialVal = {
   fromURL: null,

--- a/src/store/normalize-run-data.js
+++ b/src/store/normalize-run-data.js
@@ -36,6 +36,34 @@ const validateRunStatusInput = (data) => {
   }
   return true;
 };
+/** * Normalize the timestamp format to ensure consistency
+ * @param {string|Date} timestamp - The timestamp to normalize
+ * @return {string} Normalized timestamp string in ISO format
+ */
+export function normalizeTimestamp(timestamp) {
+  // Normalize the timestamp format
+
+  if (!timestamp) {
+    return;
+  }
+
+  let timestampStr = timestamp;
+
+  if (typeof timestampStr === 'string') {
+    // Replace dots with colons in the time portion (e.g., "09.54.33" -> "09:54:33")
+    timestampStr = timestampStr.replace(
+      /T(\d{2})\.(\d{2})\.(\d{2})/,
+      'T$1:$2:$3'
+    );
+
+    // Ensure the timestamp is treated as UTC if no timezone is present
+    if (!/[zZ]|[+-]\d{2}:?\d{2}$/.test(timestampStr)) {
+      timestampStr += 'Z';
+    }
+  }
+
+  return timestampStr;
+}
 
 /** * Process the raw run status data into a structured format
  * @param {Object} data Raw unformatted data input
@@ -67,8 +95,8 @@ export const processRunStatus = (data) => {
   if (data.pipeline) {
     state.pipeline = {
       runId: data.pipeline.run_id,
-      startTime: data.pipeline.start_time,
-      endTime: data.pipeline.end_time,
+      startTime: normalizeTimestamp(data.pipeline.start_time),
+      endTime: normalizeTimestamp(data.pipeline.end_time),
       duration: data.pipeline.duration,
       status: data.pipeline.status,
       error: data.pipeline.error,

--- a/src/store/normalize-run-data.test.js
+++ b/src/store/normalize-run-data.test.js
@@ -1,0 +1,126 @@
+import normalizeRunStatusData, {
+  createInitialRunStatusState,
+  normalizeTimestamp,
+  processRunStatus,
+} from './normalize-run-data';
+
+describe('createInitialRunStatusState', () => {
+  it('returns an object with the correct structure', () => {
+    const state = createInitialRunStatusState();
+    expect(state).toEqual({
+      nodes: {},
+      datasets: {},
+      pipeline: {},
+    });
+  });
+});
+
+describe('normalizeTimestamp', () => {
+  it('returns undefined for falsy values', () => {
+    expect(normalizeTimestamp(null)).toBeUndefined();
+    expect(normalizeTimestamp('')).toBeUndefined();
+  });
+
+  it('converts dots to colons and adds UTC timezone', () => {
+    expect(normalizeTimestamp('2023-01-01T09.54.33')).toBe(
+      '2023-01-01T09:54:33Z'
+    );
+  });
+
+  it('preserves existing timezone information', () => {
+    expect(normalizeTimestamp('2023-01-01T10:00:00Z')).toBe(
+      '2023-01-01T10:00:00Z'
+    );
+    expect(normalizeTimestamp('2023-01-01T10:00:00+05:00')).toBe(
+      '2023-01-01T10:00:00+05:00'
+    );
+  });
+});
+
+describe('processRunStatus', () => {
+  it('processes run status data correctly', () => {
+    const data = {
+      nodes: {
+        node1: { status: 'success', duration: 1.5, error: null },
+      },
+      datasets: {
+        dataset1: {
+          name: 'Test Dataset',
+          size: 1024,
+          status: 'available',
+          error: null,
+        },
+      },
+      pipeline: {
+        // eslint-disable-next-line camelcase
+        run_id: 'test-run-123',
+        // eslint-disable-next-line camelcase
+        start_time: '2023-01-01T10.00.00',
+        // eslint-disable-next-line camelcase
+        end_time: '2023-01-01T10.05.30',
+        duration: 330,
+        status: 'completed',
+        error: null,
+      },
+    };
+
+    const result = processRunStatus(data);
+
+    expect(result.nodes.node1).toEqual({
+      status: 'success',
+      duration: 1.5,
+      error: null,
+    });
+    expect(result.datasets.dataset1).toEqual({
+      name: 'Test Dataset',
+      size: 1024,
+      status: 'available',
+      error: null,
+    });
+    expect(result.pipeline).toEqual({
+      runId: 'test-run-123',
+      startTime: '2023-01-01T10:00:00Z',
+      endTime: '2023-01-01T10:05:30Z',
+      duration: 330,
+      status: 'completed',
+      error: null,
+    });
+  });
+});
+
+describe('normalizeRunStatusData', () => {
+  it('should throw an error when data is invalid', () => {
+    expect(() => normalizeRunStatusData({})).toThrow();
+    expect(() => normalizeRunStatusData({ nodes: [] })).toThrow();
+  });
+
+  it('returns initial state for falsy input', () => {
+    const result = normalizeRunStatusData(null);
+    expect(result).toEqual(createInitialRunStatusState());
+  });
+
+  it('processes valid run status data correctly', () => {
+    const data = {
+      nodes: {
+        node1: { status: 'success', duration: 2.1 },
+      },
+      datasets: {
+        dataset1: { name: 'Test Data', size: 512 },
+      },
+      pipeline: {
+        // eslint-disable-next-line camelcase
+        run_id: 'run-456',
+        // eslint-disable-next-line camelcase
+        start_time: '2023-01-01T09.30.00',
+        status: 'completed',
+      },
+    };
+
+    const result = normalizeRunStatusData(data);
+
+    expect(result.nodes.node1).toEqual({ status: 'success', duration: 2.1 });
+    expect(result.datasets.dataset1).toEqual({ name: 'Test Data', size: 512 });
+    expect(result.pipeline.runId).toBe('run-456');
+    expect(result.pipeline.startTime).toBe('2023-01-01T09:30:00Z');
+  });
+});

--- a/src/utils/run-status.js
+++ b/src/utils/run-status.js
@@ -1,4 +1,5 @@
 import { localStorageLastRunEndTime } from '../config';
+import { normalizeTimestamp } from '../components/workflow/workflow-utils/format';
 
 /**
  * Handle the latest run status by comparing end times
@@ -19,8 +20,11 @@ export const handleLatestRunStatus = (endTime) => {
   }
 
   try {
-    const currentRunTime = new Date(endTime).getTime();
-    const lastRunTime = new Date(lastEndTime).getTime();
+    const normalizedEndTime = normalizeTimestamp(endTime);
+    const normalizedLastEndTime = normalizeTimestamp(lastEndTime);
+
+    const currentRunTime = new Date(normalizedEndTime).getTime();
+    const lastRunTime = new Date(normalizedLastEndTime).getTime();
 
     // Return true if current run is newer than the last recorded run
     return currentRunTime > lastRunTime;

--- a/src/utils/run-status.js
+++ b/src/utils/run-status.js
@@ -1,0 +1,40 @@
+import { localStorageLastRunEndTime } from '../config';
+
+/**
+ * Handle the latest run status by comparing end times
+ * @param {string} endTime End time of the latest run
+ * @returns {boolean} True if the latest run is newer than the last stored run
+ */
+export const handleLatestRunStatus = (endTime) => {
+  const lastEndTime = localStorage.getItem(localStorageLastRunEndTime);
+
+  // If no endTime available, assume it's not the latest run
+  if (!endTime) {
+    return false;
+  }
+
+  // If no previous run recorded, this is considered the latest
+  if (!lastEndTime) {
+    return true;
+  }
+
+  try {
+    const currentRunTime = new Date(endTime).getTime();
+    const lastRunTime = new Date(lastEndTime).getTime();
+
+    // Return true if current run is newer than the last recorded run
+    return currentRunTime > lastRunTime;
+  } catch (error) {
+    console.warn('Error comparing run timestamps:', error);
+    // If there's an error parsing dates, assume it's not the latest run
+    return false;
+  }
+};
+
+/**
+ * Reset the latest run status by clearing the last run end time from localStorage
+ * @param {string} endTime End time of the latest run
+ */
+export function setLocalStorageLastRunEndTime(endTime) {
+  localStorage.setItem(localStorageLastRunEndTime, endTime);
+}

--- a/src/utils/run-status.js
+++ b/src/utils/run-status.js
@@ -1,12 +1,11 @@
 import { localStorageLastRunEndTime } from '../config';
-import { normalizeTimestamp } from '../components/workflow/workflow-utils/format';
 
 /**
- * Handle the latest run status by comparing end times
+ * Check the latest run status by comparing end times
  * @param {string} endTime End time of the latest run
  * @returns {boolean} True if the latest run is newer than the last stored run
  */
-export const handleLatestRunStatus = (endTime) => {
+export const isNewRun = (endTime) => {
   const lastEndTime = localStorage.getItem(localStorageLastRunEndTime);
 
   // If no endTime available, assume it's not the latest run
@@ -20,11 +19,8 @@ export const handleLatestRunStatus = (endTime) => {
   }
 
   try {
-    const normalizedEndTime = normalizeTimestamp(endTime);
-    const normalizedLastEndTime = normalizeTimestamp(lastEndTime);
-
-    const currentRunTime = new Date(normalizedEndTime).getTime();
-    const lastRunTime = new Date(normalizedLastEndTime).getTime();
+    const currentRunTime = new Date(endTime).getTime();
+    const lastRunTime = new Date(lastEndTime).getTime();
 
     // Return true if current run is newer than the last recorded run
     return currentRunTime > lastRunTime;

--- a/src/utils/run-status.test.js
+++ b/src/utils/run-status.test.js
@@ -1,0 +1,65 @@
+import { isNewRun, setLocalStorageLastRunEndTime } from './run-status';
+import { localStorageLastRunEndTime } from '../config';
+
+describe('run-status', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+  });
+
+  describe('isNewRun', () => {
+    it('returns false when endTime is falsy', () => {
+      expect(isNewRun()).toBe(false);
+      expect(isNewRun('')).toBe(false);
+      expect(isNewRun(null)).toBe(false);
+    });
+
+    it('returns true when no previous run is recorded', () => {
+      const result = isNewRun('2023-01-01T10:00:00Z');
+      expect(result).toBe(true);
+    });
+
+    it('returns true when current run is newer than last recorded run', () => {
+      localStorage.setItem(localStorageLastRunEndTime, '2023-01-01T09:00:00Z');
+
+      const result = isNewRun('2023-01-01T10:00:00Z');
+
+      expect(result).toBe(true);
+    });
+
+    it('returns false when current run is older than last recorded run', () => {
+      localStorage.setItem(localStorageLastRunEndTime, '2023-01-01T10:00:00Z');
+
+      const result = isNewRun('2023-01-01T09:00:00Z');
+
+      expect(result).toBe(false);
+    });
+
+    it('returns false when current run has same time as last recorded run', () => {
+      const endTime = '2023-01-01T10:00:00Z';
+      localStorage.setItem(localStorageLastRunEndTime, endTime);
+
+      const result = isNewRun(endTime);
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('setLocalStorageLastRunEndTime', () => {
+    it('stores the endTime in localStorage', () => {
+      const endTime = '2023-01-01T10:00:00Z';
+
+      setLocalStorageLastRunEndTime(endTime);
+
+      expect(localStorage.getItem(localStorageLastRunEndTime)).toBe(endTime);
+    });
+
+    it('stores falsy values correctly', () => {
+      setLocalStorageLastRunEndTime(null);
+      expect(localStorage.getItem(localStorageLastRunEndTime)).toBe('null');
+
+      setLocalStorageLastRunEndTime('');
+      expect(localStorage.getItem(localStorageLastRunEndTime)).toBe('');
+    });
+  });
+});


### PR DESCRIPTION
This pull request includes when to show new run status indicator and how to handle and update its relevant redux state.

This work was originally part of https://github.com/kedro-org/kedro-viz/pull/2353 PR  

### Global Toolbar Enhancements:
* [`src/components/global-toolbar/global-toolbar.js`](diffhunk://#diff-69e4872bdcef36fb8acc299c3b4612f114e7dfdcae3346f8121c21ad03c7f821R37-R52): Added logic to track the latest pipeline run status using `handleLatestRunStatus` and `setLocalStorageLastRunEndTime`. Introduced state management (`isLatestRun`) and conditional rendering for the "run-status-dot" indicator in the workflow navigation link. [[1]](diffhunk://#diff-69e4872bdcef36fb8acc299c3b4612f114e7dfdcae3346f8121c21ad03c7f821R37-R52) [[2]](diffhunk://#diff-69e4872bdcef36fb8acc299c3b4612f114e7dfdcae3346f8121c21ad03c7f821L52-R77) [[3]](diffhunk://#diff-69e4872bdcef36fb8acc299c3b4612f114e7dfdcae3346f8121c21ad03c7f821R86-R88)
* [`src/components/global-toolbar/global-toolbar.scss`](diffhunk://#diff-5822f5ff28b8c58146ea45ddded4fe99bde61ac3d3de6702e2e7821ba202f8c7R71-R80): Added styles for the "run-status-dot" indicator and its wrapper to visually highlight the latest run status.

### Workflow Utilities Improvements:
* [`src/components/workflow/workflow-utils/format.js`](diffhunk://#diff-3ad5b3b1aa1c2c2b2eae08b035b7e987546b371cfb31e228fe688ffa9f7a38b7R36-R57): Extracted timestamp normalization logic into a new `normalizeTimestamp` function to streamline and reuse timestamp processing. Updated `formatTimestamp` to use this new function. [[1]](diffhunk://#diff-3ad5b3b1aa1c2c2b2eae08b035b7e987546b371cfb31e228fe688ffa9f7a38b7R36-R57) [[2]](diffhunk://#diff-3ad5b3b1aa1c2c2b2eae08b035b7e987546b371cfb31e228fe688ffa9f7a38b7L45-L54)

### Pipeline Run Status Utilities:
* [`src/utils/run-status.js`](diffhunk://#diff-0b70ddcdbaef5c30d296b71c6cf9c90f8ff5832f263b379f54b4bc11dd481095R1-R44): Added utility functions `handleLatestRunStatus` to determine if the latest pipeline run is newer than the last recorded run and `setLocalStorageLastRunEndTime` to update the stored end time in localStorage. These utilities facilitate tracking and resetting the latest run status.

### Configuration Updates:
* [`src/config.js`](diffhunk://#diff-23821ae067a9c7dfb6227774aefb39fa3951a5874ea953b9401dfc80175c026cR8): Introduced a new constant `localStorageLastRunEndTime` for managing the last pipeline run end time in localStorage.

<img width="953" alt="Screenshot 2025-07-01 at 1 51 50 p m" src="https://github.com/user-attachments/assets/8a04c52b-c794-4c05-8eeb-d9a9f13d2d19" />
