### PR TITLE
Ensure last pipeline node fades out by always running exit transition

### DIFF
--- a/docs/source/kedro-viz_visualisation.md
+++ b/docs/source/kedro-viz_visualisation.md
@@ -254,7 +254,7 @@ For users who prefer not to set up a Kedro environment, [Kedro-Viz visualisation
 
 ## Running Kedro-viz in a notebook. 
 
-Follow the [Jupyter notebook for Kedro project](https://docs.kedro.org/en/latest/notebooks_and_ipython/kedro_and_notebooks.html) guide on how to use a Jupyter notebook to explore elements of a Kedro project. It shows how to use `kedro jupyter notebook` to set up a notebook that has access to the `catalog`, `context`, `pipelines` and `session` variables of the Kedro project, so you can query them.
+Follow the [Jupyter notebook for Kedro project](https://docs.kedro.org/en/stable/notebooks_and_ipython/kedro_and_notebooks.html) guide on how to use a Jupyter notebook to explore elements of a Kedro project. It shows how to use `kedro jupyter notebook` to set up a notebook that has access to the `catalog`, `context`, `pipelines` and `session` variables of the Kedro project, so you can query them.
 
 Once you have followed the steps to set up your notebook. You can use line magic to display a Kedro-Viz visualisation of your pipeline directly in your notebook.
 

--- a/src/components/draw/draw-nodes.js
+++ b/src/components/draw/draw-nodes.js
@@ -39,9 +39,6 @@ export function DrawNodes({
 
   // Utility function to get D3 node selection and data join
   const getNodeSelections = (groupRef, nodes) => {
-    if (!nodes.length) {
-      return null;
-    }
     const svg = d3.select(groupRef.current);
     const nodeSel = svg
       .selectAll('.pipeline-node')
@@ -59,12 +56,20 @@ export function DrawNodes({
 
   // --- Initial node creation and removal (enter/exit) ---
   useEffect(() => {
-    const selections = getNodeSelections(groupRef, nodes);
-    if (!selections) {
+    const { updateNodes, enterNodes, exitNodes } = getNodeSelections(
+      groupRef,
+      nodes
+    );
+
+    // ===== special‐case: only exit the last node =====
+    if (nodes.length === 0) {
+      exitNodes
+        .transition('exit-nodes')
+        .duration(DURATION)
+        .style('opacity', 0)
+        .remove();
       return;
     }
-
-    const { updateNodes, enterNodes, exitNodes } = selections;
 
     enterNodes
       .attr('tabindex', '0')


### PR DESCRIPTION
## Description


Bug Reported here - _Originally posted by @merelcht in https://github.com/kedro-org/kedro-viz/issues/2329#issuecomment-3028112563_


This patch fixes a bug where the very last graph node(s) would never run its exit transition (and thus never be removed) because we were bailing out early when nodes.length === 0.

Before fix
 - Open Kedro-Viz for your project.
 - Select the “reporting” pipeline from the dropdown.
 - Click the hide-node toggle on each node, one by one.
 - On the final node hide, the node stays visible and you see the empty-state message overlapping it.

After fix
- Open Kedro-Viz and choose the “reporting” pipeline.
- Hide each node one at a time.
- On hiding the last node, it now smoothly fades out , leaving only the empty-state message behind.

## QA notes

<!-- How has the expected behaviour changed? What testing strategies have you used? -->

## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes
