### PR TITLE
Fix for autoreload to ignore notebook file changes

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -5,6 +5,10 @@ Please follow the established format:
 - Use present tense (e.g. 'Add new feature')
 - Include the ID number for the related PR (or PRs) in parentheses
 -->
+# Release 12.5.0
+
+## Bug fixes and other changes
+ - Fix for `autoreload` to ignore notebook file changes. (#2712)
 
 # Release 12.4.0
 

--- a/package/features/environment.py
+++ b/package/features/environment.py
@@ -87,6 +87,7 @@ def _setup_context_with_venv(context, venv_dir):
     # Windows thinks the pip version check warning is a failure
     # so disable it here.
     context.env["PIP_DISABLE_PIP_VERSION_CHECK"] = "1"
+    context.env["MPLBACKEND"] = "Agg"
 
     call(
         [context.python, "-m", "pip", "install", "-U", "pip>=21.2", "setuptools>=38.0"],

--- a/package/features/steps/cli_steps.py
+++ b/package/features/steps/cli_steps.py
@@ -1,6 +1,5 @@
 """Behave step definitions for the cli_scenarios feature."""
 
-import sys
 from pathlib import Path
 from time import sleep, time
 
@@ -28,26 +27,6 @@ def _create_config_file(context, include_example):
     }
     with context.config_file.open("w") as config_file:
         yaml.dump(config, config_file, default_flow_style=False)
-
-
-def _numpy_pin_for_python() -> str | None:
-    """Return the numpy pin used by lower_requirements.txt for this Python version."""
-    version = sys.version_info
-    if version >= (3, 14):
-        return "2.3.2"
-    if version >= (3, 13):
-        return "2.1.0"
-    if version >= (3, 12):
-        return "2.0.2"
-    if version >= (3, 10):
-        return "1.26.4"
-    return None
-
-
-def _add_package_pin(requirements_path: str, package_name: str, version: str) -> None:
-    """Append a package pin to a requirements file."""
-    with open(requirements_path, "a", encoding="utf-8") as req_file:
-        req_file.write(f"\n{package_name}=={version}\n")
 
 
 @given("I have prepared a config file with example code")
@@ -101,11 +80,6 @@ def install_project_requirements(context):
     """Run ``pip install -r requirements.txt``."""
     requirements_path = str(context.root_project_dir) + "/requirements.txt"
 
-    if getattr(context, "lower_bound_requirements_installed", False):
-        numpy_pin = _numpy_pin_for_python()
-        if numpy_pin:
-            _add_package_pin(requirements_path, "numpy", numpy_pin)
-
     cmd = [context.pip, "install", "-r", requirements_path]
     res = run(cmd, env=context.env)
 
@@ -126,8 +100,6 @@ def install_lower_bound_requirements(context):
         print(res.stdout)
         print(res.stderr)
         assert False
-
-    context.lower_bound_requirements_installed = True
 
 
 @given('I have installed kedro version "{version}"')

--- a/package/features/steps/cli_steps.py
+++ b/package/features/steps/cli_steps.py
@@ -201,9 +201,7 @@ def check_kedroviz_up(context):
 
     while time() < end_by:
         try:
-            data_json = requests.get(
-                "http://localhost:4141/api/main", timeout=5
-            ).json()
+            data_json = requests.get("http://localhost:4141/api/main", timeout=5).json()
         except Exception:  # noqa: BLE001
             sleep(2.0)
             continue

--- a/package/features/steps/cli_steps.py
+++ b/package/features/steps/cli_steps.py
@@ -1,5 +1,6 @@
 """Behave step definitions for the cli_scenarios feature."""
 
+import sys
 from pathlib import Path
 from time import sleep, time
 
@@ -27,6 +28,51 @@ def _create_config_file(context, include_example):
     }
     with context.config_file.open("w") as config_file:
         yaml.dump(config, config_file, default_flow_style=False)
+
+
+def _numpy_pin_for_python() -> str | None:
+    """Return the numpy pin used by lower_requirements.txt for this Python version."""
+    version = sys.version_info
+    if version >= (3, 14):
+        return "2.3.2"
+    if version >= (3, 13):
+        return "2.1.0"
+    if version >= (3, 12):
+        return "2.0.2"
+    if version >= (3, 10):
+        return "1.26.4"
+    return None
+
+
+def _add_package_pin(requirements_path: str, package_name: str, version: str) -> None:
+    """Append a package pin to a requirements file."""
+    with open(requirements_path, "a", encoding="utf-8") as req_file:
+        req_file.write(f"\n{package_name}=={version}\n")
+
+
+def _ensure_kedro_cli(context) -> None:
+    """Ensure the kedro CLI entry point exists after pip installs."""
+    kedro_path = Path(context.kedro)
+    if kedro_path.exists():
+        return
+
+    res = run([context.pip, "install", "-U", "kedro"], env=context.env)
+    if res.returncode != OK_EXIT_CODE:
+        print(res.stdout)
+        print(res.stderr)
+        assert False
+
+    assert kedro_path.exists(), f"kedro CLI not found at {context.kedro}"
+
+
+def _assert_viz_process_started(context) -> None:
+    """Fail fast if kedro viz exits immediately after launch."""
+    sleep(0.5)
+    if context.result.poll() is None:
+        return
+
+    _, stderr = context.result.communicate()
+    raise AssertionError(f"kedro viz failed to start: {stderr.decode()}")
 
 
 @given("I have prepared a config file with example code")
@@ -80,6 +126,11 @@ def install_project_requirements(context):
     """Run ``pip install -r requirements.txt``."""
     requirements_path = str(context.root_project_dir) + "/requirements.txt"
 
+    if getattr(context, "lower_bound_requirements_installed", False):
+        numpy_pin = _numpy_pin_for_python()
+        if numpy_pin:
+            _add_package_pin(requirements_path, "numpy", numpy_pin)
+
     cmd = [context.pip, "install", "-r", requirements_path]
     res = run(cmd, env=context.env)
 
@@ -87,6 +138,8 @@ def install_project_requirements(context):
         print(res.stdout)
         print(res.stderr)
         assert False
+
+    _ensure_kedro_cli(context)
 
 
 @given("I have installed the lower-bound Kedro-viz requirements")
@@ -100,6 +153,8 @@ def install_lower_bound_requirements(context):
         print(res.stdout)
         print(res.stderr)
         assert False
+
+    context.lower_bound_requirements_installed = True
 
 
 @given('I have installed kedro version "{version}"')
@@ -123,21 +178,25 @@ def install_kedro(context, version):
 @when("I execute the kedro viz run command")
 def exec_viz_command(context):
     """Execute Kedro-Viz command."""
+    _ensure_kedro_cli(context)
     context.result = ChildTerminatingPopen(
         [context.kedro, "viz", "run", "--no-browser"],
         env=context.env,
         cwd=str(context.root_project_dir),
     )
+    _assert_viz_process_started(context)
 
 
 @when("I execute the kedro viz run command with lite option")
 def exec_viz_lite_command(context):
     """Execute Kedro-Viz command."""
+    _ensure_kedro_cli(context)
     context.result = ChildTerminatingPopen(
         [context.kedro, "viz", "run", "--lite", "--no-browser"],
         env=context.env,
         cwd=str(context.root_project_dir),
     )
+    _assert_viz_process_started(context)
 
 
 @then("kedro-viz should start successfully")
@@ -145,6 +204,7 @@ def check_kedroviz_up(context):
     """Check that Kedro-Viz is up and responding to requests."""
     max_duration = 30  # 30 seconds
     end_by = time() + max_duration
+    data_json = None
 
     while time() < end_by:
         try:
@@ -156,7 +216,13 @@ def check_kedroviz_up(context):
             break
 
     try:
-        assert context.result.poll() is None
+        if context.result.poll() is not None:
+            _, stderr = context.result.communicate()
+            raise AssertionError(
+                f"Kedro Viz process exited unexpectedly: {stderr.decode()}"
+            )
+        if data_json is None:
+            raise AssertionError("Kedro Viz did not respond within 30 seconds")
         assert (
             "X_test" == sorted(data_json["nodes"], key=lambda i: i["name"])[0]["name"]
         )
@@ -168,6 +234,7 @@ def check_kedroviz_up(context):
 def get_main_api_response(context):
     max_duration = 30  # 30 seconds
     end_by = time() + max_duration
+    context.response = None
 
     while time() < end_by:
         try:
@@ -179,6 +246,12 @@ def get_main_api_response(context):
             continue
         else:
             break
+
+    try:
+        if context.response is None:
+            raise AssertionError("Kedro Viz did not respond within 30 seconds")
+    finally:
+        context.result.terminate()
 
 
 @then("I compare the responses in regular and lite mode")

--- a/package/features/steps/cli_steps.py
+++ b/package/features/steps/cli_steps.py
@@ -50,7 +50,7 @@ def _add_package_pin(requirements_path: str, package_name: str, version: str) ->
         req_file.write(f"\n{package_name}=={version}\n")
 
 
-def _ensure_kedro_cli(context) -> None:
+def _ensure_kedro_cli(context):
     """Ensure the kedro CLI entry point exists after pip installs."""
     kedro_path = Path(context.kedro)
     if kedro_path.exists():

--- a/package/features/steps/cli_steps.py
+++ b/package/features/steps/cli_steps.py
@@ -1,16 +1,66 @@
 """Behave step definitions for the cli_scenarios feature."""
 
+import sys
 from pathlib import Path
 from time import sleep, time
 
 import requests
 import yaml
 from behave import given, then, when
-from packaging.version import parse
 
 from features.steps.sh_run import ChildTerminatingPopen, run
 
 OK_EXIT_CODE = 0
+
+
+def _numpy_pandas_pins():
+    """Return lower-bound numpy and pandas pins for the current Python version."""
+    version = sys.version_info
+    if version >= (3, 14):
+        return "2.3.2", "2.3.3"
+    if version >= (3, 13):
+        return "2.1.0", "2.2.3"
+    if version >= (3, 12):
+        return "2.0.2", "2.2.3"
+    if version >= (3, 10):
+        return "1.26.4", "1.5"
+    return None, None
+
+
+def _force_reinstall_numpy_pandas(context):
+    """Ensure numpy and pandas wheels match after lower-bound installs."""
+    numpy_pin, pandas_pin = _numpy_pandas_pins()
+    if not numpy_pin or not pandas_pin:
+        return
+
+    res = run(
+        [
+            context.pip,
+            "install",
+            "--no-cache-dir",
+            "--force-reinstall",
+            f"numpy=={numpy_pin}",
+            f"pandas=={pandas_pin}",
+        ],
+        env=context.env,
+    )
+    if res.returncode != OK_EXIT_CODE:
+        print(res.stdout)
+        print(res.stderr)
+        assert False
+
+    import_res = run(
+        [
+            context.python,
+            "-c",
+            "import numpy as np; import pandas as pd; print(np.__version__, pd.__version__)",
+        ],
+        env=context.env,
+    )
+    if import_res.returncode != OK_EXIT_CODE:
+        print(import_res.stdout)
+        print(import_res.stderr)
+        assert False
 
 
 def _create_config_file(context, include_example):
@@ -93,13 +143,15 @@ def install_project_requirements(context):
 def install_lower_bound_requirements(context):
     cwd = Path(__file__).resolve().parent
     requirements_path = cwd / "lower_requirements.txt"
-    cmd = [context.pip, "install", "-r", requirements_path]
+    cmd = [context.pip, "install", "-r", str(requirements_path), "--force-reinstall"]
     res = run(cmd, env=context.env)
 
     if res.returncode != OK_EXIT_CODE:
         print(res.stdout)
         print(res.stderr)
         assert False
+
+    _force_reinstall_numpy_pandas(context)
 
 
 @given('I have installed kedro version "{version}"')
@@ -143,13 +195,15 @@ def exec_viz_lite_command(context):
 @then("kedro-viz should start successfully")
 def check_kedroviz_up(context):
     """Check that Kedro-Viz is up and responding to requests."""
-    max_duration = 30  # 30 seconds
+    max_duration = 45
     end_by = time() + max_duration
     data_json = None
 
     while time() < end_by:
         try:
-            data_json = requests.get("http://localhost:4141/api/main").json()
+            data_json = requests.get(
+                "http://localhost:4141/api/main", timeout=5
+            ).json()
         except Exception:  # noqa: BLE001
             sleep(2.0)
             continue
@@ -163,7 +217,7 @@ def check_kedroviz_up(context):
                 f"Kedro Viz process exited unexpectedly: {stderr.decode()}"
             )
         if data_json is None:
-            raise AssertionError("Kedro Viz did not respond within 30 seconds")
+            raise AssertionError("Kedro Viz did not respond within 45 seconds")
         assert (
             "X_test" == sorted(data_json["nodes"], key=lambda i: i["name"])[0]["name"]
         )
@@ -173,12 +227,12 @@ def check_kedroviz_up(context):
 
 @then("I store the response from main endpoint")
 def get_main_api_response(context):
-    max_duration = 30  # 30 seconds
+    max_duration = 45  # 45 seconds
     end_by = time() + max_duration
 
     while time() < end_by:
         try:
-            response = requests.get("http://localhost:4141/api/main")
+            response = requests.get("http://localhost:4141/api/main", timeout=5)
             context.response = response.json()
             assert response.status_code == 200
         except Exception:  # noqa: BLE001

--- a/package/features/steps/cli_steps.py
+++ b/package/features/steps/cli_steps.py
@@ -50,31 +50,6 @@ def _add_package_pin(requirements_path: str, package_name: str, version: str) ->
         req_file.write(f"\n{package_name}=={version}\n")
 
 
-def _ensure_kedro_cli(context):
-    """Ensure the kedro CLI entry point exists after pip installs."""
-    kedro_path = Path(context.kedro)
-    if kedro_path.exists():
-        return
-
-    res = run([context.pip, "install", "-U", "kedro"], env=context.env)
-    if res.returncode != OK_EXIT_CODE:
-        print(res.stdout)
-        print(res.stderr)
-        assert False
-
-    assert kedro_path.exists(), f"kedro CLI not found at {context.kedro}"
-
-
-def _assert_viz_process_started(context) -> None:
-    """Fail fast if kedro viz exits immediately after launch."""
-    sleep(0.5)
-    if context.result.poll() is None:
-        return
-
-    _, stderr = context.result.communicate()
-    raise AssertionError(f"kedro viz failed to start: {stderr.decode()}")
-
-
 @given("I have prepared a config file with example code")
 def create_config_file_with_example(context):
     """Behave step to create a temporary config file
@@ -139,8 +114,6 @@ def install_project_requirements(context):
         print(res.stderr)
         assert False
 
-    _ensure_kedro_cli(context)
-
 
 @given("I have installed the lower-bound Kedro-viz requirements")
 def install_lower_bound_requirements(context):
@@ -178,25 +151,21 @@ def install_kedro(context, version):
 @when("I execute the kedro viz run command")
 def exec_viz_command(context):
     """Execute Kedro-Viz command."""
-    _ensure_kedro_cli(context)
     context.result = ChildTerminatingPopen(
         [context.kedro, "viz", "run", "--no-browser"],
         env=context.env,
         cwd=str(context.root_project_dir),
     )
-    _assert_viz_process_started(context)
 
 
 @when("I execute the kedro viz run command with lite option")
 def exec_viz_lite_command(context):
     """Execute Kedro-Viz command."""
-    _ensure_kedro_cli(context)
     context.result = ChildTerminatingPopen(
         [context.kedro, "viz", "run", "--lite", "--no-browser"],
         env=context.env,
         cwd=str(context.root_project_dir),
     )
-    _assert_viz_process_started(context)
 
 
 @then("kedro-viz should start successfully")
@@ -234,7 +203,6 @@ def check_kedroviz_up(context):
 def get_main_api_response(context):
     max_duration = 30  # 30 seconds
     end_by = time() + max_duration
-    context.response = None
 
     while time() < end_by:
         try:
@@ -246,12 +214,6 @@ def get_main_api_response(context):
             continue
         else:
             break
-
-    try:
-        if context.response is None:
-            raise AssertionError("Kedro Viz did not respond within 30 seconds")
-    finally:
-        context.result.terminate()
 
 
 @then("I compare the responses in regular and lite mode")

--- a/package/features/steps/lower_requirements.txt
+++ b/package/features/steps/lower_requirements.txt
@@ -19,7 +19,8 @@ orjson==3.11.6; python_version >= '3.13'
 secure==0.3.0
 # numpy 2.0 breaks with old versions of pandas and this
 # could be removed when the lowest version supported is updated
-numpy==1.26.4; python_version < '3.13'
+numpy==1.26.4; python_version < '3.12'
+numpy==2.0.2; python_version >= '3.12' and python_version < '3.13'
 numpy==2.1.0; python_version >= '3.13' and python_version < '3.14'
 numpy==2.3.2; python_version >= '3.14'
 pathspec==0.12.1

--- a/package/features/steps/lower_requirements.txt
+++ b/package/features/steps/lower_requirements.txt
@@ -1,4 +1,5 @@
-ipython==7.0.0
+ipython==7.0.0; python_version < '3.11'
+ipython==8.10.0; python_version >= '3.11'
 fastapi==0.100.0
 fsspec==2021.4; python_version < '3.12'
 fsspec==2021.06.01; python_version >= '3.12'
@@ -9,17 +10,17 @@ watchfiles==1.1.0; python_version >= '3.14'
 plotly==4.8
 packaging==23.0
 pandas==1.5; python_version >= '3.10' and python_version < '3.12'
-pandas==2.1.1; python_version >= '3.12' and python_version < '3.13'
-pandas==2.2.3; python_version >= '3.13' and python_version < '3.14'
+pandas==2.2.3; python_version >= '3.12' and python_version < '3.14'
 pandas==2.3.3; python_version >= '3.14'
-networkx==2.5; python_version < '3.13'
+networkx==2.5; python_version < '3.12'
+networkx==2.6; python_version >= '3.12' and python_version < '3.13'
 networkx==2.7; python_version >= '3.13'
 orjson==3.9; python_version < '3.13'
 orjson==3.11.6; python_version >= '3.13'
 secure==0.3.0
 # numpy 2.0 breaks with old versions of pandas and this
 # could be removed when the lowest version supported is updated
-numpy==1.26.4; python_version < '3.12'
+numpy==1.26.4; python_version >= '3.10' and python_version < '3.12'
 numpy==2.0.2; python_version >= '3.12' and python_version < '3.13'
 numpy==2.1.0; python_version >= '3.13' and python_version < '3.14'
 numpy==2.3.2; python_version >= '3.14'

--- a/package/features/steps/sh_run.py
+++ b/package/features/steps/sh_run.py
@@ -1,11 +1,16 @@
 import shlex
 import subprocess
-from typing import Any, Sequence
+from typing import Any, Sequence, Union
 
 import psutil
 
 
-def run(cmd: str, split: bool = True, print_output: bool = False, **kwargs: Any) -> int:
+def run(
+    cmd: Union[str, Sequence[str]],
+    split: bool = True,
+    print_output: bool = False,
+    **kwargs: Any,
+) -> subprocess.CompletedProcess[str]:
     """
     Args:
         cmd: A command string, or a command followed by program
@@ -33,7 +38,7 @@ def run(cmd: str, split: bool = True, print_output: bool = False, **kwargs: Any)
 
     """
     if isinstance(cmd, str) and split:
-        cmd = shlex.split(cmd)  # type: ignore
+        cmd = shlex.split(cmd)
     result = subprocess.run(
         cmd, input="", stdout=subprocess.PIPE, stderr=subprocess.PIPE, **kwargs
     )
@@ -41,7 +46,7 @@ def run(cmd: str, split: bool = True, print_output: bool = False, **kwargs: Any)
     result.stderr = result.stderr.decode("utf-8")
     if print_output:
         print(result.stdout)
-    return result  # type: ignore
+    return result
 
 
 class ChildTerminatingPopen(subprocess.Popen):

--- a/package/features/viz.feature
+++ b/package/features/viz.feature
@@ -4,9 +4,9 @@ Feature: Viz plugin in new project
 
     Scenario: Execute viz with latest Kedro with lower-bound viz requirements
         Given I have installed kedro version "latest"
-        And I have installed the lower-bound Kedro-viz requirements
         And I have run a non-interactive kedro new with spaceflights-pandas starter
         And I have installed the project's requirements
+        And I have installed the lower-bound Kedro-viz requirements
         When I execute the kedro viz run command
         Then kedro-viz should start successfully
     

--- a/package/kedro_viz/autoreload_file_filter.py
+++ b/package/kedro_viz/autoreload_file_filter.py
@@ -1,6 +1,6 @@
 """
 This module provides a custom file filter for autoreloading that filters out files based on allowed
-file extensions and patterns specified in a .gitignore file.
+file extensions, patterns specified in a .gitignore file, and changes under the notebooks folder.
 """
 
 import logging
@@ -18,10 +18,12 @@ logger = logging.getLogger(__name__)
 class AutoreloadFileFilter(DefaultFilter):
     """
     Custom file filter for autoreloading that extends DefaultFilter.
-    Filters out files based on allowed file extensions and patterns specified in a .gitignore file.
+    Filters out files based on allowed file extensions, patterns specified in a .gitignore file,
+    and changes under the notebooks folder.
     """
 
     allowed_extensions: Set[str] = {".py", ".yml", ".yaml", ".json"}
+    ignore_patterns: tuple[str, ...] = ("notebooks/**",)
 
     def __init__(self, base_path: Optional[Path] = None):
         """
@@ -38,6 +40,28 @@ class AutoreloadFileFilter(DefaultFilter):
 
         # Load .gitignore patterns
         self.gitignore_spec = load_gitignore_patterns(self.cwd)
