### PR TITLE
NodeContextMenu support for VSCode

### DIFF
--- a/src/actions/nodes.js
+++ b/src/actions/nodes.js
@@ -14,6 +14,19 @@ export function toggleNodeClicked(nodeClicked) {
   };
 }
 
+export const NODE_CONTEXT_MENU = 'NODE_CONTEXT_MENU';
+
+/**
+ * Dispatch when a node is right-clicked (context menu)
+ * @param {String} nodeId The node's unique identifier
+ */
+export function nodeContextMenu(nodeId) {
+  return {
+    type: NODE_CONTEXT_MENU,
+    nodeId,
+  };
+}
+
 export const TOGGLE_NODES_DISABLED = 'TOGGLE_NODES_DISABLED';
 
 /**

--- a/src/components/draw/draw-nodes.jsx
+++ b/src/components/draw/draw-nodes.jsx
@@ -24,6 +24,7 @@ export function DrawNodes({
   focusMode = null,
   orientation = 'vertical',
   onNodeClick,
+  onNodeContextMenu,
   onNodeMouseOver,
   onNodeMouseOut,
   onNodeFocus,
@@ -101,6 +102,8 @@ export function DrawNodes({
       })
       .attr('transform', (node) => `translate(${node.x}, ${node.y})`)
       .attr('data-id', (node) => node.id)
+      .attr('data-node-type', (node) => node.type)
+      .attr('data-node-fullname', (node) => node.fullName)
       .classed(
         'pipeline-node--parameters',
         (node) => node.type === 'parameters'
@@ -108,6 +111,7 @@ export function DrawNodes({
       .classed('pipeline-node--data', (node) => node.type === 'data')
       .classed('pipeline-node--task', (node) => node.type === 'task')
       .on('click', onNodeClick)
+      .on('contextmenu', onNodeContextMenu)
       .on('mouseover', onNodeMouseOver)
       .on('mouseout', onNodeMouseOut)
       .on('focus', onNodeFocus || onNodeMouseOver)
@@ -160,6 +164,7 @@ export function DrawNodes({
   }, [
     nodes,
     onNodeClick,
+    onNodeContextMenu,
     onNodeMouseOver,
     onNodeMouseOut,
     onNodeFocus,

--- a/src/components/draw/draw-nodes.test.jsx
+++ b/src/components/draw/draw-nodes.test.jsx
@@ -30,4 +30,24 @@ describe('DrawNodes', () => {
       container.querySelector('.pipeline-flowchart__nodes')
     ).toBeInTheDocument();
   });
+
+  it('renders data-node-type attribute on nodes', () => {
+    const taskNode = { ...baseNode, type: 'task' };
+    const { container } = render(<DrawNodes nodes={[taskNode]} />);
+    const nodeEl = container.querySelector('[data-node-type="task"]');
+    expect(nodeEl).toBeInTheDocument();
+  });
+
+  it('renders data-node-fullname attribute on nodes', () => {
+    const taskNode = {
+      ...baseNode,
+      type: 'task',
+      fullName: 'my_pipeline.split_data',
+    };
+    const { container } = render(<DrawNodes nodes={[taskNode]} />);
+    const nodeEl = container.querySelector(
+      '[data-node-fullname="my_pipeline.split_data"]'
+    );
+    expect(nodeEl).toBeInTheDocument();
+  });
 });

--- a/src/components/flowchart/flowchart.jsx
+++ b/src/components/flowchart/flowchart.jsx
@@ -13,6 +13,7 @@ import {
   loadNodeData,
   toggleNodeHovered,
   toggleNodeClicked,
+  nodeContextMenu,
 } from '../../actions/nodes';
 import {
   applySlicePipeline,
@@ -508,6 +509,15 @@ export class FlowChart extends Component {
     event.stopPropagation();
   };
 
+  /**
+   * Handle right-click (context menu) on a node
+   * @param {Object} event Event object
+   * @param {Object} node Datum for a single node
+   */
+  handleNodeContextMenu = (event, node) => {
+    this.props.onNodeContextMenu(node.id);
+  };
+
   resetSlicedPipeline = () => {
     this.props.onResetSlicePipeline();
     this.updateSlicedPipelineState(null, null, []);
@@ -913,6 +923,7 @@ export class FlowChart extends Component {
             focusMode={focusMode}
             orientation={orientation}
             onNodeClick={this.handleNodeClick}
+            onNodeContextMenu={this.handleNodeContextMenu}
             onNodeMouseOver={this.handleNodeMouseOver}
             onNodeMouseOut={this.handleNodeMouseOut}
             onNodeFocus={this.handleNodeMouseOver}
@@ -1070,6 +1081,9 @@ export const mapDispatchToProps = (dispatch, ownProps) => ({
   },
   onResetSlicePipeline: () => {
     dispatch(resetSlicePipeline());
+  },
+  onNodeContextMenu: (nodeId) => {
+    dispatch(nodeContextMenu(nodeId));
   },
   ...ownProps,
 });

--- a/src/store/middleware.js
+++ b/src/store/middleware.js
@@ -1,4 +1,4 @@
-import { TOGGLE_NODE_CLICKED } from '../actions/nodes';
+import { TOGGLE_NODE_CLICKED, NODE_CONTEXT_MENU } from '../actions/nodes';
 import { SHOW_PIPELINE_FILTER } from '../actions';
 
 /**
@@ -39,14 +39,21 @@ const createCallbackMiddleware =
         };
         callback(showPipelineFilterAction);
         break;
-      /** 
-      * Add additional cases here to handle other action types.
-      * Ensure on whatever action you want to trigger, It should be a Redux action. 
-      * And payload should be in Redux state.
-      * Example:
-      * const action = { type: SLICE_PIPELINE, payload: runCommand };
-        callback(action);
-      */
+      case NODE_CONTEXT_MENU:
+        if (action.nodeId) {
+          const state = store.getState();
+          const node = state?.graph?.nodes?.find(
+            (node) => node.id === action.nodeId
+          );
+          if (node) {
+            const contextMenuAction = {
+              type: NODE_CONTEXT_MENU,
+              payload: node,
+            };
+            callback(contextMenuAction);
+          }
+        }
+        break;
       default:
         break;
     }

--- a/src/store/middleware.js
+++ b/src/store/middleware.js
@@ -39,6 +39,9 @@ const createCallbackMiddleware =
         };
         callback(showPipelineFilterAction);
         break;
+      // Forwards node right-click events to the host app for embedding cases
+      // (e.g. Kedro VS Code extension) to show a custom context menu without
+      // DOM scraping.
       case NODE_CONTEXT_MENU:
         if (action.nodeId) {
           const state = store.getState();

--- a/src/store/middleware.test.js
+++ b/src/store/middleware.test.js
@@ -57,6 +57,41 @@ describe('createCallbackMiddleware', () => {
     expect(next).toHaveBeenCalledWith(action);
   });
 
+  it('should call the callback with the correct node when action type is NODE_CONTEXT_MENU', () => {
+    const nodeId = '123';
+    const node = { id: nodeId, name: 'Node 123' };
+    const action = { type: 'NODE_CONTEXT_MENU', nodeId };
+
+    store.getState.mockReturnValue({
+      graph: {
+        nodes: [node],
+      },
+    });
+
+    middleware(action);
+
+    expect(callback).toHaveBeenCalledWith({
+      type: 'NODE_CONTEXT_MENU',
+      payload: node,
+    });
+    expect(next).toHaveBeenCalledWith(action);
+  });
+
+  it('should not call the callback if NODE_CONTEXT_MENU node is not found', () => {
+    const action = { type: 'NODE_CONTEXT_MENU', nodeId: '999' };
+
+    store.getState.mockReturnValue({
+      graph: {
+        nodes: [{ id: '456', name: 'Node 456' }],
+      },
+    });
+
+    middleware(action);
+
+    expect(callback).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledWith(action);
+  });
+
   it('should not call the callback if callback is not provided', () => {
     middleware = createCallbackMiddleware(null)(store)(next);
     const action = { type: 'TOGGLE_NODE_CLICKED', nodeClicked: '123' };


### PR DESCRIPTION
## Description                                                                                                                          
                                                                                                                                        
  Adds a right-click context menu integration point to Kedro-Viz, enabling embedded consumers (e.g. the Kedro VS Code extension) to respond to node right-click events without resorting to DOM scraping.
                                                                                                                                          
  ### Context                                                                                                                          
   
  The [Kedro VS Code extension](https://github.com/kedro-org/vscode-kedro/pull/257) embeds Kedro-Viz inside a webview to provide a one-click debug experience — users right-click a pipeline node and select it as a debug target. Without a first-class API for right-click events, the extension was forced to implement ~80 lines of fragile DOM scraping: capture-phase event listeners, SVG class name traversal, D3 `__data__` property access, and `composedPath` fallbacks. This approach breaks whenever Kedro-Viz refactors its internals.

  These changes expose right-click as a proper integration point through the existing `onActionCallback` middleware pattern, eliminating the need for any DOM introspection by consumers.
                                                                                                                                          
  ### Changes                                                          

  #### `src/actions/nodes.js`
  - Added `NODE_CONTEXT_MENU` action constant
  - Added `nodeContextMenu(nodeId)` action creator                                                                                        
   
  #### `src/components/draw/draw-nodes.jsx`                                                                                               
  - Added `onNodeContextMenu` prop                                     
  - Added `data-node-type` and `data-node-fullname` attributes to each node element in the D3 enter chain, consistent with the existing
  `data-id` attribute                                                                                                                     
  - Wired `.on('contextmenu', onNodeContextMenu)` in the D3 enter chain
  - Added `onNodeContextMenu` to the `useEffect` dependency array                                                                         
                                                                                                                                          
  #### `src/components/flowchart/flowchart.jsx`                                                                                           
  - Imported `nodeContextMenu` action                                                                                                     
  - Added `handleNodeContextMenu` handler — intentionally does **not** call `preventDefault()` or `stopPropagation()` so the native
  browser context menu still fires                                                                                                        
  - Passed `onNodeContextMenu={this.handleNodeContextMenu}` to `<DrawNodes>`
  - Added `onNodeContextMenu` dispatch in `mapDispatchToProps`                                                                            
                                                                                                                                          
  #### `src/store/middleware.js`
  - Imported `NODE_CONTEXT_MENU`                                                                                                          
  - Added `NODE_CONTEXT_MENU` case to the callback middleware switch, following the same pattern as `TOGGLE_NODE_CLICKED` — looks up the
  full node object from Redux state and passes it as `payload` to the callback                                                            
   
  #### Tests                                                                                                                              
  - `draw-nodes.test.jsx` — added tests for `data-node-type` and `data-node-fullname` attribute rendering
  - `middleware.test.js` — added tests for the `NODE_CONTEXT_MENU` middleware case (node found and node not found)                        
                                                                                                                                          
  ### Backward compatibility
                                                                                                                                          
  All changes are purely additive:                                                                                                        
   
  - `onNodeContextMenu` is an optional prop — omitting it means D3 registers no handler (no-op)                                           
  - The middleware guard (`if (!callback) return next(action)`) ensures the new case is never reached in standalone Kedro-Viz where no
  `onActionCallback` is provided                                                                                                          
  - `handleNodeContextMenu` does not suppress the native context menu, so right-click behaviour in the browser is unchanged
  - No existing reducer handles `NODE_CONTEXT_MENU`, so Redux state is unaffected                                                         
  - `data-*` attributes on SVG elements are inert metadata with no functional side effects                                                
                                                                                                                                          
  ### How consumers use this                                                                                                              
                                                                                                                                          
  Consumers that pass `onActionCallback` to `configureStore` will now receive:                                                            
   
  ```js                                                                                                                                   
  {                                                                    
    type: 'NODE_CONTEXT_MENU',
    payload: {                                                                                                                            
      id: 'abc123',
      name: 'split_data',                                                                                                                 
      fullName: 'uk.data_processing.split_data',                       
      type: 'task',                                                                                                                       
      // ...full node object from Redux state
    }                                                                                                                                     
  }                                                                    
  ```                                                                                                                                        
  The data-node-type and data-node-fullname DOM attributes are also available for consumers that need node metadata synchronously during the contextmenu event (e.g. VS Code's data-vscode-context which must be set before the browser reads it).
                                                                                                                                          
### Related                                                              

  - kedro-org/vscode-kedro#257
  
  ### Test
  There is no visible or functional changes to Kedro-Viz when used out side of VSCode extension.   