### PR TITLE
Expose full internal Kedro node name as `kedro_node_name` in pipeline API response.

### DIFF
--- a/package/kedro_viz/api/rest/responses/pipelines.py
+++ b/package/kedro_viz/api/rest/responses/pipelines.py
@@ -54,9 +54,11 @@ class TaskNodeAPIResponse(BaseGraphNodeAPIResponse):
 
     Attributes:
         parameters (Dict): A dictionary containing the parameters for the task node.
+        kedro_node_name (Optional[str]): The full internal Kedro node name including namespace and hash suffix.
     """
 
     parameters: Dict
+    kedro_node_name: Optional[str] = None
     model_config = ConfigDict(
         json_schema_extra={
             "example": {
@@ -80,6 +82,7 @@ class TaskNodeAPIResponse(BaseGraphNodeAPIResponse):
                         "review_scores_rating",
                     ],
                 },
+                "kedro_node_name": "data_science.split_data_node",
             }
         }
     )

--- a/package/kedro_viz/api/rest/responses/pipelines.py
+++ b/package/kedro_viz/api/rest/responses/pipelines.py
@@ -54,16 +54,17 @@ class TaskNodeAPIResponse(BaseGraphNodeAPIResponse):
 
     Attributes:
         parameters (Dict): A dictionary containing the parameters for the task node.
-        kedro_node_name (Optional[str]): The full internal Kedro node name including namespace and hash suffix.
+        full_name (str): The full internal Kedro node name including namespace and hash suffix.
     """
 
     parameters: Dict
-    kedro_node_name: Optional[str] = None
+    full_name: str
     model_config = ConfigDict(
         json_schema_extra={
             "example": {
                 "id": "6ab908b8",
                 "name": "split_data_node",
+                "full_name": "data_science.split_data_node",
                 "tags": [],
                 "pipelines": ["__default__", "ds"],
                 "modular_pipelines": [],
@@ -82,7 +83,6 @@ class TaskNodeAPIResponse(BaseGraphNodeAPIResponse):
                         "review_scores_rating",
                     ],
                 },
-                "kedro_node_name": "data_science.split_data_node",
             }
         }
     )

--- a/package/kedro_viz/models/flowchart/nodes.py
+++ b/package/kedro_viz/models/flowchart/nodes.py
@@ -95,6 +95,7 @@ class GraphNode(BaseModel, ABC):
             kedro_obj=node,
             modular_pipelines=modular_pipelines,
             node_extras=node_extras,
+            kedro_node_name=node.name,
         )
 
     @classmethod
@@ -255,6 +256,11 @@ class TaskNode(GraphNode):
         default=None,
         validate_default=True,
         description="The original namespace on this node",
+    )
+
+    kedro_node_name: Optional[str] = Field(
+        default=None,
+        description="The full internal Kedro node name including namespace and hash suffix",
     )
 
     @model_validator(mode="before")

--- a/package/kedro_viz/models/flowchart/nodes.py
+++ b/package/kedro_viz/models/flowchart/nodes.py
@@ -95,7 +95,7 @@ class GraphNode(BaseModel, ABC):
             kedro_obj=node,
             modular_pipelines=modular_pipelines,
             node_extras=node_extras,
-            kedro_node_name=node.name,
+            full_name=node.name,
         )
 
     @classmethod
@@ -258,8 +258,7 @@ class TaskNode(GraphNode):
         description="The original namespace on this node",
     )
 
-    kedro_node_name: Optional[str] = Field(
-        default=None,
+    full_name: str = Field(
         description="The full internal Kedro node name including namespace and hash suffix",
     )
 

--- a/package/tests/test_api/main
+++ b/package/tests/test_api/main
@@ -7,7 +7,8 @@
       "pipelines": ["data_processing", "__default__"],
       "type": "task",
       "modular_pipelines": ["uk.data_processing"],
-      "parameters": { "uk.data_processing.train_test_split": 0.1 }
+      "parameters": { "uk.data_processing.train_test_split": 0.1 },
+      "kedro_node_name": "uk.data_processing.process_data"
     },
     {
       "id": "f0ebef01",
@@ -46,7 +47,8 @@
       "pipelines": ["__default__", "data_science"],
       "type": "task",
       "modular_pipelines": ["uk.data_science"],
-      "parameters": { "train_test_split": 0.1, "num_epochs": 1000 }
+      "parameters": { "train_test_split": 0.1, "num_epochs": 1000 },
+      "kedro_node_name": "uk.data_science.train_model"
     },
     {
       "id": "f1f1425b",

--- a/package/tests/test_api/main
+++ b/package/tests/test_api/main
@@ -8,7 +8,7 @@
       "type": "task",
       "modular_pipelines": ["uk.data_processing"],
       "parameters": { "uk.data_processing.train_test_split": 0.1 },
-      "kedro_node_name": "uk.data_processing.process_data"
+      "full_name": "uk.data_processing.process_data"
     },
     {
       "id": "f0ebef01",
@@ -48,7 +48,7 @@
       "type": "task",
       "modular_pipelines": ["uk.data_science"],
       "parameters": { "train_test_split": 0.1, "num_epochs": 1000 },
-      "kedro_node_name": "uk.data_science.train_model"
+      "full_name": "uk.data_science.train_model"
     },
     {
       "id": "f1f1425b",

--- a/package/tests/test_api/test_rest/test_responses/assert_helpers.py
+++ b/package/tests/test_api/test_rest/test_responses/assert_helpers.py
@@ -101,6 +101,7 @@ def assert_example_data(response_data):
             "type": "task",
             "parameters": {"uk.data_processing.train_test_split": 0.1},
             "node_extras": None,
+            "kedro_node_name": "uk.data_processing.process_data",
         },
         {
             "id": "13399a82",
@@ -153,6 +154,7 @@ def assert_example_data(response_data):
                 "num_epochs": 1000,
             },
             "node_extras": None,
+            "kedro_node_name": "uk.data_science.train_model",
         },
         {
             "id": "f1f1425b",
@@ -303,6 +305,7 @@ def assert_example_data_from_file(response_data):
             "modular_pipelines": ["uk.data_processing"],
             "type": "task",
             "parameters": {"uk.data_processing.train_test_split": 0.1},
+            "kedro_node_name": "uk.data_processing.process_data",
         },
         {
             "id": "13399a82",
@@ -345,6 +348,7 @@ def assert_example_data_from_file(response_data):
                 "train_test_split": 0.1,
                 "num_epochs": 1000,
             },
+            "kedro_node_name": "uk.data_science.train_model",
         },
         {
             "id": "f1f1425b",
@@ -484,6 +488,7 @@ def assert_example_transcoded_data(response_data):
             "modular_pipelines": None,
             "parameters": {"uk.data_processing.train_test_split": 0.1},
             "node_extras": None,
+            "kedro_node_name": "process_data",
         },
         {
             "id": "7c58d8e6",
@@ -527,6 +532,7 @@ def assert_example_transcoded_data(response_data):
             "modular_pipelines": None,
             "parameters": {"train_test_split": 0.1, "num_epochs": 1000},
             "node_extras": None,
+            "kedro_node_name": "train_model",
         },
         {
             "id": "f1f1425b",

--- a/package/tests/test_api/test_rest/test_responses/assert_helpers.py
+++ b/package/tests/test_api/test_rest/test_responses/assert_helpers.py
@@ -101,7 +101,7 @@ def assert_example_data(response_data):
             "type": "task",
             "parameters": {"uk.data_processing.train_test_split": 0.1},
             "node_extras": None,
-            "kedro_node_name": "uk.data_processing.process_data",
+            "full_name": "uk.data_processing.process_data",
         },
         {
             "id": "13399a82",
@@ -154,7 +154,7 @@ def assert_example_data(response_data):
                 "num_epochs": 1000,
             },
             "node_extras": None,
-            "kedro_node_name": "uk.data_science.train_model",
+            "full_name": "uk.data_science.train_model",
         },
         {
             "id": "f1f1425b",
@@ -305,7 +305,7 @@ def assert_example_data_from_file(response_data):
             "modular_pipelines": ["uk.data_processing"],
             "type": "task",
             "parameters": {"uk.data_processing.train_test_split": 0.1},
-            "kedro_node_name": "uk.data_processing.process_data",
+            "full_name": "uk.data_processing.process_data",
         },
         {
             "id": "13399a82",
@@ -348,7 +348,7 @@ def assert_example_data_from_file(response_data):
                 "train_test_split": 0.1,
                 "num_epochs": 1000,
             },
-            "kedro_node_name": "uk.data_science.train_model",
+            "full_name": "uk.data_science.train_model",
         },
         {
             "id": "f1f1425b",
@@ -488,7 +488,7 @@ def assert_example_transcoded_data(response_data):
             "modular_pipelines": None,
             "parameters": {"uk.data_processing.train_test_split": 0.1},
             "node_extras": None,
-            "kedro_node_name": "process_data",
+            "full_name": "process_data",
         },
         {
             "id": "7c58d8e6",
@@ -532,7 +532,7 @@ def assert_example_transcoded_data(response_data):
             "modular_pipelines": None,
             "parameters": {"train_test_split": 0.1, "num_epochs": 1000},
             "node_extras": None,
-            "kedro_node_name": "train_model",
+            "full_name": "train_model",
         },
         {
             "id": "f1f1425b",

--- a/package/tests/test_api/test_rest/test_responses/test_pipelines.py
+++ b/package/tests/test_api/test_rest/test_responses/test_pipelines.py
@@ -135,6 +135,7 @@ class TestSinglePipelineEndpoint:
                     "num_epochs": 1000,
                 },
                 "node_extras": None,
+                "kedro_node_name": "uk.data_science.train_model",
             },
             {
                 "id": "f1f1425b",

--- a/package/tests/test_api/test_rest/test_responses/test_pipelines.py
+++ b/package/tests/test_api/test_rest/test_responses/test_pipelines.py
@@ -135,7 +135,7 @@ class TestSinglePipelineEndpoint:
                     "num_epochs": 1000,
                 },
                 "node_extras": None,
-                "kedro_node_name": "uk.data_science.train_model",
+                "full_name": "uk.data_science.train_model",
             },
             {
                 "id": "f1f1425b",

--- a/package/tests/test_models/test_flowchart/test_nodes.py
+++ b/package/tests/test_models/test_flowchart/test_nodes.py
@@ -55,6 +55,21 @@ class TestGraphNodeCreation:
         assert task_node.pipelines == set()
         assert task_node.modular_pipelines == expected_modular_pipelines
         assert task_node.namespace == namespace
+        assert task_node.kedro_node_name == kedro_node.name
+
+    def test_create_task_node_without_name(self):
+        """Test that kedro_node_name captures the full internal name including hash suffix
+        when no explicit name is provided."""
+        kedro_node = node(
+            identity,
+            inputs="x",
+            outputs="y",
+        )
+        task_node = GraphNode.create_task_node(kedro_node, "some_id", set())
+        assert task_node.name == "identity"
+        assert task_node.kedro_node_name == kedro_node.name
+        # Full internal name should include hash suffix, e.g. "identity__<hash>"
+        assert "__" in task_node.kedro_node_name
 
     @pytest.mark.parametrize(
         "dataset_name, expected_modular_pipelines",

--- a/package/tests/test_models/test_flowchart/test_nodes.py
+++ b/package/tests/test_models/test_flowchart/test_nodes.py
@@ -55,10 +55,10 @@ class TestGraphNodeCreation:
         assert task_node.pipelines == set()
         assert task_node.modular_pipelines == expected_modular_pipelines
         assert task_node.namespace == namespace
-        assert task_node.kedro_node_name == kedro_node.name
+        assert task_node.full_name == kedro_node.name
 
     def test_create_task_node_without_name(self):
-        """Test that kedro_node_name captures the full internal name including hash suffix
+        """Test that full_name captures the full internal name including hash suffix
         when no explicit name is provided."""
         kedro_node = node(
             identity,
@@ -67,9 +67,9 @@ class TestGraphNodeCreation:
         )
         task_node = GraphNode.create_task_node(kedro_node, "some_id", set())
         assert task_node.name == "identity"
-        assert task_node.kedro_node_name == kedro_node.name
+        assert task_node.full_name == kedro_node.name
         # Full internal name should include hash suffix, e.g. "identity__<hash>"
-        assert "__" in task_node.kedro_node_name
+        assert "__" in task_node.full_name
 
     @pytest.mark.parametrize(
         "dataset_name, expected_modular_pipelines",

--- a/package/tests/test_models/test_flowchart/test_nodes.py
+++ b/package/tests/test_models/test_flowchart/test_nodes.py
@@ -306,6 +306,7 @@ class TestGraphNodeCreation:
             tags=set(),
             kedro_obj=None,
             modular_pipelines=set(),
+            full_name="my_task",
         )
 
         assert task_node.namespace is None


### PR DESCRIPTION
  Related: [kedro-org/vscode-kedro#60](https://github.com/kedro-org/vscode-kedro/issues/60)     

## Description                                                                                                                          
                                                                                                                                                                                        
When a Kedro node is defined without an explicit `name=` parameter, Kedro internally generates a unique name with a hash suffix (e.g., `reporting.make_cancel_policy_bar_chart__7c6d9304`). Kedro-viz was only surfacing the bare function name (e.g., `make_cancel_policy_bar_chart`) as the display name, and the full internal name was only accessible via the `/api/nodes/<node_id>` endpoint — which is problematic because `node_id` is not a stable identifier.                                                           
                                                                                                                                          
This meant the VS Code Kedro extension (`vscode-kedro`) had no reliable way to retrieve the full internal node name from the main pipeline JSON, requiring either a separate unstable API call or loading the Kedro project independently (risking inconsistency with the viz graph).                                                                                                                                                                                                                               
                                                                                                                                          
  ### Solution                                                                                                                            
  Expose `node.name` (the full internal Kedro node name) as a new `kedro_node_name` field on `TaskNode` and `TaskNodeAPIResponse`. This field is now included in the response from `/api/pipelines/<id>` and `get_kedro_project_json_data()`.                                                                              
                                                                                                                                          
  ### Behaviour                                                                                                                           
                                                                                                                                          
  | Scenario | `name` (existing display name) | `kedro_node_name` (new) |                                                                 
  |---|---|---|                                             
  | With explicit `name="my_node"` | `"my_node"` | `"my_node"` |                                                                          
  | Without name | `"identity"` | `"identity__784efba9"` |  
  | Without name + namespace | `"identity"` | `"reporting.identity__784efba9"` |                                                          
  | With name + namespace | `"my_node"` | `"reporting.my_node"` |                                                                         
                                                                                                                                          
  ### Changes                                                                                                                             
  - `models/flowchart/nodes.py` — added `kedro_node_name` field to `TaskNode`; populated via `node.name` in `create_task_node()`
  - `api/rest/responses/pipelines.py` — added `kedro_node_name` field to `TaskNodeAPIResponse` including OpenAPI schema example           
  - `tests/test_models/test_flowchart/test_nodes.py` — asserts `kedro_node_name` in existing test; adds new test covering the             
  no-explicit-name case         
  
  
  ## How to Test                       
                                                                                                                                                                                                                                                          
  - This branch checked out: `vscode/api-new-entry`                    
  - Dependencies installed: `make install` / `pip install -e package`                                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                                                            
### 1. Start the backend                                                                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                                                     
  ```bash                                                                                                                                                                                                                                                                                                                            
  make build                                                           
  make run
  ```

  ### 2. Start the frontend (in another terminal)

  ```bash                                                                                                                                                                                                                                                                                                                            
  npm run start:dev
  ```                                                                                                                                                                                                                                                                                                                                
                                                                       
  ### 3. Inspect the `/api/main` response

  - Open the app in the browser.                                                                                                                                                                                                                                                                                                     
  - Open DevTools → **Network** tab → find the `main` request.
  - In the **Response** tab, locate the `nodes` array.                                                                                                                                                                                                                                                                               
  - For each **task** node, confirm a new `kedro_node_name` field is present and holds the full internal Kedro name (e.g. `reporting.make_cancel_policy_bar_chart` or `<func_name>__<8-char-hash>` when no explicit name was set).                                                                                                   
  - For **data** / **parameter** nodes, the field should be absent / `null`. 

                                                                       
  ### 4. Verify the static-file export path

  ```bash
  kedro viz build
  cat build/api/main | python -m json.tool | grep kedro_node_name
  ```                                                                                                                                                                                                                                                                                                                                
   
  **Expected:** same `kedro_node_name` values appear in the exported static JSON.                                                                                                                                                                                                                                                     