### PR TITLE
  Remove importlib_metadata fallback import

### DIFF
--- a/package/kedro_viz/api/rest/utils.py
+++ b/package/kedro_viz/api/rest/utils.py
@@ -1,18 +1,13 @@
 """`kedro_viz.api.rest.utils` contains utility functions used in the `kedro_viz.api.rest` package"""
 
 import logging
-from importlib.metadata import PackageNotFoundError
+from importlib.metadata import PackageNotFoundError, version
 from typing import List
 
 import packaging
 
 from kedro_viz.constants import PACKAGE_REQUIREMENTS
 from kedro_viz.models.metadata import PackageCompatibility
-
-try:
-    from importlib.metadata import version
-except ImportError:  # pragma: no cover
-    from importlib_metadata import version
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Description

  - Removed unnecessary try/except block for importing `version` from `importlib_metadata` fallback
  - Simplified import to use `importlib.metadata.version` directly alongside `PackageNotFoundError`

  ## Context
  The `importlib.metadata` module has been part of Python's standard library since Python 3.8. The fallback to `importlib_metadata` is no longer needed for the supported Python versions in this project.

  ## Changes
  - Consolidated imports in `package/kedro_viz/api/rest/utils.py`
  - Removed try/except block for backwards compatibility


## QA notes

<!-- How has the expected behaviour changed? What testing strategies have you used? -->

## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes
