### PR TITLE
Fix/notification bar position

### DIFF
--- a/src/components/run-status-notification/run-status-notification.scss
+++ b/src/components/run-status-notification/run-status-notification.scss
@@ -44,9 +44,21 @@
   max-width: 90%;
 }
 
+// Adjust position when there is no sidebar or meta sidebar
 .run-status-notification--no-sidebar,
 .run-status-notification--with-meta-sidebar {
   left: 35%;
+}
+
+// Notification success bar: wider width due to more text, so adjust position for better centering
+.run-status-notification--success {
+  left: 43%; // Default when sidebar is visible
+}
+
+// shift further left to compensate for the longer width of the message
+.run-status-notification--no-sidebar.run-status-notification--success,
+.run-status-notification--with-meta-sidebar.run-status-notification--success {
+  left: 30%;
 }
 
 // Status section


### PR DESCRIPTION
## Description

Since the notification has 2 set of width,

- in the successful state, the width is longer due to longer text shown on screen
- in the failed state, the width is shorter

Therefore to center the notification bar, we need to take into account which state that is



## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes
