### PR TITLE
Fix/layout issue for expanding single modular pipeline node

### DIFF
--- a/src/components/draw/draw-nodes.js
+++ b/src/components/draw/draw-nodes.js
@@ -257,13 +257,7 @@ export function DrawNodes({
       .text((node) => node.name)
       .style('transition-delay', (node) => (node.showText ? '200ms' : '0ms'))
       .style('opacity', (node) => (node.showText ? 1 : 0));
-  }, [
-    nodes,
-    nodeTypeDisabled.parameters,
-    nodesWithInputParams,
-    orientation,
-    nodeActive,
-  ]);
+  }, [nodes, orientation]);
 
   return <g id="nodes" className="pipeline-flowchart__nodes" ref={groupRef} />;
 }


### PR DESCRIPTION
## Description
Fixes a layout issue that occurred when expanding all nodes by clicking on a modular pipeline node.

## QA notes
Before the changes (on `main` branch):
- When expanding a pipeline by clicking on a node or switching pipelines via the dropdown, the layout behaves inconsistently—nodes do not move in sync.
- This issue is demonstrated in the video below.

https://github.com/user-attachments/assets/7555dd5d-0e31-4ea0-b847-c8b77fa4e1c7


After the changes (on this branch locally or via Codespaces):
- When expanding a pipeline by clicking on a node or switching pipelines from the dropdown, all nodes now move together smoothly in sync.
- See the video below for the updated behavior.


https://github.com/user-attachments/assets/e043cfc4-3e60-4a3e-ba62-7219d9d85e4d


## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes
