### PR TITLE
Fix broken publish and share kedro-viz link

### DIFF
--- a/docs/share_kedro_viz.md
+++ b/docs/share_kedro_viz.md
@@ -9,7 +9,7 @@ The publish and share feature on Kedro-Viz enables seamless sharing of pipeline 
 * [Publish and share on Azure](publish_and_share_kedro_viz_on_azure.md)
 * [Publish and share on GCP](publish_and_share_kedro_viz_on_gcp.md)
 
-3. **Publish and Share Kedro-Viz with Github Actions**: Use the `publish-kedro-viz` action available on the Github Marketplace to deploy Kedro-Viz for your Kedro project repository on GitHub Pages. For further information and usage instructions, please refer to [publish-kedro-viz](https://github.com/marketplace/actions/publish-kedro-viz)
+3. **Publish and Share Kedro-Viz with Github Actions**: Use the `publish-kedro-viz` action available on the Github Marketplace to deploy Kedro-Viz for your Kedro project repository on GitHub Pages. For further information and usage instructions, please refer to [publish-kedro-viz](https://github.com/marketplace/actions/publish-kedro-viz-to-github-pages)
 
 ## Filtering and sharing Kedro-Viz pipelines 
 


### PR DESCRIPTION
## Description

Fixes broken publish-kedro-viz link in docs - https://docs.kedro.org/projects/kedro-viz/en/v9.0.0.post1/share_kedro_viz.html

## Development notes

- Updated `publish-kedro-viz` url to https://github.com/marketplace/actions/publish-kedro-viz-to-github-pages

## QA notes

- All tests should pass

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes
