### PR TITLE
Layers: dataset layers from the inspection snapshot

### DIFF
--- a/package/kedro_viz/integrations/kedro/inspection/graph_builder.py
+++ b/package/kedro_viz/integrations/kedro/inspection/graph_builder.py
@@ -9,8 +9,7 @@ from __future__ import annotations
 
 import re
 from collections import defaultdict
-from dataclasses import dataclass
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any
 
 from kedro_viz.api.rest.responses.pipelines import (
     DataNodeAPIResponse,
@@ -20,12 +19,15 @@ from kedro_viz.api.rest.responses.pipelines import (
     TaskNodeAPIResponse,
 )
 from kedro_viz.constants import DEFAULT_REGISTERED_PIPELINE_ID
+from kedro_viz.integrations.kedro.inspection.layers import (
+    _extract_layers,
+    sort_layers,
+)
 from kedro_viz.integrations.kedro.node_ids import (
     _create_dataset_node_id,
     _create_task_node_id,
 )
 from kedro_viz.models.flowchart.model_utils import GraphNodeType
-from kedro_viz.services.layers import sort_layers
 from kedro_viz.utils import _strip_transcoding, is_dataset_param
 
 if TYPE_CHECKING:
@@ -35,20 +37,11 @@ if TYPE_CHECKING:
         ProjectSnapshot,
     )
 
-    from kedro_viz.models.flowchart.nodes import GraphNode
-
 _AUTO_NAME_RE = re.compile(r"^(?P<func>.+)__[0-9a-f]{8}$")
 
 # Match the live backend's get_dataset_type(MemoryDataset()) output for datasets
 # absent from the snapshot catalog.
 MEMORY_DATASET_TYPE = "io.memory_dataset.MemoryDataset"
-
-
-@dataclass(frozen=True)
-class _LayerNode:
-    """Minimal stand-in carrying just ``.layer`` for the layer sorter."""
-
-    layer: str
 
 
 class _SnapshotGraphIndex:
@@ -102,21 +95,16 @@ class GraphBuilder:
     def __init__(
         self,
         snapshot: ProjectSnapshot,
-        layer_mapping: dict[str, str] | None = None,
+        catalog_config: dict[str, Any] | None = None,
     ) -> None:
         self._snapshot = snapshot
-        self._layers = layer_mapping or {}
+        self._layer_by_dataset = _extract_layers(
+            catalog_config or {}, _dataset_names_from_snapshot(snapshot)
+        )
         self._pipelines_by_id = {
             pipeline.name: pipeline for pipeline in snapshot.pipelines
         }
         self._index = _SnapshotGraphIndex(self._pipelines_by_id)
-        # Seed the sort with every layered dataset in the graph so the layer order stays
-        # consistent across pipeline views.
-        self._global_layer_nodes: dict[str, _LayerNode] = {
-            _create_dataset_node_id(name): _LayerNode(layer)
-            for name, layer in self._layers.items()
-            if self._index.get_pipelines_for_dataset_name(name)
-        }
 
     def default_pipeline_id(self) -> str:
         """Return the default pipeline ID to render.
@@ -196,7 +184,7 @@ class GraphBuilder:
         return GraphAPIResponse(
             nodes=nodes,
             edges=list(edges.values()),
-            layers=self._sorted_layers(nodes, edges),
+            layers=self._sorted_layers_for_pipeline(nodes, edges),
             tags=[
                 NamedEntityAPIResponse(id=tag, name=tag)
                 for tag in self._index.get_all_tags()
@@ -251,27 +239,33 @@ class GraphBuilder:
                 else GraphNodeType.DATA.value
             ),
             modular_pipelines=None,
-            layer=None if is_parameter else self._layers.get(stripped_name),
+            layer=(None if is_parameter else self._layer_by_dataset.get(stripped_name)),
             dataset_type=dataset_type,
         )
 
-    def _sorted_layers(
+    def _sorted_layers_for_pipeline(
         self,
         nodes: list[TaskNodeAPIResponse | DataNodeAPIResponse],
         edges: dict[tuple[str, str], GraphEdgeAPIResponse],
     ) -> list[str]:
-        """Topologically sort the data-node layers, reusing the existing layers service."""
-        if not self._layers:
+        """Sort the project-wide layer set using the selected pipeline's edges."""
+        if not self._layer_by_dataset:
             return []
         dependencies: dict[str, set[str]] = defaultdict(set)
         for source, target in edges:
             dependencies[source].add(target)
-        # Global layered datasets give layer presence; this view's nodes give the ordering.
-        nodes_by_id: dict[str, object] = dict(self._global_layer_nodes)
-        nodes_by_id.update({node.id: node for node in nodes})
-        # sort_layers only reads ``.layer`` off each node, so these stand in for the domain
-        # ``GraphNode`` it is typed against.
-        return sort_layers(cast("dict[str, GraphNode]", nodes_by_id), dependencies)
+        layer_by_node_id: dict[str, str | None] = {
+            node.id: node.layer if isinstance(node, DataNodeAPIResponse) else None
+            for node in nodes
+        }
+        # Include layered datasets used by any pipeline so every view exposes the
+        # project-wide layer set; this view's edges determine their order.
+        for dataset_name, layer in self._layer_by_dataset.items():
+            dataset_pipelines = self._index.get_pipelines_for_dataset_name(dataset_name)
+            if is_dataset_param(dataset_name) or not dataset_pipelines:
+                continue
+            layer_by_node_id.setdefault(_create_dataset_node_id(dataset_name), layer)
+        return sort_layers(layer_by_node_id, dependencies)
 
     @staticmethod
     def _register_dataset(
@@ -300,3 +294,14 @@ def _display_name(snapshot_name: str, namespace: str | None) -> str:
         local = local[len(prefix) :]
     auto = _AUTO_NAME_RE.match(local)
     return auto.group("func") if auto else local
+
+
+def _dataset_names_from_snapshot(snapshot: ProjectSnapshot) -> set[str]:
+    """Return non-parameter dataset names referenced by registered pipelines."""
+    return {
+        name
+        for pipeline in snapshot.pipelines
+        for node in pipeline.nodes
+        for name in (*node.inputs, *node.outputs)
+        if not is_dataset_param(name)
+    }

--- a/package/kedro_viz/integrations/kedro/inspection/graph_builder.py
+++ b/package/kedro_viz/integrations/kedro/inspection/graph_builder.py
@@ -99,7 +99,8 @@ class GraphBuilder:
     ) -> None:
         self._snapshot = snapshot
         self._layer_by_dataset = _extract_layers(
-            catalog_config or {}, _dataset_names_from_snapshot(snapshot)
+            catalog_config=catalog_config or {},
+            dataset_names=_dataset_names_from_snapshot(snapshot),
         )
         self._pipelines_by_id = {
             pipeline.name: pipeline for pipeline in snapshot.pipelines

--- a/package/kedro_viz/integrations/kedro/inspection/graph_builder.py
+++ b/package/kedro_viz/integrations/kedro/inspection/graph_builder.py
@@ -9,7 +9,8 @@ from __future__ import annotations
 
 import re
 from collections import defaultdict
-from typing import TYPE_CHECKING
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, cast
 
 from kedro_viz.api.rest.responses.pipelines import (
     DataNodeAPIResponse,
@@ -24,6 +25,7 @@ from kedro_viz.integrations.kedro.node_ids import (
     _create_task_node_id,
 )
 from kedro_viz.models.flowchart.model_utils import GraphNodeType
+from kedro_viz.services.layers import sort_layers
 from kedro_viz.utils import _strip_transcoding, is_dataset_param
 
 if TYPE_CHECKING:
@@ -33,11 +35,20 @@ if TYPE_CHECKING:
         ProjectSnapshot,
     )
 
+    from kedro_viz.models.flowchart.nodes import GraphNode
+
 _AUTO_NAME_RE = re.compile(r"^(?P<func>.+)__[0-9a-f]{8}$")
 
 # Match the live backend's get_dataset_type(MemoryDataset()) output for datasets
 # absent from the snapshot catalog.
 MEMORY_DATASET_TYPE = "io.memory_dataset.MemoryDataset"
+
+
+@dataclass(frozen=True)
+class _LayerNode:
+    """Minimal stand-in carrying just ``.layer`` for the layer sorter."""
+
+    layer: str
 
 
 class _SnapshotGraphIndex:
@@ -88,12 +99,24 @@ class GraphBuilder:
     while rendered nodes and edges are scoped to the selected pipeline.
     """
 
-    def __init__(self, snapshot: ProjectSnapshot) -> None:
+    def __init__(
+        self,
+        snapshot: ProjectSnapshot,
+        layer_mapping: dict[str, str] | None = None,
+    ) -> None:
         self._snapshot = snapshot
+        self._layers = layer_mapping or {}
         self._pipelines_by_id = {
             pipeline.name: pipeline for pipeline in snapshot.pipelines
         }
         self._index = _SnapshotGraphIndex(self._pipelines_by_id)
+        # Seed the sort with every layered dataset in the graph so the layer order stays
+        # consistent across pipeline views.
+        self._global_layer_nodes: dict[str, _LayerNode] = {
+            _create_dataset_node_id(name): _LayerNode(layer)
+            for name, layer in self._layers.items()
+            if self._index.get_pipelines_for_dataset_name(name)
+        }
 
     def default_pipeline_id(self) -> str:
         """Return the default pipeline ID to render.
@@ -173,7 +196,7 @@ class GraphBuilder:
         return GraphAPIResponse(
             nodes=nodes,
             edges=list(edges.values()),
-            layers=[],
+            layers=self._sorted_layers(nodes, edges),
             tags=[
                 NamedEntityAPIResponse(id=tag, name=tag)
                 for tag in self._index.get_all_tags()
@@ -228,9 +251,27 @@ class GraphBuilder:
                 else GraphNodeType.DATA.value
             ),
             modular_pipelines=None,
-            layer=None,
+            layer=None if is_parameter else self._layers.get(stripped_name),
             dataset_type=dataset_type,
         )
+
+    def _sorted_layers(
+        self,
+        nodes: list[TaskNodeAPIResponse | DataNodeAPIResponse],
+        edges: dict[tuple[str, str], GraphEdgeAPIResponse],
+    ) -> list[str]:
+        """Topologically sort the data-node layers, reusing the existing layers service."""
+        if not self._layers:
+            return []
+        dependencies: dict[str, set[str]] = defaultdict(set)
+        for source, target in edges:
+            dependencies[source].add(target)
+        # Global layered datasets give layer presence; this view's nodes give the ordering.
+        nodes_by_id: dict[str, object] = dict(self._global_layer_nodes)
+        nodes_by_id.update({node.id: node for node in nodes})
+        # sort_layers only reads ``.layer`` off each node, so these stand in for the domain
+        # ``GraphNode`` it is typed against.
+        return sort_layers(cast("dict[str, GraphNode]", nodes_by_id), dependencies)
 
     @staticmethod
     def _register_dataset(

--- a/package/kedro_viz/integrations/kedro/inspection/layers.py
+++ b/package/kedro_viz/integrations/kedro/inspection/layers.py
@@ -33,6 +33,7 @@ def _extract_layers(
     for name, config in catalog_config.items():
         if not isinstance(config, dict):
             continue
+        # Include entries without layers to preserve Kedro's resolver precedence.
         resolver_entry: dict[str, Any] = {"type": "kedro.io.MemoryDataset"}
         resolver_config[name] = resolver_entry
         try:

--- a/package/kedro_viz/integrations/kedro/inspection/layers.py
+++ b/package/kedro_viz/integrations/kedro/inspection/layers.py
@@ -1,0 +1,27 @@
+"""Extract dataset layers from the raw catalog config.
+
+Layer is a Kedro-Viz concept (under ``metadata.kedro-viz.layer``); Kedro stores the ``metadata``
+dict but doesn't interpret it, and the inspection snapshot drops it. So we read the catalog config
+directly here (no ``DataCatalog`` is materialised). Transcoding is stripped, so ``name@a`` and
+``name@b`` map to one layer.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from kedro_viz.utils import _strip_transcoding
+
+
+def _extract_layers(catalog_config: dict[str, Any]) -> dict[str, str]:
+    """Map dataset name to its layer from ``metadata.kedro-viz.layer`` in the catalog config."""
+    mapping: dict[str, str] = {}
+    for name, config in catalog_config.items():
+        if not isinstance(config, dict):
+            continue
+        try:
+            layer = config["metadata"]["kedro-viz"]["layer"]
+        except (KeyError, TypeError):
+            continue
+        mapping[_strip_transcoding(name)] = layer
+    return mapping

--- a/package/kedro_viz/integrations/kedro/inspection/layers.py
+++ b/package/kedro_viz/integrations/kedro/inspection/layers.py
@@ -1,19 +1,18 @@
-"""Extract dataset layers from the raw catalog config.
-
-Layer is a Kedro-Viz concept (under ``metadata.kedro-viz.layer``); Kedro stores the ``metadata``
-dict but doesn't interpret it, and the inspection snapshot drops it. So we read the catalog config
-directly here (no ``DataCatalog`` is materialised). Transcoding is stripped, so ``name@a`` and
-``name@b`` map to one layer.
-"""
+"""Extract and sort dataset layers for the inspection adapter."""
 
 from __future__ import annotations
 
+import logging
+from collections import defaultdict
 from collections.abc import Iterable
+from graphlib import CycleError, TopologicalSorter
 from typing import Any
 
 from kedro.io import CatalogConfigResolver
 
 from kedro_viz.utils import _strip_transcoding
+
+logger = logging.getLogger(__name__)
 
 
 def _extract_layers(
@@ -28,7 +27,7 @@ def _extract_layers(
         ValueError: If transcoded variants of one dataset (``name@a``, ``name@b``) declare
             different layers, matching the legacy backend's validation.
     """
-    mapping: dict[str, str] = {}
+    layer_by_dataset: dict[str, str] = {}
     resolver_config: dict[str, dict[str, Any]] = {}
     has_patterns = False
     for name, config in catalog_config.items():
@@ -44,7 +43,7 @@ def _extract_layers(
         if CatalogConfigResolver.is_pattern(name):
             has_patterns = True
             continue
-        _set_layer(mapping, name, layer)
+        _set_layer(layer_by_dataset, name, layer)
 
     if has_patterns:
         resolver = CatalogConfigResolver(
@@ -57,19 +56,76 @@ def _extract_layers(
                 layer = resolved_config["metadata"]["kedro-viz"]["layer"]
             except (KeyError, TypeError):
                 continue
-            _set_layer(mapping, name, layer)
+            _set_layer(layer_by_dataset, name, layer)
 
-    return mapping
+    return layer_by_dataset
 
 
-def _set_layer(mapping: dict[str, str], name: str, layer: str) -> None:
+def _set_layer(layer_by_dataset: dict[str, str], name: str, layer: str) -> None:
     """Store a layer under the dataset's non-transcoded name."""
     stripped = _strip_transcoding(name)
-    existing = mapping.get(stripped)
+    existing = layer_by_dataset.get(stripped)
     if existing is not None and existing != layer:
         raise ValueError(
             "Transcoded datasets should have the same layer. "
             "Please ensure consistent layering in your Kedro catalog. "
             f"Mismatch found for: {stripped}"
         )
-    mapping[stripped] = layer
+    layer_by_dataset[stripped] = layer
+
+
+def sort_layers(
+    layer_by_node_id: dict[str, str | None],
+    dependencies: dict[str, set[str]],
+) -> list[str]:
+    """Return dataset layers in graph dependency order."""
+    child_layers_by_node: dict[str, set[str]] = {}
+
+    def find_child_layers(node_id: str) -> set[str]:
+        if node_id in child_layers_by_node:
+            return child_layers_by_node[node_id]
+
+        child_layers = child_layers_by_node[node_id] = set()
+        node_layer = layer_by_node_id[node_id]
+        if node_layer is not None:
+            child_layers.add(node_layer)
+
+        for child_id in dependencies.get(node_id, set()):
+            child_layer = layer_by_node_id[child_id]
+            if child_layer is not None:
+                child_layers.add(child_layer)
+            child_layers.update(find_child_layers(child_id))
+
+        return child_layers
+
+    for node_id in sorted(layer_by_node_id):
+        find_child_layers(node_id)
+
+    layer_dependencies: dict[str, set[str]] = defaultdict(set)
+    all_layers: set[str] = set()
+    for node_id, child_layers in child_layers_by_node.items():
+        node_layer = layer_by_node_id[node_id]
+        if node_layer is None:
+            continue
+        all_layers.add(node_layer)
+        for child_layer in child_layers:
+            all_layers.add(child_layer)
+            if child_layer != node_layer:
+                layer_dependencies[child_layer].add(node_layer)
+
+    for layer in all_layers:
+        layer_dependencies.setdefault(layer, set())
+
+    ordered_dependencies = {
+        layer: layer_dependencies[layer] for layer in sorted(layer_dependencies)
+    }
+    try:
+        return list(TopologicalSorter(ordered_dependencies).static_order())
+    except CycleError as exc:
+        logger.warning(
+            "Layers visualisation is disabled as circular dependency detected among layers. "
+            "Circular dependency detected: %s. "
+            "Please check the `layer` configuration in your catalog for the datasets to avoid circular references. ",
+            str(exc),
+        )
+        return []

--- a/package/kedro_viz/integrations/kedro/inspection/layers.py
+++ b/package/kedro_viz/integrations/kedro/inspection/layers.py
@@ -87,12 +87,12 @@ def sort_layers(
             return child_layers_by_node[node_id]
 
         child_layers = child_layers_by_node[node_id] = set()
-        node_layer = layer_by_node_id[node_id]
+        node_layer = layer_by_node_id.get(node_id)
         if node_layer is not None:
             child_layers.add(node_layer)
 
         for child_id in dependencies.get(node_id, set()):
-            child_layer = layer_by_node_id[child_id]
+            child_layer = layer_by_node_id.get(child_id)
             if child_layer is not None:
                 child_layers.add(child_layer)
             child_layers.update(find_child_layers(child_id))
@@ -105,7 +105,7 @@ def sort_layers(
     layer_dependencies: dict[str, set[str]] = defaultdict(set)
     all_layers: set[str] = set()
     for node_id, child_layers in child_layers_by_node.items():
-        node_layer = layer_by_node_id[node_id]
+        node_layer = layer_by_node_id.get(node_id)
         if node_layer is None:
             continue
         all_layers.add(node_layer)

--- a/package/kedro_viz/integrations/kedro/inspection/layers.py
+++ b/package/kedro_viz/integrations/kedro/inspection/layers.py
@@ -8,33 +8,68 @@ directly here (no ``DataCatalog`` is materialised). Transcoding is stripped, so 
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from typing import Any
+
+from kedro.io import CatalogConfigResolver
 
 from kedro_viz.utils import _strip_transcoding
 
 
-def _extract_layers(catalog_config: dict[str, Any]) -> dict[str, str]:
-    """Map dataset name to its layer from ``metadata.kedro-viz.layer`` in the catalog config.
+def _extract_layers(
+    catalog_config: dict[str, Any], dataset_names: Iterable[str] = ()
+) -> dict[str, str]:
+    """Map concrete dataset names to layers from ``metadata.kedro-viz.layer``.
+
+    Dataset factory patterns are resolved against ``dataset_names`` using Kedro's catalog
+    resolver.
 
     Raises:
         ValueError: If transcoded variants of one dataset (``name@a``, ``name@b``) declare
             different layers, matching the legacy backend's validation.
     """
     mapping: dict[str, str] = {}
+    resolver_config: dict[str, dict[str, Any]] = {}
+    has_patterns = False
     for name, config in catalog_config.items():
         if not isinstance(config, dict):
             continue
+        resolver_entry: dict[str, Any] = {"type": "kedro.io.MemoryDataset"}
+        resolver_config[name] = resolver_entry
         try:
             layer = config["metadata"]["kedro-viz"]["layer"]
         except (KeyError, TypeError):
             continue
-        stripped = _strip_transcoding(name)
-        existing = mapping.get(stripped)
-        if existing is not None and existing != layer:
-            raise ValueError(
-                "Transcoded datasets should have the same layer. "
-                "Please ensure consistent layering in your Kedro catalog. "
-                f"Mismatch found for: {stripped}"
-            )
-        mapping[stripped] = layer
+        resolver_entry["metadata"] = {"kedro-viz": {"layer": layer}}
+        if CatalogConfigResolver.is_pattern(name):
+            has_patterns = True
+            continue
+        _set_layer(mapping, name, layer)
+
+    if has_patterns:
+        resolver = CatalogConfigResolver(
+            resolver_config,
+            default_runtime_patterns={"{default}": {"type": "kedro.io.MemoryDataset"}},
+        )
+        for name in dataset_names:
+            resolved_config = resolver.resolve_pattern(name)
+            try:
+                layer = resolved_config["metadata"]["kedro-viz"]["layer"]
+            except (KeyError, TypeError):
+                continue
+            _set_layer(mapping, name, layer)
+
     return mapping
+
+
+def _set_layer(mapping: dict[str, str], name: str, layer: str) -> None:
+    """Store a layer under the dataset's non-transcoded name."""
+    stripped = _strip_transcoding(name)
+    existing = mapping.get(stripped)
+    if existing is not None and existing != layer:
+        raise ValueError(
+            "Transcoded datasets should have the same layer. "
+            "Please ensure consistent layering in your Kedro catalog. "
+            f"Mismatch found for: {stripped}"
+        )
+    mapping[stripped] = layer

--- a/package/kedro_viz/integrations/kedro/inspection/layers.py
+++ b/package/kedro_viz/integrations/kedro/inspection/layers.py
@@ -14,7 +14,12 @@ from kedro_viz.utils import _strip_transcoding
 
 
 def _extract_layers(catalog_config: dict[str, Any]) -> dict[str, str]:
-    """Map dataset name to its layer from ``metadata.kedro-viz.layer`` in the catalog config."""
+    """Map dataset name to its layer from ``metadata.kedro-viz.layer`` in the catalog config.
+
+    Raises:
+        ValueError: If transcoded variants of one dataset (``name@a``, ``name@b``) declare
+            different layers, matching the legacy backend's validation.
+    """
     mapping: dict[str, str] = {}
     for name, config in catalog_config.items():
         if not isinstance(config, dict):
@@ -23,5 +28,13 @@ def _extract_layers(catalog_config: dict[str, Any]) -> dict[str, str]:
             layer = config["metadata"]["kedro-viz"]["layer"]
         except (KeyError, TypeError):
             continue
-        mapping[_strip_transcoding(name)] = layer
+        stripped = _strip_transcoding(name)
+        existing = mapping.get(stripped)
+        if existing is not None and existing != layer:
+            raise ValueError(
+                "Transcoded datasets should have the same layer. "
+                "Please ensure consistent layering in your Kedro catalog. "
+                f"Mismatch found for: {stripped}"
+            )
+        mapping[stripped] = layer
     return mapping

--- a/package/tests/test_inspection_adapter/test_graph_builder.py
+++ b/package/tests/test_inspection_adapter/test_graph_builder.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pytest
 
 from kedro_viz.integrations.kedro.inspection.graph_builder import GraphBuilder
+from kedro_viz.integrations.kedro.inspection.layers import _extract_layers
 from kedro_viz.integrations.kedro.inspection.snapshot_source import _InspectionSession
 
 DEMO_PROJECT = Path(__file__).resolve().parents[3] / "demo-project"
@@ -25,8 +26,10 @@ ALL_PIPELINES = [
 @pytest.fixture(scope="module")
 def builder(_restore_kedro_project_state) -> GraphBuilder:
     # Start state restoration before bootstrapping the demo project.
-    snapshot = _InspectionSession(DEMO_PROJECT).snapshot()
-    return GraphBuilder(snapshot)
+    session = _InspectionSession(DEMO_PROJECT)
+    snapshot = session.snapshot()
+    layer_mapping = _extract_layers(session.catalog_config())
+    return GraphBuilder(snapshot, layer_mapping)
 
 
 def _baseline(pipeline_id: str) -> dict:
@@ -135,3 +138,27 @@ def test_per_node_fields_match_baseline(
         assert _field_by_name(adapter["nodes"], node_type, field) == _field_by_name(
             baseline["nodes"], node_type, field
         ), field
+
+
+@pytest.mark.parametrize("pipeline_id", ALL_PIPELINES)
+def test_data_node_layers_match_baseline(
+    builder: GraphBuilder, pipeline_id: str
+) -> None:
+    """Each data node's ``layer`` (read from the catalog config) matches the baseline view."""
+    adapter = builder.build(pipeline_id).model_dump()
+    baseline = _baseline(pipeline_id)
+
+    def layer_by_name(graph: dict) -> dict[str, "str | None"]:
+        return {
+            n["name"]: n.get("layer") for n in graph["nodes"] if n["type"] == "data"
+        }
+
+    assert layer_by_name(adapter) == layer_by_name(baseline)
+
+
+@pytest.mark.parametrize("pipeline_id", ["__default__", "reporting_stage"])
+def test_layers_list_matches_baseline(builder: GraphBuilder, pipeline_id: str) -> None:
+    # The layers list is order-significant (topologically sorted).
+    adapter = builder.build(pipeline_id).model_dump()
+    baseline = _baseline(pipeline_id)
+    assert adapter["layers"] == baseline["layers"]

--- a/package/tests/test_inspection_adapter/test_graph_builder.py
+++ b/package/tests/test_inspection_adapter/test_graph_builder.py
@@ -28,7 +28,13 @@ def builder(_restore_kedro_project_state) -> GraphBuilder:
     # Start state restoration before bootstrapping the demo project.
     session = _InspectionSession(DEMO_PROJECT)
     snapshot = session.snapshot()
-    layer_mapping = _extract_layers(session.catalog_config())
+    dataset_names = {
+        name
+        for pipeline in snapshot.pipelines
+        for node in pipeline.nodes
+        for name in [*node.inputs, *node.outputs]
+    }
+    layer_mapping = _extract_layers(session.catalog_config(), dataset_names)
     return GraphBuilder(snapshot, layer_mapping)
 
 

--- a/package/tests/test_inspection_adapter/test_graph_builder.py
+++ b/package/tests/test_inspection_adapter/test_graph_builder.py
@@ -6,7 +6,6 @@ from pathlib import Path
 import pytest
 
 from kedro_viz.integrations.kedro.inspection.graph_builder import GraphBuilder
-from kedro_viz.integrations.kedro.inspection.layers import _extract_layers
 from kedro_viz.integrations.kedro.inspection.snapshot_source import _InspectionSession
 
 DEMO_PROJECT = Path(__file__).resolve().parents[3] / "demo-project"
@@ -27,15 +26,7 @@ ALL_PIPELINES = [
 def builder(_restore_kedro_project_state) -> GraphBuilder:
     # Start state restoration before bootstrapping the demo project.
     session = _InspectionSession(DEMO_PROJECT)
-    snapshot = session.snapshot()
-    dataset_names = {
-        name
-        for pipeline in snapshot.pipelines
-        for node in pipeline.nodes
-        for name in [*node.inputs, *node.outputs]
-    }
-    layer_mapping = _extract_layers(session.catalog_config(), dataset_names)
-    return GraphBuilder(snapshot, layer_mapping)
+    return GraphBuilder(session.snapshot(), session.catalog_config())
 
 
 def _baseline(pipeline_id: str) -> dict:
@@ -162,7 +153,7 @@ def test_data_node_layers_match_baseline(
     assert layer_by_name(adapter) == layer_by_name(baseline)
 
 
-@pytest.mark.parametrize("pipeline_id", ["__default__", "reporting_stage"])
+@pytest.mark.parametrize("pipeline_id", ALL_PIPELINES)
 def test_layers_list_matches_baseline(builder: GraphBuilder, pipeline_id: str) -> None:
     # The layers list is order-significant (topologically sorted).
     adapter = builder.build(pipeline_id).model_dump()

--- a/package/tests/test_inspection_adapter/test_graph_builder_edge_cases.py
+++ b/package/tests/test_inspection_adapter/test_graph_builder_edge_cases.py
@@ -371,4 +371,4 @@ def test_layers_include_all_pipelines_but_exclude_unused_catalog_entries() -> No
     }
 
     graph = _builder(snapshot, catalog_config).build("pipe_a")
-    assert set(graph.layers) == {"raw", "model", "external", "reporting"}
+    assert graph.layers == ["external", "raw", "reporting", "model"]

--- a/package/tests/test_inspection_adapter/test_graph_builder_edge_cases.py
+++ b/package/tests/test_inspection_adapter/test_graph_builder_edge_cases.py
@@ -271,3 +271,40 @@ def test_build_rejects_unknown_pipeline_id() -> None:
 def test_display_name(name: str, namespace: str | None, expected: str) -> None:
     """Display name strips the namespace prefix and any auto-name ``__<hash>`` suffix."""
     assert _display_name(name, namespace) == expected
+
+
+def test_no_layer_mapping_yields_empty_layers() -> None:
+    """With no layer mapping, the layers list is empty and data nodes carry no layer."""
+    builder = _builder(
+        _snapshot([_pipeline("__default__", [_node("t", ["x"], ["y"])])])
+    )
+    graph = builder.build("__default__")
+    assert graph.layers == []
+    data_node = next(n for n in graph.nodes if n.type == "data")
+    assert isinstance(data_node, DataNodeAPIResponse)
+    assert data_node.layer is None
+
+
+def test_layers_reflect_mapping_and_sort_topologically() -> None:
+    """Data nodes carry their mapped layer, and the layers list is in dependency order."""
+    snapshot = _snapshot([_pipeline("__default__", [_node("t", ["x"], ["y"])])])
+    builder = GraphBuilder(
+        cast("ProjectSnapshot", snapshot), {"x": "raw", "y": "model"}
+    )
+    graph = builder.build("__default__")
+    layer_by_name = {n.name: n.layer for n in graph.nodes if n.type == "data"}
+    assert layer_by_name == {"x": "raw", "y": "model"}
+    # x -> t -> y, so the raw layer sorts before the model layer.
+    assert graph.layers == ["raw", "model"]
+
+
+def test_layered_dataset_absent_from_graph_is_excluded() -> None:
+    """A layer mapped to a dataset no node uses must not leak into the layers list."""
+    snapshot = _snapshot([_pipeline("__default__", [_node("t", ["x"], ["y"])])])
+    builder = GraphBuilder(
+        cast("ProjectSnapshot", snapshot),
+        {"x": "raw", "y": "model", "orphan": "reporting"},
+    )
+    graph = builder.build("__default__")
+    assert "reporting" not in graph.layers
+    assert graph.layers == ["raw", "model"]

--- a/package/tests/test_inspection_adapter/test_graph_builder_edge_cases.py
+++ b/package/tests/test_inspection_adapter/test_graph_builder_edge_cases.py
@@ -1,7 +1,7 @@
 """Hermetic edge cases for the snapshot graph builder."""
 
 from types import SimpleNamespace
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import pytest
 
@@ -15,8 +15,10 @@ if TYPE_CHECKING:
     from kedro.inspection.models import ProjectSnapshot
 
 
-def _builder(snapshot: SimpleNamespace) -> GraphBuilder:
-    return GraphBuilder(cast("ProjectSnapshot", snapshot))
+def _builder(
+    snapshot: SimpleNamespace, catalog_config: dict[str, Any] | None = None
+) -> GraphBuilder:
+    return GraphBuilder(cast("ProjectSnapshot", snapshot), catalog_config)
 
 
 def _node(
@@ -273,40 +275,100 @@ def test_display_name(name: str, namespace: str | None, expected: str) -> None:
     assert _display_name(name, namespace) == expected
 
 
-def test_no_layer_mapping_yields_empty_layers() -> None:
-    """With no layer mapping, the layers list is empty and data nodes carry no layer."""
+def test_no_catalog_config_yields_empty_layers() -> None:
     builder = _builder(
         _snapshot([_pipeline("__default__", [_node("t", ["x"], ["y"])])])
     )
     graph = builder.build("__default__")
     assert graph.layers == []
-    data_node = next(n for n in graph.nodes if n.type == "data")
-    assert isinstance(data_node, DataNodeAPIResponse)
-    assert data_node.layer is None
+    data_nodes = [
+        node
+        for node in graph.nodes
+        if isinstance(node, DataNodeAPIResponse) and node.type == "data"
+    ]
+    assert data_nodes
+    assert all(node.layer is None for node in data_nodes)
 
 
-def test_layers_reflect_mapping_and_sort_topologically() -> None:
-    """Data nodes carry their mapped layer, and the layers list is in dependency order."""
+def test_layers_from_catalog_config_are_sorted_topologically() -> None:
     snapshot = _snapshot([_pipeline("__default__", [_node("t", ["x"], ["y"])])])
-    builder = GraphBuilder(
-        cast("ProjectSnapshot", snapshot), {"x": "raw", "y": "model"}
-    )
-    graph = builder.build("__default__")
+    catalog_config = {
+        "x": {"metadata": {"kedro-viz": {"layer": "raw"}}},
+        "y": {"metadata": {"kedro-viz": {"layer": "model"}}},
+    }
+    graph = _builder(snapshot, catalog_config).build("__default__")
     layer_by_name = {
-        n.name: n.layer for n in graph.nodes if isinstance(n, DataNodeAPIResponse)
+        node.name: node.layer
+        for node in graph.nodes
+        if isinstance(node, DataNodeAPIResponse) and node.type == "data"
     }
     assert layer_by_name == {"x": "raw", "y": "model"}
-    # x -> t -> y, so the raw layer sorts before the model layer.
     assert graph.layers == ["raw", "model"]
 
 
-def test_layered_dataset_absent_from_graph_is_excluded() -> None:
-    """A layer mapped to a dataset no node uses must not leak into the layers list."""
-    snapshot = _snapshot([_pipeline("__default__", [_node("t", ["x"], ["y"])])])
-    builder = GraphBuilder(
-        cast("ProjectSnapshot", snapshot),
-        {"x": "raw", "y": "model", "orphan": "reporting"},
+def test_factory_layer_is_resolved_for_concrete_dataset() -> None:
+    snapshot = _snapshot(
+        [
+            _pipeline(
+                "__default__",
+                [_node("t", ["processing.int_companies"], ["model"])],
+            )
+        ]
     )
-    graph = builder.build("__default__")
-    assert "reporting" not in graph.layers
-    assert graph.layers == ["raw", "model"]
+    catalog_config = {
+        "{namespace}.int_{name}": {
+            "metadata": {"kedro-viz": {"layer": "intermediate"}}
+        },
+        "model": {"metadata": {"kedro-viz": {"layer": "model"}}},
+    }
+
+    graph = _builder(snapshot, catalog_config).build("__default__")
+    layer_by_name = {
+        node.name: node.layer
+        for node in graph.nodes
+        if isinstance(node, DataNodeAPIResponse) and node.type == "data"
+    }
+    assert layer_by_name["processing.int_companies"] == "intermediate"
+
+
+def test_factory_layer_does_not_apply_to_parameters() -> None:
+    snapshot = _snapshot(
+        [
+            _pipeline(
+                "__default__",
+                [_node("t", ["params:model_options"], ["result"])],
+            )
+        ]
+    )
+    catalog_config = {
+        "{name}": {"metadata": {"kedro-viz": {"layer": "factory"}}},
+        "result": {"type": "kedro.io.MemoryDataset"},
+    }
+
+    graph = _builder(snapshot, catalog_config).build("__default__")
+    parameter = next(
+        node
+        for node in graph.nodes
+        if isinstance(node, DataNodeAPIResponse) and node.type == "parameters"
+    )
+    assert parameter.layer is None
+    assert graph.layers == []
+
+
+def test_layers_include_all_pipelines_but_exclude_unused_catalog_entries() -> None:
+    snapshot = _snapshot(
+        [
+            _pipeline("pipe_a", [_node("a", ["raw_data"], ["model"])]),
+            _pipeline("pipe_b", [_node("b", ["external"], ["report"])]),
+        ]
+    )
+    catalog_config = {
+        "raw_data": {"metadata": {"kedro-viz": {"layer": "raw"}}},
+        "model": {"metadata": {"kedro-viz": {"layer": "model"}}},
+        "external": {"metadata": {"kedro-viz": {"layer": "external"}}},
+        "report": {"metadata": {"kedro-viz": {"layer": "reporting"}}},
+        "orphan": {"metadata": {"kedro-viz": {"layer": "unused"}}},
+    }
+
+    graph = _builder(snapshot, catalog_config).build("pipe_a")
+    assert set(graph.layers) == {"raw", "model", "external", "reporting"}

--- a/package/tests/test_inspection_adapter/test_graph_builder_edge_cases.py
+++ b/package/tests/test_inspection_adapter/test_graph_builder_edge_cases.py
@@ -292,7 +292,9 @@ def test_layers_reflect_mapping_and_sort_topologically() -> None:
         cast("ProjectSnapshot", snapshot), {"x": "raw", "y": "model"}
     )
     graph = builder.build("__default__")
-    layer_by_name = {n.name: n.layer for n in graph.nodes if n.type == "data"}
+    layer_by_name = {
+        n.name: n.layer for n in graph.nodes if isinstance(n, DataNodeAPIResponse)
+    }
     assert layer_by_name == {"x": "raw", "y": "model"}
     # x -> t -> y, so the raw layer sorts before the model layer.
     assert graph.layers == ["raw", "model"]

--- a/package/tests/test_inspection_adapter/test_layers.py
+++ b/package/tests/test_inspection_adapter/test_layers.py
@@ -20,6 +20,43 @@ def test_strips_transcoding() -> None:
     assert _extract_layers(config) == {"shuttles": "primary"}
 
 
+def test_resolves_dataset_factory_layer() -> None:
+    config = {
+        "{namespace}.int_{name}": {
+            "type": "pandas.ParquetDataset",
+            "metadata": {"kedro-viz": {"layer": "intermediate"}},
+        }
+    }
+    assert _extract_layers(config, ["processing.int_companies"]) == {
+        "processing.int_companies": "intermediate"
+    }
+
+
+def test_explicit_dataset_takes_precedence_over_factory_layer() -> None:
+    config = {
+        "{name}": {
+            "type": "pandas.ParquetDataset",
+            "metadata": {"kedro-viz": {"layer": "factory"}},
+        },
+        "companies": {
+            "type": "pandas.CSVDataset",
+            "metadata": {"kedro-viz": {"layer": "raw"}},
+        },
+    }
+    assert _extract_layers(config, ["companies"]) == {"companies": "raw"}
+
+
+def test_more_specific_factory_without_layer_takes_precedence() -> None:
+    config = {
+        "{name}": {
+            "type": "pandas.ParquetDataset",
+            "metadata": {"kedro-viz": {"layer": "factory"}},
+        },
+        "{namespace}.int_{name}": {"type": "pandas.ParquetDataset"},
+    }
+    assert _extract_layers(config, ["processing.int_companies"]) == {}
+
+
 def test_skips_entries_without_a_layer() -> None:
     config = {
         "no_metadata": {"type": "pandas.CSVDataset"},  # KeyError on "metadata"

--- a/package/tests/test_inspection_adapter/test_layers.py
+++ b/package/tests/test_inspection_adapter/test_layers.py
@@ -1,0 +1,37 @@
+"""Unit tests for ``_extract_layers`` (catalog-config layer extraction)."""
+
+from kedro_viz.integrations.kedro.inspection.layers import _extract_layers
+
+
+def test_reads_kedro_viz_layer() -> None:
+    config = {
+        "companies": {
+            "type": "pandas.CSVDataset",
+            "metadata": {"kedro-viz": {"layer": "raw"}},
+        }
+    }
+    assert _extract_layers(config) == {"companies": "raw"}
+
+
+def test_strips_transcoding() -> None:
+    config = {"shuttles@pandas": {"metadata": {"kedro-viz": {"layer": "primary"}}}}
+    assert _extract_layers(config) == {"shuttles": "primary"}
+
+
+def test_skips_entries_without_a_layer() -> None:
+    config = {
+        "no_metadata": {"type": "pandas.CSVDataset"},  # KeyError on "metadata"
+        "metadata_without_layer": {
+            "metadata": {"kedro-viz": {}}
+        },  # KeyError on "layer"
+    }
+    assert _extract_layers(config) == {}
+
+
+def test_skips_non_dict_config() -> None:
+    # A non-mapping entry (e.g. a stray string) must be ignored, not crash.
+    config = {
+        "_stray": "not-a-dict",
+        "companies": {"metadata": {"kedro-viz": {"layer": "raw"}}},
+    }
+    assert _extract_layers(config) == {"companies": "raw"}

--- a/package/tests/test_inspection_adapter/test_layers.py
+++ b/package/tests/test_inspection_adapter/test_layers.py
@@ -1,5 +1,7 @@
 """Unit tests for ``_extract_layers`` (catalog-config layer extraction)."""
 
+import pytest
+
 from kedro_viz.integrations.kedro.inspection.layers import _extract_layers
 
 
@@ -35,3 +37,22 @@ def test_skips_non_dict_config() -> None:
         "companies": {"metadata": {"kedro-viz": {"layer": "raw"}}},
     }
     assert _extract_layers(config) == {"companies": "raw"}
+
+
+def test_transcoded_variants_with_same_layer_collapse_to_one() -> None:
+    config = {
+        "cars@csv": {"metadata": {"kedro-viz": {"layer": "raw"}}},
+        "cars@parquet": {"metadata": {"kedro-viz": {"layer": "raw"}}},
+    }
+    assert _extract_layers(config) == {"cars": "raw"}
+
+
+def test_transcoded_variants_with_conflicting_layers_raise() -> None:
+    config = {
+        "cars@csv": {"metadata": {"kedro-viz": {"layer": "raw"}}},
+        "cars@parquet": {"metadata": {"kedro-viz": {"layer": "model"}}},
+    }
+    with pytest.raises(
+        ValueError, match="Transcoded datasets should have the same layer"
+    ):
+        _extract_layers(config)

--- a/package/tests/test_inspection_adapter/test_layers.py
+++ b/package/tests/test_inspection_adapter/test_layers.py
@@ -1,8 +1,10 @@
-"""Unit tests for ``_extract_layers`` (catalog-config layer extraction)."""
+"""Tests for inspection-adapter layer handling."""
+
+import logging
 
 import pytest
 
-from kedro_viz.integrations.kedro.inspection.layers import _extract_layers
+from kedro_viz.integrations.kedro.inspection.layers import _extract_layers, sort_layers
 
 
 def test_reads_kedro_viz_layer() -> None:
@@ -93,3 +95,78 @@ def test_transcoded_variants_with_conflicting_layers_raise() -> None:
         ValueError, match="Transcoded datasets should have the same layer"
     ):
         _extract_layers(config)
+
+
+def test_sort_layers_returns_empty_when_no_nodes_have_layers() -> None:
+    assert (
+        sort_layers(
+            {"input": None, "task": None, "output": None},
+            {"input": {"task"}, "task": {"output"}},
+        )
+        == []
+    )
+
+
+def test_sort_layers_follows_indirect_dependencies() -> None:
+    assert sort_layers(
+        {"input": "raw", "task": None, "output": "intermediate"},
+        {"input": {"task"}, "task": {"output"}},
+    ) == ["raw", "intermediate"]
+
+
+@pytest.mark.parametrize(
+    "layer_by_node_id,dependencies,expected",
+    [
+        (
+            {
+                "raw": "raw",
+                "split": None,
+                "intermediate": "intermediate",
+                "feature": "feature",
+                "model_input": "model_input",
+            },
+            {
+                "raw": {"split"},
+                "split": {"intermediate"},
+                "intermediate": {"feature", "model_input"},
+            },
+            ["raw", "intermediate", "feature", "model_input"],
+        ),
+        (
+            {"node_1": "c", "node_2": "a", "node_3": "d", "node_4": "b"},
+            {"node_1": {"node_2"}, "node_3": {"node_4"}},
+            ["c", "d", "a", "b"],
+        ),
+    ],
+)
+def test_sort_layers_is_deterministic(
+    layer_by_node_id: dict[str, str | None],
+    dependencies: dict[str, set[str]],
+    expected: list[str],
+) -> None:
+    assert sort_layers(layer_by_node_id, dependencies) == expected
+
+
+def test_sort_layers_returns_empty_on_cyclic_layers(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    with caplog.at_level(
+        logging.WARNING,
+        logger="kedro_viz.integrations.kedro.inspection.layers",
+    ):
+        result = sort_layers(
+            {"first": "raw", "second": "intermediate", "third": "raw"},
+            {
+                "first": {"second"},
+                "second": {"third"},
+                "third": {"first"},
+            },
+        )
+
+    assert result == []
+    assert "circular dependency detected among layers" in caplog.text
+
+
+def test_sort_layers_rejects_unknown_dependency_nodes() -> None:
+    with pytest.raises(KeyError, match="missing"):
+        sort_layers({"source": "raw"}, {"source": {"missing"}})

--- a/package/tests/test_inspection_adapter/test_layers.py
+++ b/package/tests/test_inspection_adapter/test_layers.py
@@ -165,8 +165,3 @@ def test_sort_layers_returns_empty_on_cyclic_layers(
 
     assert result == []
     assert "circular dependency detected among layers" in caplog.text
-
-
-def test_sort_layers_rejects_unknown_dependency_nodes() -> None:
-    with pytest.raises(KeyError, match="missing"):
-        sort_layers({"source": "raw"}, {"source": {"missing"}})


### PR DESCRIPTION
**Sub-task:** #2658 · **Parent:** #2265

Third slice of the inspection-adapter backend: dataset layers. This stacks on the merged graph-builder PR (#2697) and foundation PR (#2689), and targets **`feat/backend_v2`**, not `main`.

## Description

This PR adds dataset-layer support to the snapshot graph builder. It is additive: nothing is wired to `/api/main` yet, and parity is checked against the captured legacy-backend baseline.

What changed:

- **`layers.py` (new):** extracts `metadata.kedro-viz.layer` from raw catalog configuration, resolves dataset-factory patterns, normalises transcoded names, and rejects conflicting layers for transcoded variants. It also contains an inspection-native sorter that works with a node-ID-to-layer mapping and preserves the legacy ordering and cycle behaviour.
- **`graph_builder.py`:** `GraphBuilder` accepts optional raw catalog configuration and resolves its layer mapping internally. Data nodes receive their layer, and each graph response contains the project-wide set of used layers ordered by the selected pipeline's dependencies. Parameter references and unused catalog entries do not create layers.
- **Tests:** add catalog extraction and sorting unit tests, layer parity for every registered pipeline, and focused coverage for factory patterns, parameters, transcoding, absent configuration, cross-pipeline layers, and unused catalog entries.

## Deferred to later phases

The required response fields remain valid using empty placeholders:

- **Modular pipelines** (#2657): `modular_pipelines={}` on the response and `modular_pipelines=None` on nodes.
- **Resolved parameter values and node metadata** (later slice): `parameters={}` on task nodes.
- **Runtime wiring:** the builder is not yet routed to serve `/api/main`; that is handled in a later phase.

## Notes

- Parity is structural rather than based on literal IDs because node IDs changed in the foundation work. Layer parity is compared by dataset name.
- The `layers` list is order-sensitive and is asserted against every pipeline baseline.
- Layer extraction and sorting remain private inspection-adapter details and are not re-exported from the package.
- The inspection-native sorter replaces the temporary dependency on the legacy `GraphNode`-based layer service. The legacy implementation can be removed with the old backend.
- `dataset_type` is unchanged and continues to use the raw catalog string from the snapshot.
- `RELEASE.md` is intentionally deferred until the `backend_v2` integration line merges to `main`, consistent with #2689 and #2697.

## Follow-up when the legacy backend is removed

- Move the dictionary-based `sort_layers` from `integrations/kedro/inspection/layers.py` to `services/layers.py`.
- Remove the old `GraphNode`-based `sort_layers`.
- Remove `CatalogRepository.layers_mapping` and its related legacy layer helpers and tests.

## Verification

Validated with Python 3.14.4 and Kedro 1.4.0:

- `ruff check`: clean
- `ruff format --check`: clean
- `mypy --config-file package/mypy.ini`: clean for package and tests
- `pytest package/tests/test_inspection_adapter/`: **117 passed**
- `graph_builder.py` and `layers.py`: **100% line coverage**

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a draft if it is work in progress
- [ ] Updated user-facing documentation (not applicable: internal adapter only)
- [ ] Added a `RELEASE.md` entry (deferred; see Notes)
- [x] Added tests for the changes