### PR TITLE
babel-systemjs-override for the CI fix

### DIFF
--- a/tools/test-lib/react-app/jest.setup.js
+++ b/tools/test-lib/react-app/jest.setup.js
@@ -5,3 +5,14 @@ if (typeof window.URL.createObjectURL === 'undefined') {
 }
 
 global.fetch = require('node-fetch');
+
+jest.mock('mermaid', () => ({
+  __esModule: true,
+  default: {
+    initialize: jest.fn(),
+    render: jest.fn(() => Promise.resolve({ svg: '<svg></svg>' })),
+    parse: jest.fn(() => Promise.resolve()),
+    run: jest.fn(() => Promise.resolve()),
+    contentLoaded: jest.fn(),
+  },
+}));

--- a/tools/test-lib/react-app/package.json
+++ b/tools/test-lib/react-app/package.json
@@ -11,7 +11,7 @@
     "moduleNameMapper": {
       "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/__mocks__/fileMock.js",
       "\\.(css|less|scss)$": "<rootDir>/__mocks__/styleMock.js",
-      "^\\./graph-worker\\.js$": "<rootDir>/__mocks__/inline-worker-mock.js"
+      "^\\./graph-worker\\.js(\\?worker&inline)?$": "<rootDir>/__mocks__/inline-worker-mock.js"
     },
     "transformIgnorePatterns": [
       "/node_modules/(?!d3|d3-array|internmap|delaunator|robust-predicates)"
@@ -73,12 +73,14 @@
     "lodash": ">=4.17.23",
     "yaml": ">=2.8.0",
     "qs": ">=6.15.2",
-    "path-to-regexp": ">=0.1.13",
+    "express": {
+      "path-to-regexp": "0.1.13"
+    },
     "diff": ">=5.2.2",
     "d3-color": ">=3.1.0",
     "shell-quote": ">=1.8.4",
     "fast-uri": "^3.1.2",
-    "@babel/plugin-transform-modules-systemjs": ">=7.29.4",
+    "@babel/plugin-transform-modules-systemjs": ">=7.29.4 <8",
     "protocol-buffers-schema": ">=3.6.1",
     "follow-redirects": ">=1.16.0"
   }


### PR DESCRIPTION
This pull request updates the testing setup and dependencies for the React app in the `tools/test-lib/react-app` directory. 

This is the CI fix for 

```
> test:ci
> jest

FAIL ./app.test.js
  ● Test suite failed to run

    [BABEL]: You appear to be using a native ECMAScript module preset, which is only supported when running Babel asynchronously or when using the Node.js `--experimental-require-module` flag. (While processing: /home/runner/work/kedro-viz/kedro-viz/tools/test-lib/react-app/node_modules/@babel/preset-env/lib/index.js)
        at /home/runner/work/kedro-viz/kedro-viz/tools/test-lib/react-app/node_modules/@babel/preset-env/lib/index.js

      at loadPartialConfigSync (node_modules/@babel/core/src/config/index.ts:53:60)
      at loadPartialConfigSync (node_modules/@babel/core/src/config/index.ts:72:14)
      at ScriptTransformer._getCacheKey (node_modules/@jest/transform/build/ScriptTransformer.js:228:41)
      at ScriptTransformer._getFileCachePath (node_modules/@jest/transform/build/ScriptTransformer.js:289:27)
      at ScriptTransformer.transformSource (node_modules/@jest/transform/build/ScriptTransformer.js:525:32)
      at ScriptTransformer._transformAndBuildScript (node_modules/@jest/transform/build/ScriptTransformer.js:674:40)
      at ScriptTransformer.transform (node_modules/@jest/transform/build/ScriptTransformer.js:726:19)

Test Suites: 1 failed, 1 total
Tests:       0 total
Snapshots:   0 total
Time:        0.86 s
Ran all test suites.
Error: Process completed with exit code 1.
```