### PR TITLE
Deploy Kedro builder to Kedro-Viz Github-pages

### DIFF
--- a/.github/workflows/deploy-demo-with-kedro-builder.yml
+++ b/.github/workflows/deploy-demo-with-kedro-builder.yml
@@ -30,6 +30,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: demo
 
       - name: Set up Python ${{ env.PYTHON_VERSION }}
         uses: actions/setup-python@v5
@@ -70,7 +72,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: kedro-org/kedro-builder
-          ref: github-pages
+          ref: gh-pages
           token: ${{ secrets.KEDRO_BUILDER_READ_TOKEN }}
           path: temp-kedro-builder
 


### PR DESCRIPTION
## Summary

This PR adds a new GitHub Actions workflow that deploys Kedro-Viz demo site along with Kedro-Builder documentation to GitHub Pages. The workflow combines content from both repositories into a single deployment accessible at `https://demo.kedro.org`.

## What This Workflow Does

1. **Checks out** the `demo` branch of `kedro-viz` repository
2. **Builds** the Kedro-Viz React application and demo project
3. **Fetches** the `github-pages` branch from the private `kedro-org/kedro-builder` repository
4. **Combines** both contents into a single build directory:
   - Kedro-Viz content at `https://demo.kedro.org/`
   - Kedro-Builder content at `https://demo.kedro.org/kedro-builder/`
5. **Deploys** everything to GitHub Pages using the custom domain `https://demo.kedro.org`

## Changes

- **New file**: `.github/workflows/deploy-demo-with-kedro-builder.yml`
- Based on the existing `deploy-demo.yml` workflow with additional steps to integrate Kedro-Builder content

## Key Differences from `deploy-demo.yml`

| Feature | `deploy-demo.yml` | `deploy-demo-with-kedro-builder.yml` |
|---------|-------------------|--------------------------------------|
| **Trigger** | Push to `demo` branch + Manual | Manual only |
| **Kedro-Builder** | Not included | Included from private repo |

## How to Trigger

This workflow can **only be triggered manually**:

1. Go to **Actions** tab in the GitHub repository
2. Select **"Deploy static content to Pages with Kedro Builder"** from the workflows list
3. Click **"Run workflow"** button
4. Select the branch (workflow will always use `demo` branch for kedro-viz code)
5. Click **"Run workflow"** to start

## Prerequisites

- **Secret Required**: `KEDRO_BUILDER_READ_TOKEN` must be configured in repository secrets with read access to the private `kedro-org/kedro-builder` repository
- The `github-pages` branch must exist in the `kedro-org/kedro-builder` repository

## Deployment Details

- **Environment**: `github-pages`
- **URL**: `https://demo.kedro.org`
- **Deployment paths**:
  - Root: Kedro-Viz demo application
  - `/kedro-builder`: Kedro-Builder documentation from its github-pages branch

## Testing

Tested in personal repository to verify:
- ✅ Workflow triggers manually
- ✅ Authentication with private repository works
- ✅ Build directory structure is correct
- ✅ Both contents are deployed successfully