### PR TITLE
Reset state correctly for workflow view

### DIFF
--- a/src/components/workflow-wrapper/workflow-wrapper.js
+++ b/src/components/workflow-wrapper/workflow-wrapper.js
@@ -11,17 +11,27 @@ import { VIEW, PIPELINE } from '../../config';
  * Main workflow container.
  * Sets the current view to 'workflow' and resets relevant state on mount.
  */
-const WorkflowWrapper = ({ onSetView, onResetState, isRunStatusAvailable }) => {
+const WorkflowWrapper = ({
+  onSetView,
+  onResetState,
+  isRunStatusAvailable,
+  nodeIds,
+}) => {
   useEffect(() => {
     onSetView(VIEW.WORKFLOW);
-    onResetState();
-  }, [onSetView, onResetState]);
+    // Reset state only after pipelines are loaded
+    // This is to ensure that the workflow view is reset correctly
+    if (nodeIds.length > 0) {
+      onResetState();
+    }
+  }, [onSetView, onResetState, nodeIds]);
 
-   return <>{isRunStatusAvailable ? <Workflow /> : <RunNotFoundWarning />}</>;
+  return <>{isRunStatusAvailable ? <Workflow /> : <RunNotFoundWarning />}</>;
 };
 
 export const mapStateToProps = (state) => ({
   isRunStatusAvailable: isRunStatusAvailable(state),
+  nodeIds: state.node.ids,
 });
 
 const mapDispatchToProps = (dispatch) => ({


### PR DESCRIPTION
## Description

This pull request fix the state reset issue when hitting /workflow view directly and ensure proper functionality when pipelines are loaded.

## Development notes

* Added a new `nodeIds` prop to the `WorkflowWrapper` component to track pipeline node IDs, ensuring state resets occur only after pipelines are loaded.
* Updated the `useEffect` dependency array to include `nodeIds`, ensuring the effect is triggered correctly when pipeline data changes.
* Modified `mapStateToProps` to include `nodeIds` from the Redux state, enabling the component to access pipeline node IDs.


## QA notes

1. Load the flowchart view first
2. Switch to other pipeline and collapse pipeline
3. switch to workflow view
4. Pipeline should be default and it should be expanded

## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes
