### PR TITLE
Use `kedro_session` directly to avoid `AbstractSession` typing error

### DIFF
--- a/package/kedro_viz/integrations/kedro/data_loader.py
+++ b/package/kedro_viz/integrations/kedro/data_loader.py
@@ -187,12 +187,12 @@ def _load_data_helper(
         runtime_params=extra_params,
     )
 
-    with kedro_session as session:
+    with kedro_session:
         # check for --include-hooks option
         if not include_hooks:
-            session._hook_manager = _VizNullPluginManager()  # type: ignore
+            kedro_session._hook_manager = _VizNullPluginManager()  # type: ignore
 
-        context = session.load_context()
+        context = kedro_session.load_context()
 
         # If user wants lite, we patch AbstractDatasetLite no matter what
         if is_lite:


### PR DESCRIPTION
## Description

We recently merged https://github.com/kedro-org/kedro/pull/5441 which introduced an `AbstractSession` base class and removed `KedroSession.__enter__`. `KedroSession` now inherits `__enter__` from `AbstractSession`, whose return type is `AbstractSession` which has no `load_context` method.

mypy infers `session: AbstractSession` and fails on `load_context`.

## Development notes

<!-- What have you changed? Consider adding a screenshot or GIF. -->

## QA notes

<!-- How has the expected behaviour changed? What testing strategies have you used? -->

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes
