### PR TITLE
Update e2e tests to use pre-release version of kedro for testing

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -15,15 +15,16 @@ jobs:
 
         # below condition checks if the operating system is Ubuntu, or 
         # if the operating system is Windows and the branch is main/demo
-        if: >
-          inputs.os == 'ubuntu-latest' || 
-          (
-            (
-              github.ref == 'refs/heads/main' || 
-              github.ref == 'refs/heads/demo'
-            ) && 
-            inputs.os == 'windows-latest'
-          )
+        # [TODO: Revert the change after testing]
+        # if: >
+        #   inputs.os == 'ubuntu-latest' || 
+        #   (
+        #     (
+        #       github.ref == 'refs/heads/main' || 
+        #       github.ref == 'refs/heads/demo'
+        #     ) && 
+        #     inputs.os == 'windows-latest'
+        #   )
           
         steps:
         - name: Checkout code

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -15,15 +15,16 @@ jobs:
 
         # below condition checks if the operating system is Ubuntu, or 
         # if the operating system is Windows and the branch is main/demo
-        if: >
-          inputs.os == 'ubuntu-latest' || 
-          (
-            (
-              github.ref == 'refs/heads/main' || 
-              github.ref == 'refs/heads/demo'
-            ) && 
-            inputs.os == 'windows-latest'
-          )
+        # [TODO: Revert the change after testing]
+        # if: >
+        #   inputs.os == 'ubuntu-latest' || 
+        #   (
+        #     (
+        #       github.ref == 'refs/heads/main' || 
+        #       github.ref == 'refs/heads/demo'
+        #     ) && 
+        #     inputs.os == 'windows-latest'
+        #   )
           
         steps:
         - name: Checkout code

--- a/package/features/steps/cli_steps.py
+++ b/package/features/steps/cli_steps.py
@@ -89,14 +89,7 @@ def create_project_with_starter(context, starter):
 @given("I have installed the project's requirements")
 def install_project_requirements(context):
     """Run ``pip install -r requirements.txt``."""
-    if context.kedro_version != "latest":
-        requirements_path = str(context.root_project_dir) + "/src/requirements.txt"
-        # numpy 2.0 breaks with old versions of pandas and this
-        # could be removed when the lowest version supported is updated
-        _add_package_pin(requirements_path, "numpy", "1.26.4")
-    else:
-        requirements_path = str(context.root_project_dir) + "/requirements.txt"
-
+    requirements_path = str(context.root_project_dir) + "/requirements.txt"
     cmd = [context.pip, "install", "-r", requirements_path]
     res = run(cmd, env=context.env)
 

--- a/package/features/viz.feature
+++ b/package/features/viz.feature
@@ -3,7 +3,7 @@ Feature: Viz plugin in new project
         Given I have prepared a config file with example code
 
     Scenario: Execute viz with latest Kedro with lower-bound viz requirements
-        Given I have installed kedro version "latest"
+        Given I have installed kedro version "1.0.0rc2"
         And I have installed the lower-bound Kedro-viz requirements
         And I have run a non-interactive kedro new with spaceflights-pandas starter
         And I have installed the project's requirements
@@ -11,20 +11,20 @@ Feature: Viz plugin in new project
         Then kedro-viz should start successfully
     
     Scenario: Execute viz with latest Kedro
-        Given I have installed kedro version "latest"
+        Given I have installed kedro version "1.0.0rc2"
         And I have run a non-interactive kedro new with spaceflights-pandas starter
         And I have installed the project's requirements
         When I execute the kedro viz run command
         Then kedro-viz should start successfully
 
     Scenario: Execute viz lite with latest Kedro
-        Given I have installed kedro version "latest"
+        Given I have installed kedro version "1.0.0rc2"
         And I have run a non-interactive kedro new with spaceflights-pandas starter
         When I execute the kedro viz run command with lite option
         Then kedro-viz should start successfully
 
     Scenario: Compare viz responses in regular and lite mode
-        Given I have installed kedro version "latest"
+        Given I have installed kedro version "1.0.0rc2"
         And I have run a non-interactive kedro new with spaceflights-pandas starter
         When I execute the kedro viz run command with lite option
         Then I store the response from main endpoint

--- a/package/features/viz.feature
+++ b/package/features/viz.feature
@@ -3,7 +3,7 @@ Feature: Viz plugin in new project
         Given I have prepared a config file with example code
 
     Scenario: Execute viz with latest Kedro with lower-bound viz requirements
-        Given I have installed kedro version "1.0.0rc2"
+        Given I have installed kedro version "1.0.0rc3"
         And I have installed the lower-bound Kedro-viz requirements
         And I have run a non-interactive kedro new with spaceflights-pandas starter
         And I have installed the project's requirements
@@ -11,20 +11,20 @@ Feature: Viz plugin in new project
         Then kedro-viz should start successfully
     
     Scenario: Execute viz with latest Kedro
-        Given I have installed kedro version "1.0.0rc2"
+        Given I have installed kedro version "1.0.0rc3"
         And I have run a non-interactive kedro new with spaceflights-pandas starter
         And I have installed the project's requirements
         When I execute the kedro viz run command
         Then kedro-viz should start successfully
 
     Scenario: Execute viz lite with latest Kedro
-        Given I have installed kedro version "1.0.0rc2"
+        Given I have installed kedro version "1.0.0rc3"
         And I have run a non-interactive kedro new with spaceflights-pandas starter
         When I execute the kedro viz run command with lite option
         Then kedro-viz should start successfully
 
     Scenario: Compare viz responses in regular and lite mode
-        Given I have installed kedro version "1.0.0rc2"
+        Given I have installed kedro version "1.0.0rc3"
         And I have run a non-interactive kedro new with spaceflights-pandas starter
         When I execute the kedro viz run command with lite option
         Then I store the response from main endpoint


### PR DESCRIPTION
## Description

To test kedro-viz e2e against pre-release kedro versions

## Development notes

- Updated e2e tests to use kedro 1.0.0rc2

## QA notes

- All tests should pass

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes
