### PR TITLE
Saving api response for run status on `kedro viz build/deploy` 

### DIFF
--- a/demo-project/build/api/run-status
+++ b/demo-project/build/api/run-status
@@ -1,0 +1,335 @@
+{
+  "nodes": {
+    "69c523b6": {
+      "duration": 0.019909750029910356,
+      "status": "success",
+      "error": null
+    },
+    "ea604da4": {
+      "duration": 0.018141041975468397,
+      "status": "success",
+      "error": null
+    },
+    "f33b9291": {
+      "duration": 0.0436144580016844,
+      "status": "success",
+      "error": null
+    },
+    "8de402c1": {
+      "duration": 0.60970383399399,
+      "status": "success",
+      "error": null
+    },
+    "cb5166f3": {
+      "duration": 0.05434016702929512,
+      "status": "success",
+      "error": null
+    },
+    "04ba733a": {
+      "duration": 0.021437250019516796,
+      "status": "success",
+      "error": null
+    },
+    "7932e672": {
+      "duration": 0.003806374967098236,
+      "status": "success",
+      "error": null
+    },
+    "e50f81b8": {
+      "duration": 0.01313387497793883,
+      "status": "success",
+      "error": null
+    },
+    "9a6ef457": {
+      "duration": 0.0038898339844308794,
+      "status": "success",
+      "error": null
+    },
+    "be6b7919": {
+      "duration": 0.25152412499301136,
+      "status": "success",
+      "error": null
+    },
+    "44ef9b48": {
+      "duration": 0.011709082988090813,
+      "status": "success",
+      "error": null
+    },
+    "c7646ea1": {
+      "duration": 0.015510708035435528,
+      "status": "success",
+      "error": null
+    },
+    "3fb71518": {
+      "duration": 0.01119254098739475,
+      "status": "success",
+      "error": null
+    },
+    "40886786": {
+      "duration": 0.057450166961643845,
+      "status": "success",
+      "error": null
+    },
+    "6ea2ec2c": {
+      "duration": 0.016979040985461324,
+      "status": "success",
+      "error": null
+    },
+    "4adb5c8b": {
+      "duration": 0.028318417025730014,
+      "status": "success",
+      "error": null
+    },
+    "2816ba38": {
+      "duration": 0.01545824995264411,
+      "status": "success",
+      "error": null
+    },
+    "af9a43c8": {
+      "duration": 0.10215837502619252,
+      "status": "success",
+      "error": null
+    },
+    "038647c7": {
+      "duration": 9.027734917006455,
+      "status": "success",
+      "error": null
+    },
+    "d2885635": {
+      "duration": 0.008146999985910952,
+      "status": "success",
+      "error": null
+    },
+    "bf8530bc": {
+      "duration": 0.13887566700577736,
+      "status": "success",
+      "error": null
+    }
+  },
+  "datasets": {
+    "aed46479": {
+      "name": "companies",
+      "size": 1810602,
+      "status": "success",
+      "error": null
+    },
+    "f23ad217": {
+      "name": "ingestion.int_typed_companies",
+      "size": 550104,
+      "status": "success",
+      "error": null
+    },
+    "7b2c6e04": {
+      "name": "reviews",
+      "size": 2937144,
+      "status": "success",
+      "error": null
+    },
+    "b5609df0": {
+      "name": "params:ingestion.typing.reviews.columns_as_floats",
+      "size": 0,
+      "status": "success",
+      "error": null
+    },
+    "4f7ffa1b": {
+      "name": "ingestion.int_typed_reviews",
+      "size": 1334176,
+      "status": "success",
+      "error": null
+    },
+    "f1d596c2": {
+      "name": "shuttles",
+      "size": 4195290,
+      "status": "success",
+      "error": null
+    },
+    "c0ddbcbf": {
+      "name": "ingestion.int_typed_shuttles@pandas1",
+      "size": 1234354,
+      "status": "success",
+      "error": null
+    },
+    "8f20d98e": {
+      "name": "ingestion.prm_agg_companies",
+      "size": 0,
+      "status": "success",
+      "error": null
+    },
+    "9f266f06": {
+      "name": "prm_shuttle_company_reviews",
+      "size": 1053909,
+      "status": "success",
+      "error": null
+    },
+    "f063cc82": {
+      "name": "prm_spine_table",
+      "size": 659388,
+      "status": "success",
+      "error": null
+    },
+    "abed6a4d": {
+      "name": "params:feature_engineering.feature.derived",
+      "size": 0,
+      "status": "success",
+      "error": null
+    },
+    "7c92a703": {
+      "name": "feature_engineering.feat_derived_features",
+      "size": 0,
+      "status": "success",
+      "error": null
+    },
+    "1e3cc50a": {
+      "name": "feature_importance_output",
+      "size": 458,
+      "status": "success",
+      "error": null
+    },
+    "a3627e31": {
+      "name": "params:feature_engineering.feature.static",
+      "size": 0,
+      "status": "success",
+      "error": null
+    },
+    "8e4f1015": {
+      "name": "feature_engineering.feat_static_features",
+      "size": 0,
+      "status": "success",
+      "error": null
+    },
+    "c08c7708": {
+      "name": "ingestion.prm_spine_table_clone",
+      "size": 0,
+      "status": "success",
+      "error": null
+    },
+    "3b199c6b": {
+      "name": "reporting.confusion_matrix",
+      "size": 1024,
+      "status": "success",
+      "error": null
+    },
+    "c0be8342": {
+      "name": "reporting.top_shuttle_data",
+      "size": 4100,
+      "status": "success",
+      "error": null
+    },
+    "d0e9b00f": {
+      "name": "reporting.cancellation_policy_breakdown",
+      "size": 8610,
+      "status": "success",
+      "error": null
+    },
+    "8838ca1f": {
+      "name": "reporting.cancellation_policy_grid",
+      "size": 3116,
+      "status": "success",
+      "error": null
+    },
+    "c6992660": {
+      "name": "reporting.price_histogram",
+      "size": 1024,
+      "status": "success",
+      "error": null
+    },
+    "23c94afb": {
+      "name": "model_input_table",
+      "size": 623095,
+      "status": "success",
+      "error": null
+    },
+    "eb7d6d28": {
+      "name": "reporting.feature_importance",
+      "size": 960,
+      "status": "success",
+      "error": null
+    },
+    "22eec376": {
+      "name": "params:split_options",
+      "size": 0,
+      "status": "success",
+      "error": null
+    },
+    "cae2d1c7": {
+      "name": "X_train",
+      "size": 0,
+      "status": "success",
+      "error": null
+    },
+    "872981f9": {
+      "name": "X_test",
+      "size": 0,
+      "status": "success",
+      "error": null
+    },
+    "9ca016a8": {
+      "name": "y_train",
+      "size": 0,
+      "status": "success",
+      "error": null
+    },
+    "f6d9538c": {
+      "name": "y_test",
+      "size": 0,
+      "status": "success",
+      "error": null
+    },
+    "98eb115e": {
+      "name": "params:train_evaluation.model_options.linear_regression",
+      "size": 0,
+      "status": "success",
+      "error": null
+    },
+    "10e51dea": {
+      "name": "train_evaluation.linear_regression.regressor",
+      "size": 640,
+      "status": "success",
+      "error": null
+    },
+    "b701864d": {
+      "name": "train_evaluation.linear_regression.experiment_params",
+      "size": 0,
+      "status": "success",
+      "error": null
+    },
+    "72baf5c6": {
+      "name": "params:train_evaluation.model_options.random_forest",
+      "size": 0,
+      "status": "success",
+      "error": null
+    },
+    "01675921": {
+      "name": "train_evaluation.random_forest.regressor",
+      "size": 640,
+      "status": "success",
+      "error": null
+    },
+    "4f79de77": {
+      "name": "train_evaluation.random_forest.experiment_params",
+      "size": 0,
+      "status": "success",
+      "error": null
+    },
+    "495a0bbc": {
+      "name": "train_evaluation.linear_regression.r2_score",
+      "size": 0,
+      "status": "success",
+      "error": null
+    },
+    "b16095d0": {
+      "name": "train_evaluation.random_forest.r2_score",
+      "size": 0,
+      "status": "success",
+      "error": null
+    }
+  },
+  "pipeline": {
+    "run_id": "bd075209-bc3c-4ba9-bf6d-e1baca1b8d6f",
+    "start_time": "2025-06-03T10.59.17.704458Z",
+    "end_time": "2025-06-03T10.59.35.297883Z",
+    "duration": 10.473034875933081,
+    "status": "success",
+    "error": null
+  }
+}

--- a/package/kedro_viz/api/apps.py
+++ b/package/kedro_viz/api/apps.py
@@ -153,4 +153,10 @@ def create_api_app_from_file(api_dir: str) -> FastAPI:
             (Path(api_dir) / "deploy-viz-metadata").read_text(encoding="utf8")
         )
 
+    @app.get("/api/run-status", response_class=JSONResponse)
+    async def get_run_status():
+        return json.loads(  # pragma: no cover
+            (Path(api_dir) / "run-status").read_text(encoding="utf8")
+        )
+
     return app

--- a/package/kedro_viz/api/rest/responses/save_responses.py
+++ b/package/kedro_viz/api/rest/responses/save_responses.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from kedro_viz.api.rest.responses.nodes import get_node_metadata_response
 from kedro_viz.api.rest.responses.pipelines import get_pipeline_response
+from kedro_viz.api.rest.responses.run_events import get_run_status_response
 from kedro_viz.api.rest.responses.utils import get_encoded_response
 from kedro_viz.data_access import data_access_manager
 from kedro_viz.models.flowchart.node_metadata import DataNodeMetadata
@@ -24,6 +25,7 @@ def save_api_responses_to_fs(path: str, remote_fs: Any, is_all_previews_enabled:
         main_path = f"{path}/api/main"
         nodes_path = f"{path}/api/nodes"
         pipelines_path = f"{path}/api/pipelines"
+        run_status_path = f"{path}/api/run-status"
 
         if "file" in remote_fs.protocol:
             remote_fs.makedirs(path, exist_ok=True)
@@ -33,6 +35,7 @@ def save_api_responses_to_fs(path: str, remote_fs: Any, is_all_previews_enabled:
         save_api_main_response_to_fs(main_path, remote_fs)
         save_api_node_response_to_fs(nodes_path, remote_fs, is_all_previews_enabled)
         save_api_pipeline_response_to_fs(pipelines_path, remote_fs)
+        save_api_run_status_response_to_fs(run_status_path, remote_fs)
 
     except Exception as exc:  # pragma: no cover
         logger.exception(
@@ -88,6 +91,13 @@ def save_api_node_response_to_fs(
             )
             raise exc
 
+def save_api_run_status_response_to_fs(run_status_path: str, remote_fs: Any):
+    """Saves API /run-status response to a directory."""
+    try:
+        write_api_response_to_fs(run_status_path, get_run_status_response(), remote_fs)
+    except Exception as exc:  # pragma: no cover
+        logger.exception("Failed to save run status response. Error: %s", str(exc))
+        raise exc 
 
 def write_api_response_to_fs(file_path: str, response: Any, remote_fs: Any):
     """Get encoded responses and writes it to a file"""

--- a/package/kedro_viz/api/rest/responses/save_responses.py
+++ b/package/kedro_viz/api/rest/responses/save_responses.py
@@ -91,13 +91,15 @@ def save_api_node_response_to_fs(
             )
             raise exc
 
+
 def save_api_run_status_response_to_fs(run_status_path: str, remote_fs: Any):
     """Saves API /run-status response to a directory."""
     try:
         write_api_response_to_fs(run_status_path, get_run_status_response(), remote_fs)
     except Exception as exc:  # pragma: no cover
         logger.exception("Failed to save run status response. Error: %s", str(exc))
-        raise exc 
+        raise exc
+
 
 def write_api_response_to_fs(file_path: str, response: Any, remote_fs: Any):
     """Get encoded responses and writes it to a file"""


### PR DESCRIPTION
This pull request introduces functionality to handle and save the `/run-status` API response in the `kedro_viz` package. The changes include adding a new endpoint, implementing methods to save the response, and updating the test suite to cover the new functionality.

### New API Endpoint and Response Handling:

* **Added `/api/run-status` endpoint**: Introduced a new endpoint in `async def get_run_status()` to serve the `run-status` data as a JSON response. (`package/kedro_viz/api/apps.py`)

### Saving the `/run-status` Response:

* **Added logic to save `/run-status` response**:
  - Added a new function `save_api_run_status_response_to_fs` to save the `/run-status` API response to the filesystem. (`package/kedro_viz/api/rest/responses/save_responses.py`)
  - Updated `save_api_responses_to_fs` to include the `run-status` path and call the new save function. (`package/kedro_viz/api/rest/responses/save_responses.py`) [[1]](diffhunk://#diff-3df2f10749547ec9487dfa3d6a41ea48a6cfa3e7ce8716cf26e766b9248a0caaR28) [[2]](diffhunk://#diff-3df2f10749547ec9487dfa3d6a41ea48a6cfa3e7ce8716cf26e766b9248a0caaR38)

### Testing Updates:

* **Added tests for `/run-status` response saving**:
  - Introduced a new test `test_save_api_run_status_response_to_fs` to verify the functionality of saving the `/run-status` response. (`package/tests/test_api/test_rest/test_responses/test_save_responses.py`)
  - Updated `test_save_api_responses_to_fs` to include assertions for the `/run-status` response saving logic. (`package/tests/test_api/test_rest/test_responses/test_save_responses.py`) [[1]](diffhunk://#diff-e4b31f86a270a0a0965f9e2281f146ca89bba19ac33bd452c37538258911e0c9R37-R39) [[2]](diffhunk://#diff-e4b31f86a270a0a0965f9e2281f146ca89bba19ac33bd452c37538258911e0c9R59-R61)

### Dependency Updates:

* **Imported `get_run_status_response`**: Added the necessary import for the new response handling logic. (`package/kedro_viz/api/rest/responses/save_responses.py`)

 ## QA notes
 
 - Checkout the current branch
 - At root of kedro-viz run `pip install -e package`
 - In demo_project run `kedro run`
 - In demo_project run `kedro viz build`
 - Above step will add demo-project/build/api/run-status