### PR TITLE
Set telemetry consent to false on CI/CD setup

### DIFF
--- a/.github/actions/setup_tests/action.yml
+++ b/.github/actions/setup_tests/action.yml
@@ -11,10 +11,11 @@ inputs:
     required: false
     default: '3.9'
 
+env:
+  KEDRO_DISABLE_TELEMETRY: "true"
+
 runs:
   using: "composite"
-  env:
-    KEDRO_DISABLE_TELEMETRY: "true"
   steps:
     - name: Set up Python ${{inputs.python-version}}
       uses: actions/setup-python@v5

--- a/.github/actions/setup_tests/action.yml
+++ b/.github/actions/setup_tests/action.yml
@@ -13,6 +13,8 @@ inputs:
 
 runs:
   using: "composite"
+  env:
+    KEDRO_DISABLE_TELEMETRY: "true"
   steps:
     - name: Set up Python ${{inputs.python-version}}
       uses: actions/setup-python@v5

--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -23,6 +23,7 @@ concurrency:
 
 env:
   PYTHON_VERSION: '3.9'
+  KEDRO_DISABLE_TELEMETRY: "true"
 
 jobs:
   # Single deploy job since we're just deploying

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -9,6 +9,10 @@ on:
         type: string
       python-version:
         type: string
+
+env:
+  KEDRO_DISABLE_TELEMETRY: "true"
+
 jobs:
     e2e_tests:
         runs-on: ${{ inputs.os }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,6 +10,10 @@ on:
         type: string
       python-version:
         type: string
+
+env:
+  KEDRO_DISABLE_TELEMETRY: "true"
+
 jobs:
     lint:
         runs-on: ${{ inputs.os }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -9,6 +9,10 @@ on:
         type: string
       python-version:
         type: string
+
+env:
+  KEDRO_DISABLE_TELEMETRY: "true"
+
 jobs:
     unit_tests:
         runs-on: ${{ inputs.os }}

--- a/package/tests/test_api/test_apps.py
+++ b/package/tests/test_api/test_apps.py
@@ -7,6 +7,7 @@ from kedro_viz.api import apps
 
 
 class TestIndexEndpoint:
+    # Ensure telemetry is not disabled by environment variable for this test
     @mock.patch.dict("os.environ", {"KEDRO_DISABLE_TELEMETRY": ""}, clear=False)
     def test_index(self, client):
         response = client.get("/")
@@ -21,6 +22,7 @@ class TestIndexEndpoint:
     ):
         mock_get_heap_app_id.return_value = "my_heap_app"
         mock_get_heap_identity.return_value = "my_heap_identity"
+        # Ensure telemetry is not disabled by environment variable for this test
         with mock.patch.dict(
             "os.environ", {"KEDRO_DISABLE_TELEMETRY": ""}, clear=False
         ):
@@ -28,6 +30,13 @@ class TestIndexEndpoint:
             assert response.status_code == 200
             assert 'heap.load("my_heap_app")' in response.text
             assert 'heap.identify("my_heap_identity")' in response.text
+
+    def test_heap_disabled_by_env_var(self, client):
+        """Test that heap analytics is disabled when KEDRO_DISABLE_TELEMETRY=true"""
+        with mock.patch.dict("os.environ", {"KEDRO_DISABLE_TELEMETRY": "true"}):
+            response = client.get("/")
+            assert response.status_code == 200
+            assert "heap" not in response.text
 
 
 @pytest.fixture

--- a/package/tests/test_api/test_apps.py
+++ b/package/tests/test_api/test_apps.py
@@ -21,7 +21,9 @@ class TestIndexEndpoint:
     ):
         mock_get_heap_app_id.return_value = "my_heap_app"
         mock_get_heap_identity.return_value = "my_heap_identity"
-        with mock.patch.dict("os.environ", {"KEDRO_DISABLE_TELEMETRY": ""}, clear=False):
+        with mock.patch.dict(
+            "os.environ", {"KEDRO_DISABLE_TELEMETRY": ""}, clear=False
+        ):
             response = client.get("/")
             assert response.status_code == 200
             assert 'heap.load("my_heap_app")' in response.text

--- a/package/tests/test_api/test_apps.py
+++ b/package/tests/test_api/test_apps.py
@@ -7,6 +7,7 @@ from kedro_viz.api import apps
 
 
 class TestIndexEndpoint:
+    @mock.patch.dict("os.environ", {"KEDRO_DISABLE_TELEMETRY": ""}, clear=False)
     def test_index(self, client):
         response = client.get("/")
         assert response.status_code == 200
@@ -20,10 +21,11 @@ class TestIndexEndpoint:
     ):
         mock_get_heap_app_id.return_value = "my_heap_app"
         mock_get_heap_identity.return_value = "my_heap_identity"
-        response = client.get("/")
-        assert response.status_code == 200
-        assert 'heap.load("my_heap_app")' in response.text
-        assert 'heap.identify("my_heap_identity")' in response.text
+        with mock.patch.dict("os.environ", {"KEDRO_DISABLE_TELEMETRY": ""}, clear=False):
+            response = client.get("/")
+            assert response.status_code == 200
+            assert 'heap.load("my_heap_app")' in response.text
+            assert 'heap.identify("my_heap_identity")' in response.text
 
 
 @pytest.fixture

--- a/package/tests/test_integrations/test_telemetry.py
+++ b/package/tests/test_integrations/test_telemetry.py
@@ -11,9 +11,11 @@ def test_get_heap_app_id_no_telemetry_file():
 
 
 def test_get_heap_app_id_invalid_telemetry_file(tmpdir):
-    telemetry_file = tmpdir / ".telemetry"
-    telemetry_file.write_text("foo", encoding="utf-8")
-    assert kedro_telemetry.get_heap_app_id(tmpdir) is not None
+    # Ensure telemetry is not disabled by environment variable for this test
+    with mock.patch.dict("os.environ", {"KEDRO_DISABLE_TELEMETRY": ""}, clear=False):
+        telemetry_file = tmpdir / ".telemetry"
+        telemetry_file.write_text("foo", encoding="utf-8")
+        assert kedro_telemetry.get_heap_app_id(tmpdir) is not None
 
 
 def test_get_heap_app_id_no_consent(tmpdir):
@@ -27,11 +29,13 @@ def test_get_heap_app_id_no_consent(tmpdir):
 def test_get_heap_app_id_with_consent(
     mock_check_for_telemetry_consent, mock_get_heap_app_id, tmpdir
 ):
-    mock_check_for_telemetry_consent.return_value = True
-    mock_get_heap_app_id.return_value = "my_heap_id"
-    telemetry_file = tmpdir / ".telemetry"
-    telemetry_file.write_text("consent: true", encoding="utf-8")
-    assert kedro_telemetry.get_heap_app_id(tmpdir) == "my_heap_id"
+    # Ensure telemetry is not disabled by environment variable for this test
+    with mock.patch.dict("os.environ", {"KEDRO_DISABLE_TELEMETRY": ""}, clear=False):
+        mock_check_for_telemetry_consent.return_value = True
+        mock_get_heap_app_id.return_value = "my_heap_id"
+        telemetry_file = tmpdir / ".telemetry"
+        telemetry_file.write_text("consent: true", encoding="utf-8")
+        assert kedro_telemetry.get_heap_app_id(tmpdir) == "my_heap_id"
 
 
 @mock.patch("kedro_viz.integrations.kedro.telemetry._check_for_telemetry_consent")

--- a/package/tests/test_integrations/test_telemetry.py
+++ b/package/tests/test_integrations/test_telemetry.py
@@ -5,7 +5,9 @@ from kedro_viz.integrations.kedro import telemetry as kedro_telemetry
 
 
 def test_get_heap_app_id_no_telemetry_file():
-    assert kedro_telemetry.get_heap_app_id(Path.cwd()) is not None
+    # Ensure telemetry is not disabled by environment variable for this test
+    with mock.patch.dict("os.environ", {"KEDRO_DISABLE_TELEMETRY": ""}, clear=False):
+        assert kedro_telemetry.get_heap_app_id(Path.cwd()) is not None
 
 
 def test_get_heap_app_id_invalid_telemetry_file(tmpdir):


### PR DESCRIPTION
## Description

Sets telemetry consent to `false` on Github CI configuration, to avoid generating unnecessary noise in our own telemetry dataset.

https://github.com/kedro-org/kedro/issues/4999

<!-- Why was this PR created? -->

## Development notes

<!-- What have you changed? Consider adding a screenshot or GIF. -->

## QA notes

<!-- How has the expected behaviour changed? What testing strategies have you used? -->

## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes
