### PR TITLE
Docs/fix-gif-image

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 
 <p align="center">
 
- <img src="https://raw.githubusercontent.com/kedro-org/kedro-viz/main/.github/img/banner.gif" alt="Kedro-Viz Pipeline Visualisation">
+ <img src="https://raw.githubusercontent.com/kedro-org/kedro-viz/main/.github/img/banner.gif?v=1" alt="Kedro-Viz Pipeline Visualisation">
 </p>
 
 Kedro-Viz is an interactive development tool for visualising data science pipelines built with [Kedro](https://github.com/kedro-org/kedro).


### PR DESCRIPTION
## Description

Somehow, when the GIF image is deployed to Read the Docs, it gets converted to a .png file, which causes it to render incorrectly.
https://docs.kedro.org/projects/kedro-viz/en/v11.1.0/

To prevent this automatic rewriting, I'm adding a query string to the URL

https://kedro--2454.org.readthedocs.build/projects/kedro-viz/en/2454/

```
 <img src="https://raw.githubusercontent.com/kedro-org/kedro-viz/main/.github/img/banner.gif?v=1" alt="Kedro-Viz Pipeline Visualisation">
```
## Development notes

<!-- What have you changed? Consider adding a screenshot or GIF. -->

## QA notes

<!-- How has the expected behaviour changed? What testing strategies have you used? -->

## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes
