### PR TITLE
Fix CI build issue due to kedro-telemetry 0.6.4 release

### DIFF
--- a/package/kedro_viz/integrations/kedro/telemetry.py
+++ b/package/kedro_viz/integrations/kedro/telemetry.py
@@ -20,7 +20,7 @@ def get_heap_app_id(project_path: Path) -> Optional[str]:
     if not _IS_TELEMETRY_INSTALLED:  # pragma: no cover
         return None
 
-    if _check_for_telemetry_consent(project_path):
+    if _check_for_telemetry_consent(project_path) is None or _check_for_telemetry_consent(project_path):
         return _get_heap_app_id()
     return None
 


### PR DESCRIPTION
## Description

CI on Kedro-Viz failed - https://github.com/kedro-org/kedro-viz/actions/runs/17098166931/job/48499161886?pr=2467
This is due to the `kedro-telemetry 0.6.4` release which has the [change](https://github.com/kedro-org/kedro-plugins/commit/1572f0fb2c1049363887bb642f0c246475358915#diff-35f30be1bcff732d5eaffd71c7dbc5d716e013911fcaa5cee47191ad961fcc7aR359) to `_check_for_telemetry_consent` method. 

## Development notes

- If I understand this correctly, unless user creates a `.telemetry` file and makes `consent=false` kedro-telemetry will collect information. 
- Until `kedro-telemetry 0.6.3`, the default return of `_check_for_telemetry_consent` method was `True`. Now it is changed to `None` from `kedro-telemetry 0.6.4`.
- Modified the condition at `package/kedro_viz/integrations/kedro/telemetry.py` to include `None` as default

## QA notes

- All tests should pass

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes
