### PR TITLE
Security: Template variable injection into inline JavaScript (telemetry bootstrap)

### DIFF
--- a/public/telemetry.html
+++ b/public/telemetry.html
@@ -1,9 +1,9 @@
 <script type="text/javascript">   
   window.heap=window.heap||[],heap.load=function(e,t){window.heap.appid=e,window.heap.config=t=t||{};var r=document.createElement("script");r.type="text/javascript",r.async=!0,r.src="https://cdn.heapanalytics.com/js/heap-"+e+".js";var a=document.getElementsByTagName("script")[0];a.parentNode.insertBefore(r,a);for(var n=function(e){return function(){heap.push([e].concat(Array.prototype.slice.call(arguments,0)))}},p=["addEventProperties","addUserProperties","clearEventProperties","identify","resetIdentity","removeEventProperty","setEventProperties","track","unsetEventProperty"],o=0;o<p.length;o++)heap[p[o]]=n(p[o])};
-  heap.load("{{ heap_app_id }}"); 
-  heap.identify("{{ heap_user_identity }}");
+  heap.load({{ heap_app_id|tojson }}); 
+  heap.identify({{ heap_user_identity|tojson }});
   heap.addEventProperties({
-    kedro_viz_version: "{{ kedro_viz_version }}",
+    kedro_viz_version: {{ kedro_viz_version|tojson }},
   });
 </script>
 </head>


### PR DESCRIPTION
## Problem

Template variables (`heap_app_id`, `heap_user_identity`, `kedro_viz_version`) are embedded directly inside inline JavaScript string literals. If any value contains quotes or script-breaking characters and is not context-escaped by the template engine, this can lead to reflected/stored XSS.

**Severity**: `high`
**File**: `public/telemetry.html`

## Solution

Apply JavaScript-context escaping for all injected variables, or move dynamic data into `data-*` attributes/JSON script tags and parse safely. Enforce CSP (`script-src` with nonce/hash) to reduce impact.

## Changes

- `public/telemetry.html` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
