### PR TITLE
Fix layer labels overlapping in the top-left corner on first load.

### DIFF
--- a/src/components/draw/draw-layer-names.jsx
+++ b/src/components/draw/draw-layer-names.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react';
 import { select } from 'd3-selection';
 import classnames from 'classnames';
+import { positionLayerNames } from './utils/position-layer-names';
 
 import './styles/index.scss';
 
@@ -13,7 +14,7 @@ export function DrawLayerNames({
   orientation = 'vertical',
   layerNameDuration = 400,
   layerNamesRef,
-  onLayersRendered,
+  viewTransformRef,
 }) {
   useEffect(() => {
     if (!layerNamesRef?.current || !layers.length) {
@@ -69,17 +70,22 @@ export function DrawLayerNames({
     const allNames = layerNameElement.merge(enterLayerNames);
     allNames.text((d) => d.name).style('opacity', 0.55);
 
-    // The label elements were just (re)created in the DOM. Notify the parent so
-    // it can position them for the current view transform — the initial
-    // onViewChange can run before these elements exist (e.g. on first paint).
-    onLayersRendered && onLayersRendered();
+    // The labels were just (re)created; position them for the latest view
+    // transform. The parent's onViewChange can fire before these exist on first
+    // paint, so we self-position here from the shared transform ref.
+    positionLayerNames(
+      layerNamesRef.current,
+      layers,
+      viewTransformRef?.current,
+      orientation
+    );
   }, [
     layers,
     chartSize,
     orientation,
     layerNameDuration,
     layerNamesRef,
-    onLayersRendered,
+    viewTransformRef,
   ]);
 
   return null;
@@ -92,7 +98,7 @@ export function DrawLayerNamesGroup({
   displayGlobalNavigation,
   displaySidebar,
   layerNamesRef,
-  onLayersRendered,
+  viewTransformRef,
 }) {
   if (!layers.length) {
     return null;
@@ -112,7 +118,7 @@ export function DrawLayerNamesGroup({
         chartSize={chartSize}
         orientation={orientation}
         layerNamesRef={layerNamesRef}
-        onLayersRendered={onLayersRendered}
+        viewTransformRef={viewTransformRef}
       />
     </ul>
   );

--- a/src/components/draw/draw-layer-names.jsx
+++ b/src/components/draw/draw-layer-names.jsx
@@ -13,6 +13,7 @@ export function DrawLayerNames({
   orientation = 'vertical',
   layerNameDuration = 400,
   layerNamesRef,
+  onLayersRendered,
 }) {
   useEffect(() => {
     if (!layerNamesRef?.current || !layers.length) {
@@ -67,7 +68,19 @@ export function DrawLayerNames({
     // UPDATE
     const allNames = layerNameElement.merge(enterLayerNames);
     allNames.text((d) => d.name).style('opacity', 0.55);
-  }, [layers, chartSize, orientation, layerNameDuration, layerNamesRef]);
+
+    // The label elements were just (re)created in the DOM. Notify the parent so
+    // it can position them for the current view transform — the initial
+    // onViewChange can run before these elements exist (e.g. on first paint).
+    onLayersRendered && onLayersRendered();
+  }, [
+    layers,
+    chartSize,
+    orientation,
+    layerNameDuration,
+    layerNamesRef,
+    onLayersRendered,
+  ]);
 
   return null;
 }
@@ -79,6 +92,7 @@ export function DrawLayerNamesGroup({
   displayGlobalNavigation,
   displaySidebar,
   layerNamesRef,
+  onLayersRendered,
 }) {
   if (!layers.length) {
     return null;
@@ -98,6 +112,7 @@ export function DrawLayerNamesGroup({
         chartSize={chartSize}
         orientation={orientation}
         layerNamesRef={layerNamesRef}
+        onLayersRendered={onLayersRendered}
       />
     </ul>
   );

--- a/src/components/draw/utils/position-layer-names.js
+++ b/src/components/draw/utils/position-layer-names.js
@@ -1,0 +1,33 @@
+/**
+ * Position the layer-name labels next to their bands for the given view
+ * transform. Reads the label elements from `container` and offsets each one.
+ * @param {HTMLElement} container The layer-names list element, or null.
+ * @param {Array} layers The layers, each with x/y/width/height.
+ * @param {Object} transform The current view transform ({ k, x, y }), or null.
+ * @param {String} orientation 'vertical' or 'horizontal'.
+ */
+export const positionLayerNames = (
+  container,
+  layers,
+  transform,
+  orientation
+) => {
+  if (!container || !transform) {
+    return;
+  }
+  const { k: scale, x, y } = transform;
+  const layerNames = container.querySelectorAll('.pipeline-layer-name');
+  layers.forEach((layer, i) => {
+    const el = layerNames[i];
+    if (!el) {
+      return;
+    }
+    if (orientation === 'vertical') {
+      const updateY = y + (layer.y + (layer.height || 0) / 2) * scale;
+      el.style.transform = `translateY(${updateY}px)`;
+    } else {
+      const updateX = x + (layer.x + (layer.width || 0) / 2) * scale;
+      el.style.transform = `translateX(${updateX}px) translateX(-50%)`;
+    }
+  });
+};

--- a/src/components/draw/utils/position-layer-names.test.js
+++ b/src/components/draw/utils/position-layer-names.test.js
@@ -1,0 +1,51 @@
+import { positionLayerNames } from './position-layer-names';
+
+// Builds a <ul> holding one `.pipeline-layer-name` <li> per layer.
+const makeContainer = (count) => {
+  const list = document.createElement('ul');
+  for (let i = 0; i < count; i++) {
+    const item = document.createElement('li');
+    item.className = 'pipeline-layer-name';
+    list.appendChild(item);
+  }
+  return list;
+};
+
+describe('positionLayerNames', () => {
+  it('positions labels along the Y-axis in vertical orientation', () => {
+    const container = makeContainer(2);
+    const layers = [
+      { id: 'a', y: 100, height: 40 },
+      { id: 'b', y: 200, height: 40 },
+    ];
+    positionLayerNames(container, layers, { k: 2, x: 10, y: 20 }, 'vertical');
+    const labels = container.querySelectorAll('.pipeline-layer-name');
+    // y + (layer.y + height / 2) * scale
+    expect(labels[0].style.transform).toBe('translateY(260px)');
+    expect(labels[1].style.transform).toBe('translateY(460px)');
+  });
+
+  it('positions labels along the X-axis in horizontal orientation', () => {
+    const container = makeContainer(1);
+    const layers = [{ id: 'a', x: 50, width: 30 }];
+    positionLayerNames(container, layers, { k: 2, x: 10, y: 20 }, 'horizontal');
+    const label = container.querySelector('.pipeline-layer-name');
+    // x + (layer.x + width / 2) * scale, then centre with -50%
+    expect(label.style.transform).toBe('translateX(140px) translateX(-50%)');
+  });
+
+  it('does nothing when the container or transform is missing', () => {
+    const container = makeContainer(1);
+    const layers = [{ id: 'a', y: 0, height: 0 }];
+    expect(() =>
+      positionLayerNames(null, layers, { k: 1, x: 0, y: 0 }, 'vertical')
+    ).not.toThrow();
+    expect(() =>
+      positionLayerNames(container, layers, null, 'vertical')
+    ).not.toThrow();
+    // No transform was applied to the label
+    expect(
+      container.querySelector('.pipeline-layer-name').style.transform
+    ).toBe('');
+  });
+});

--- a/src/components/flowchart/flowchart.jsx
+++ b/src/components/flowchart/flowchart.jsx
@@ -59,6 +59,7 @@ import {
 } from '../draw';
 import { createNodeStateMap, processNodeStyles } from './flowchart-utils';
 import { DURATION, MARGIN, MIN_SCALE, MAX_SCALE } from '../draw/utils/config';
+import { positionLayerNames } from '../draw/utils/position-layer-names';
 
 import './styles/flowchart.scss';
 
@@ -102,6 +103,8 @@ export class FlowChart extends Component {
     this.slicedPipelineActionBarRef = React.createRef();
     this.layersRef = React.createRef();
     this.layerNamesRef = React.createRef();
+    // Holds the latest view transform so the layer labels can self-position
+    this.viewTransformRef = React.createRef();
 
     // Cache for node style overrides
     this.nodeStyleOverridesCache = null;
@@ -304,8 +307,14 @@ export class FlowChart extends Component {
       true
     );
 
-    // Update layer label positions
-    this.positionLayerNames(transform);
+    // Record the latest transform and position the layer labels
+    this.viewTransformRef.current = transform;
+    positionLayerNames(
+      this.layerNamesRef.current,
+      this.props.layers,
+      transform,
+      this.props.orientation
+    );
 
     // Update extents
     this.updateViewExtents(transform);
@@ -333,45 +342,6 @@ export class FlowChart extends Component {
       false
     );
   }
-
-  /**
-   * Position the layer name labels for the given view transform.
-   * @param {Object} transform The current view transform
-   */
-  positionLayerNames(transform) {
-    if (!this.layerNamesRef?.current) {
-      return;
-    }
-    const { k: scale, x, y } = transform;
-    const layerNames = this.layerNamesRef.current.querySelectorAll(
-      '.pipeline-layer-name'
-    );
-    this.props.layers.forEach((layer, i) => {
-      const el = layerNames[i];
-      if (!el) {
-        return;
-      }
-      if (this.props.orientation === 'vertical') {
-        const updateY = y + (layer.y + (layer.height || 0) / 2) * scale;
-        el.style.transform = `translateY(${updateY}px)`;
-      } else {
-        const updateX = x + (layer.x + (layer.width || 0) / 2) * scale;
-        el.style.transform = `translateX(${updateX}px) translateX(-50%)`;
-      }
-    });
-  }
-
-  /**
-   * Re-applies layer label positions once the labels have been (re)rendered.
-   * The label elements are created in a post-paint effect, so the first
-   * onViewChange can run before they exist; positioning them here ensures they
-   * land correctly without requiring a manual resize.
-   */
-  handleLayerNamesRendered = () => {
-    if (this.view) {
-      this.positionLayerNames(getViewTransform(this.view));
-    }
-  };
 
   /**
    * Updates view extents based on the current view transform.
@@ -967,7 +937,7 @@ export class FlowChart extends Component {
           chartSize={chartSize}
           orientation={orientation}
           layerNamesRef={this.layerNamesRef}
-          onLayersRendered={this.handleLayerNamesRendered}
+          viewTransformRef={this.viewTransformRef}
         />
 
         <FeedbackButton

--- a/src/components/flowchart/flowchart.jsx
+++ b/src/components/flowchart/flowchart.jsx
@@ -304,25 +304,8 @@ export class FlowChart extends Component {
       true
     );
 
-    // Update layer label y positions
-    if (this.layerNamesRef?.current) {
-      const layerNames = this.layerNamesRef.current.querySelectorAll(
-        '.pipeline-layer-name'
-      );
-      this.props.layers.forEach((layer, i) => {
-        const el = layerNames[i];
-        if (!el) {
-          return;
-        }
-        if (this.props.orientation === 'vertical') {
-          const updateY = y + (layer.y + (layer.height || 0) / 2) * scale;
-          el.style.transform = `translateY(${updateY}px)`;
-        } else {
-          const updateX = x + (layer.x + (layer.width || 0) / 2) * scale;
-          el.style.transform = `translateX(${updateX}px) translateX(-50%)`;
-        }
-      });
-    }
+    // Update layer label positions
+    this.positionLayerNames(transform);
 
     // Update extents
     this.updateViewExtents(transform);
@@ -350,6 +333,45 @@ export class FlowChart extends Component {
       false
     );
   }
+
+  /**
+   * Position the layer name labels for the given view transform.
+   * @param {Object} transform The current view transform
+   */
+  positionLayerNames(transform) {
+    if (!this.layerNamesRef?.current) {
+      return;
+    }
+    const { k: scale, x, y } = transform;
+    const layerNames = this.layerNamesRef.current.querySelectorAll(
+      '.pipeline-layer-name'
+    );
+    this.props.layers.forEach((layer, i) => {
+      const el = layerNames[i];
+      if (!el) {
+        return;
+      }
+      if (this.props.orientation === 'vertical') {
+        const updateY = y + (layer.y + (layer.height || 0) / 2) * scale;
+        el.style.transform = `translateY(${updateY}px)`;
+      } else {
+        const updateX = x + (layer.x + (layer.width || 0) / 2) * scale;
+        el.style.transform = `translateX(${updateX}px) translateX(-50%)`;
+      }
+    });
+  }
+
+  /**
+   * Re-applies layer label positions once the labels have been (re)rendered.
+   * The label elements are created in a post-paint effect, so the first
+   * onViewChange can run before they exist; positioning them here ensures they
+   * land correctly without requiring a manual resize.
+   */
+  handleLayerNamesRendered = () => {
+    if (this.view) {
+      this.positionLayerNames(getViewTransform(this.view));
+    }
+  };
 
   /**
    * Updates view extents based on the current view transform.
@@ -945,6 +967,7 @@ export class FlowChart extends Component {
           chartSize={chartSize}
           orientation={orientation}
           layerNamesRef={this.layerNamesRef}
+          onLayersRendered={this.handleLayerNamesRendered}
         />
 
         <FeedbackButton

--- a/src/components/workflow/workflow.jsx
+++ b/src/components/workflow/workflow.jsx
@@ -57,6 +57,7 @@ import {
   GraphSVG,
 } from '../draw';
 import { DURATION, MARGIN, MIN_SCALE, MAX_SCALE } from '../draw/utils/config';
+import { positionLayerNames } from '../draw/utils/position-layer-names';
 import { getNodeStatusKey } from './workflow-utils/getNodeStatusKey';
 
 import ExportModal from '../export-modal';
@@ -85,6 +86,8 @@ export class Workflow extends Component {
     this.wrapperRef = React.createRef();
     this.layersRef = React.createRef();
     this.layerNamesRef = React.createRef();
+    // Holds the latest view transform so the layer labels can self-position
+    this.viewTransformRef = React.createRef();
   }
 
   componentDidMount() {
@@ -242,8 +245,14 @@ export class Workflow extends Component {
       '.pipeline-workflow__zoom-wrapper--animating',
       true
     );
-    // Update layer label positions
-    this.positionLayerNames(transform);
+    // Record the latest transform and position the layer labels
+    this.viewTransformRef.current = transform;
+    positionLayerNames(
+      this.layerNamesRef.current,
+      this.props.layers,
+      transform,
+      this.props.orientation
+    );
 
     // Update extents
     this.updateViewExtents(transform);
@@ -271,45 +280,6 @@ export class Workflow extends Component {
       false
     );
   }
-
-  /**
-   * Position the layer name labels for the given view transform.
-   * @param {Object} transform The current view transform
-   */
-  positionLayerNames(transform) {
-    if (!this.layerNamesRef?.current) {
-      return;
-    }
-    const { k: scale, x, y } = transform;
-    const layerNames = this.layerNamesRef.current.querySelectorAll(
-      '.pipeline-layer-name'
-    );
-    this.props.layers.forEach((layer, i) => {
-      const el = layerNames[i];
-      if (!el) {
-        return;
-      }
-      if (this.props.orientation === 'vertical') {
-        const updateY = y + (layer.y + (layer.height || 0) / 2) * scale;
-        el.style.transform = `translateY(${updateY}px)`;
-      } else {
-        const updateX = x + (layer.x + (layer.width || 0) / 2) * scale;
-        el.style.transform = `translateX(${updateX}px) translateX(-50%)`;
-      }
-    });
-  }
-
-  /**
-   * Re-applies layer label positions once the labels have been (re)rendered.
-   * The label elements are created in a post-paint effect, so the first
-   * onViewChange can run before they exist; positioning them here ensures they
-   * land correctly without requiring a manual resize.
-   */
-  handleLayerNamesRendered = () => {
-    if (this.view) {
-      this.positionLayerNames(getViewTransform(this.view));
-    }
-  };
 
   /**
    * Updates view extents based on the current view transform.
@@ -756,7 +726,7 @@ export class Workflow extends Component {
               chartSize={chartSize}
               orientation={orientation}
               layerNamesRef={this.layerNamesRef}
-              onLayersRendered={this.handleLayerNamesRendered}
+              viewTransformRef={this.viewTransformRef}
             />
             <RunStatusNotification
               status={pipelineStatus.status}

--- a/src/components/workflow/workflow.jsx
+++ b/src/components/workflow/workflow.jsx
@@ -242,30 +242,8 @@ export class Workflow extends Component {
       '.pipeline-workflow__zoom-wrapper--animating',
       true
     );
-    // Update layer label y positions
-    if (this.layerNamesRef?.current) {
-      const layerNames = this.layerNamesRef.current.querySelectorAll(
-        '.pipeline-layer-name'
-      );
-      if (layerNames.length !== this.props.layers.length) {
-        // If all layer labels are rendered yet; defer the update
-        setTimeout(() => this.onViewChange(transform), 0);
-        return;
-      }
-      this.props.layers.forEach((layer, i) => {
-        const el = layerNames[i];
-        if (!el) {
-          return;
-        }
-        if (this.props.orientation === 'vertical') {
-          const updateY = y + (layer.y + (layer.height || 0) / 2) * scale;
-          el.style.transform = `translateY(${updateY}px)`;
-        } else {
-          const updateX = x + (layer.x + (layer.width || 0) / 2) * scale;
-          el.style.transform = `translateX(${updateX}px) translateX(-50%)`;
-        }
-      });
-    }
+    // Update layer label positions
+    this.positionLayerNames(transform);
 
     // Update extents
     this.updateViewExtents(transform);
@@ -293,6 +271,45 @@ export class Workflow extends Component {
       false
     );
   }
+
+  /**
+   * Position the layer name labels for the given view transform.
+   * @param {Object} transform The current view transform
+   */
+  positionLayerNames(transform) {
+    if (!this.layerNamesRef?.current) {
+      return;
+    }
+    const { k: scale, x, y } = transform;
+    const layerNames = this.layerNamesRef.current.querySelectorAll(
+      '.pipeline-layer-name'
+    );
+    this.props.layers.forEach((layer, i) => {
+      const el = layerNames[i];
+      if (!el) {
+        return;
+      }
+      if (this.props.orientation === 'vertical') {
+        const updateY = y + (layer.y + (layer.height || 0) / 2) * scale;
+        el.style.transform = `translateY(${updateY}px)`;
+      } else {
+        const updateX = x + (layer.x + (layer.width || 0) / 2) * scale;
+        el.style.transform = `translateX(${updateX}px) translateX(-50%)`;
+      }
+    });
+  }
+
+  /**
+   * Re-applies layer label positions once the labels have been (re)rendered.
+   * The label elements are created in a post-paint effect, so the first
+   * onViewChange can run before they exist; positioning them here ensures they
+   * land correctly without requiring a manual resize.
+   */
+  handleLayerNamesRendered = () => {
+    if (this.view) {
+      this.positionLayerNames(getViewTransform(this.view));
+    }
+  };
 
   /**
    * Updates view extents based on the current view transform.
@@ -739,6 +756,7 @@ export class Workflow extends Component {
               chartSize={chartSize}
               orientation={orientation}
               layerNamesRef={this.layerNamesRef}
+              onLayersRendered={this.handleLayerNamesRendered}
             />
             <RunStatusNotification
               status={pipelineStatus.status}


### PR DESCRIPTION
## Description

On first load, the layer names (`raw`, `intermediate`, `primary`, and so on) stack on top of each other in the top-left of the chart instead of lining up next to their bands. Resizing the window or panning the chart puts them back in the right place.

  ## Why it happens

  The layer label elements are created after the chart paints, but their positions were only ever set during a view change (zoom, pan, or resize). On first load the positioning ran before the labels existed, so they never got placed and fell back to the default top-left spot. Anything that caused a view change
  afterwards (such as a resize) is what moved them into place.

  ## What this PR does

  Position the layer labels right after they are created, using the current view, instead of waiting for the next view change. They now land in the correct place on first paint, with no resize needed. Live updates on pan/zoom are unchanged.

  This applies to both the flowchart view and the workflow view.
  
  ## Gif
  
  ### Before 
  
<img width="1785" height="987" alt="viz-f-resize-11" src="https://github.com/user-attachments/assets/c0dac4d3-82ef-4943-b217-619c584f6c31" />

  
  ### After
  
<img width="1785" height="987" alt="viz-f-resize-22" src="https://github.com/user-attachments/assets/75d1daf9-3e7e-4adc-be70-6329a8c2f251" />


## How to test (via kedro-viz-standalone)

These changes are published to a test npm package: **`kedro-vi122@1.21.0-rc37`**. To try them in a real embedding app:

1. **Clone the standalone app:**
   ```bash
   git clone https://github.com/kedro-org/kedro-viz-standalone
   cd kedro-viz-standalone
   ```

2. **Point it at the test package** — in `package.json`:
   ```diff
   - "@quantumblack/kedro-viz": "^12.4.0",
   + "kedro-vi122": "1.21.0-rc37",
   ```

3. **Update the imports** in `app.js` (or `app.ts`):
   ```diff
   - import "@quantumblack/kedro-viz/lib/styles/styles.min.css";
   - import spaceflight from "@quantumblack/kedro-viz/lib/utils/data/spaceflights.mock.json";
   - import KedroViz from "@quantumblack/kedro-viz";
   + import "kedro-vi122/lib/styles/styles.min.css";
   + import demo from "kedro-vi122/lib/utils/data/demo.mock.json";
   + import KedroViz from "kedro-vi122";
   ```
   Also update where the data is passed to the component to match the renamed variable, e.g. `data={spaceflight}` → `data={demo}`.

4. **Install and run:**
   ```bash
   npm install
   npm start
   ```
   Open the local URL it prints (e.g. `http://localhost:3000`).

5. **Check the flowchart on first load** (no resizing):
   - Layer names (`raw`, `intermediate`, `primary`, …) line up down the left edge next to their bands — **not** stacked on top of each other in the top-left corner.
   - Node boxes fit their full labels (not shrunk to just the icon).

   Reload once or twice if needed — the layer-label case is a first-render race.


