### PR TITLE
fix(tests): make heap mocks JSON-serializable in base deployer test.

### DIFF
--- a/package/tests/test_integrations/test_base_deployer.py
+++ b/package/tests/test_integrations/test_base_deployer.py
@@ -22,8 +22,14 @@ class TestBaseDeployer:
 
     def test_upload_static_files(self, mocker):
         mocker.patch("fsspec.filesystem")
-        mocker.patch("kedro_viz.integrations.kedro.telemetry.get_heap_app_id")
-        mocker.patch("kedro_viz.integrations.kedro.telemetry.get_heap_identity")
+        mocker.patch(
+            "kedro_viz.integrations.kedro.telemetry.get_heap_app_id",
+            return_value="fake-app-id",
+        )
+        mocker.patch(
+            "kedro_viz.integrations.kedro.telemetry.get_heap_identity",
+            return_value="fake-user-identity",
+        )
 
         build = ConcreteBaseDeployer()
         build._upload_static_files(_HTML_DIR)


### PR DESCRIPTION
## Description

  Fixes `tests/test_integrations/test_base_deployer.py::TestBaseDeployer::test_upload_static_files`, which fails on CI with:

  TypeError: Object of type MagicMock is not JSON serializable

  ## Root cause

  `public/telemetry.html` (the source template copied into `package/kedro_viz/html/` during the frontend build) renders the heap values through Jinja's `|tojson` filter:

  ```jinja
  heap.load({{ heap_app_id|tojson }});
  heap.identify({{ heap_user_identity|tojson }});
  ```

The test patched `get_heap_app_id` and `get_heap_identity` without a `return_value`, so each returned a bare MagicMock. |tojson invokes json.dumps, which can't serialize a MagicMock, so _ingest_heap_analytics raised and the test failed.


  ## Fix

  Give the patched telemetry functions string return_values so the template can render cleanly.

  ## QA notes

  - pytest tests/test_integrations/test_base_deployer.py passes locally

CI: https://github.com/kedro-org/kedro-viz/actions/runs/25815968018/job/75860655690?pr=2644