### PR TITLE
Add CMP script to demo site.

### DIFF
--- a/.github/workflows/deploy-demo-with-kedro-builder.yml
+++ b/.github/workflows/deploy-demo-with-kedro-builder.yml
@@ -51,6 +51,8 @@ jobs:
         uses: "./.github/actions/install_node_dependencies"
 
       - name: Build React application
+        env:
+          VITE_INJECT_CONSENT_SCRIPT: 'true'
         run: |-
           node -v
           make build

--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -53,6 +53,8 @@ jobs:
         uses: "./.github/actions/install_node_dependencies"
 
       - name: Build React application
+        env:
+          VITE_INJECT_CONSENT_SCRIPT: 'true'
         run: |-
           node -v
           make build
@@ -69,7 +71,6 @@ jobs:
             exit 1
           fi
         shell: bash
-
 
       - name: Setup Pages
         uses: actions/configure-pages@v5

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,12 +1,33 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
+const CMP_CONSENT_SCRIPT =
+  '<script src="https://kedro.org/consent/kedro-consent.js" defer></script>';
+
+// Injects the Kedro CMP consent script into index.html when
+// VITE_INJECT_CONSENT_SCRIPT=true. Used exclusively by the demo.kedro.org
+// GitHub Pages deploy; normal builds are unaffected.
+function injectConsentScript() {
+  return {
+    name: 'inject-consent-script',
+    transformIndexHtml(html) {
+      if (process.env.VITE_INJECT_CONSENT_SCRIPT !== 'true') {
+        return html;
+      }
+      return html.replace(
+        '</head>',
+        `    ${CMP_CONSENT_SCRIPT}\n  </head>`
+      );
+    },
+  };
+}
+
 export default defineConfig({
   base: './',
   define: {
     'process.env': {},
   },
-  plugins: [react()],
+  plugins: [react(), injectConsentScript()],
   server: {
     port: 4141,
     proxy: {


### PR DESCRIPTION
Fixes https://github.com/kedro-org/kedro-viz/issues/2623

This pull request adds a mechanism to conditionally inject the Kedro CMP consent script into the `index.html` during the build process, specifically for demo deployments. 

Consent script injection for demo builds:

* Added a custom Vite plugin `injectConsentScript` in `vite.config.js` to inject the Kedro CMP consent script into `index.html` when the environment variable `VITE_INJECT_CONSENT_SCRIPT` is set to `'true'`. This ensures the script is only added for demo deployments.

Workflow updates for demo deployments:

* Updated `.github/workflows/deploy-demo.yml` and `.github/workflows/deploy-demo-with-kedro-builder.yml` to set the `VITE_INJECT_CONSENT_SCRIPT` environment variable to `'true'` during the "Build React application" step, enabling the consent script injection for these builds. [[1]](diffhunk://#diff-f64e64ec009b3dea06d69dece156c62a7624a6ed3aefda9e5b3f2da0432b6fd2R56-R57) [[2]](diffhunk://#diff-88df0eaac7ce11c1a5535738caa874f74c2bcc62eb184cd7f0f45b83abd230ddR54-R55)

Other workflow cleanup:

* Minor whitespace cleanup in `.github/workflows/deploy-demo.yml`.

## How to test

### 1. Verify the Vite plugin gates correctly

From the repo root:

```bash
# Without the env var — normal build. Should NOT contain the CMP script.
rm -rf dist && npm run build
grep kedro-consent dist/index.html || echo "OK: tag absent"

# With the env var — demo build. SHOULD contain the CMP script, exactly once.
rm -rf dist && VITE_INJECT_CONSENT_SCRIPT=true npm run build
grep -c kedro-consent dist/index.html   # expect: 1
```

Expected output:
- First run: `OK: tag absent`
- Second run: `1`

### 2. Verify the full demo pipeline (mirrors `deploy-demo.yml`)

This runs the same sequence of steps as the demo GitHub Actions workflow:

```bash
# Build the React app as the demo workflow does
rm -rf dist && VITE_INJECT_CONSENT_SCRIPT=true make build

# Install kedro-viz (skip if already installed with -e)
pip install -e package

# Run kedro viz build inside demo-project (exact CI command)
cd demo-project && kedro viz build --include-previews && cd ..

# Confirm the tag made it into the final artifact uploaded to GitHub Pages
grep -A1 -B1 kedro-consent demo-project/build/index.html
```

Expected: the line

```html
<script src="https://kedro.org/consent/kedro-consent.js" defer></script>
```

appears exactly once, immediately before `</head>`.