+        self.ignore_spec = GitIgnoreSpec.from_lines(
+            "gitwildmatch", list(self.ignore_patterns)
+        )
+
+    def _matches_ignore_patterns(self, relative_path: Path) -> Optional[bool]:
+        """Return True if ignored, False if not, None if matching failed."""
+        try:
+            if self.gitignore_spec and self.gitignore_spec.match_file(
+                str(relative_path)
+            ):
+                logger.debug("Filtered out by .gitignore: %s", relative_path)
+                return True
+
+            if self.ignore_spec.match_file(str(relative_path)):
+                logger.debug("Filtered out by ignore_patterns: %s", relative_path)
+                return True
+        # ruff: noqa: BLE001
+        except Exception as exc:
+            logger.debug("Exception during ignore pattern matching: %s", exc)
+            return None
+
+        return False
 
     def __call__(self, change: Change, path: str) -> bool:
         """
@@ -56,27 +80,19 @@ class AutoreloadFileFilter(DefaultFilter):
 
         path_obj = Path(path)
 
-        # Exclude files matching .gitignore patterns
         try:
             relative_path = path_obj.resolve().relative_to(self.cwd.resolve())
         except ValueError:
             logger.debug("Path not relative to CWD: %s", path)
             return False
 
-        try:
-            if self.gitignore_spec and self.gitignore_spec.match_file(
-                str(relative_path)
-            ):
-                logger.debug("Filtered out by .gitignore: %s", relative_path)
-                return False
-        # ruff: noqa: BLE001
-        except Exception as exc:
-            logger.debug("Exception during .gitignore matching: %s", exc)
-            return True  # Pass the file if .gitignore matching fails
+        ignore_result = self._matches_ignore_patterns(relative_path)
+        if ignore_result is True:
+            return False
 
-        # Include only files with allowed extensions
-        if path_obj.suffix in self.allowed_extensions:
+        allowed = path_obj.suffix in self.allowed_extensions
+        if allowed:
             logger.debug("Allowed file: %s", path)
-            return True
-        logger.debug("Filtered out by allowed_extensions: %s", path_obj.suffix)
-        return False
+        else:
+            logger.debug("Filtered out by allowed_extensions: %s", path_obj.suffix)
+        return allowed

--- a/package/kedro_viz/launchers/cli/run.py
+++ b/package/kedro_viz/launchers/cli/run.py
@@ -191,7 +191,9 @@ def run(  # noqa: PLR0915
             run_process_kwargs = {
                 "target": run_server,
                 "kwargs": run_server_kwargs,
-                "watch_filter": AutoreloadFileFilter(),
+                "watch_filter": AutoreloadFileFilter(
+                    base_path=Path(kedro_project_path),
+                ),
             }
             viz_process = process_context.Process(
                 target=run_process,

--- a/package/kedro_viz/launchers/jupyter.py
+++ b/package/kedro_viz/launchers/jupyter.py
@@ -126,11 +126,15 @@ def run_viz(args: str = "", local_ns: Dict[str, Any] = None) -> None:
     }
     process_context = multiprocessing.get_context("spawn")
     if autoreload:
+        from pathlib import Path
+
         run_process_args = [str(project_path)]
         run_process_kwargs = {
             "target": run_server,
             "kwargs": run_server_kwargs,
-            "watch_filter": AutoreloadFileFilter(),
+            "watch_filter": AutoreloadFileFilter(
+                base_path=Path(project_path) if project_path else None,
+            ),
         }
         viz_process = process_context.Process(
             target=run_process,

--- a/package/kedro_viz/server.py
+++ b/package/kedro_viz/server.py
@@ -155,7 +155,7 @@ if __name__ == "__main__":  # pragma: no cover
             "port": args.port,
             "project_path": str(project_path),
         },
-        "watch_filter": AutoreloadFileFilter(),
+        "watch_filter": AutoreloadFileFilter(base_path=project_path),
     }
 
     process_context = multiprocessing.get_context("spawn")

--- a/package/tests/test_autoreload_file_filter.py
+++ b/package/tests/test_autoreload_file_filter.py
@@ -139,3 +139,31 @@ def test_filtered_out_by_default_filter(file_filter, tmp_path, mocker):
 
     result = file_filter(Change.modified, str(filtered_file))
     assert not result, "File should be filtered out by DefaultFilter"
+
+
+def test_ignored_notebooks_folder(tmp_path):
+    """
+    Test that files under the notebooks folder do not pass the filter.
+    """
+    notebooks_dir = tmp_path / "notebooks"
+    notebooks_dir.mkdir()
+    notebook_file = notebooks_dir / "experiment.py"
+    notebook_file.touch()
+
+    file_filter = AutoreloadFileFilter(base_path=tmp_path)
+
+    result = file_filter(Change.modified, str(notebook_file))
+    assert not result, "Files under notebooks/ should not pass the filter"
+
+
+def test_allowed_file_outside_notebooks_folder(tmp_path):
+    """
+    Test that files outside the notebooks folder still pass the filter.
+    """
+    pipeline_file = tmp_path / "pipeline.py"
+    pipeline_file.touch()
+
+    file_filter = AutoreloadFileFilter(base_path=tmp_path)
+
+    result = file_filter(Change.modified, str(pipeline_file))
+    assert result, "Files outside notebooks/ should pass the filter"


### PR DESCRIPTION
## Description

Resolves https://github.com/kedro-org/kedro-viz/issues/2597

## Development notes

- Extend `AutoreloadFileFilter` to add `ignore_patterns` when considering reload
- Updated tests

## QA notes

- All tests should pass

**Manual testing:**
- Install dependencies and build -

```bash
pip install -r package/test_requirements.txt -r demo-project/src/docker_requirements.txt
make build
pip install -e package/
```

- Run kedro viz with autoreload

```bash
cd `demo-project`
kedro viz run --autoreload --port 4141
```

- Then in another terminal:

```bash
# Should NOT restart the server
touch demo-project/notebooks/experiment.py
# SHOULD restart the server
touch demo-project/src/spaceflights/pipeline.py
```

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [x] Added new entries to the `RELEASE.md` file
- [x] Added tests to cover my changes
