### PR TITLE
Clean up CODEOWNERS.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,5 @@
+*                    @Huongg
+
 # Frontend
 *.js                 @Huongg @jitu5
 *.json               @Huongg @jitu5

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,26 +1,14 @@
-*                                       @rashidakanchwala
+# Frontend
+*.js                 @Huongg @jitu5
+*.json               @Huongg @jitu5
+*.scss               @Huongg @jitu5
+*.css                @Huongg @jitu5
 
-src/                                    @rashidakanchwala
-public/                                 @rashidakanchwala
-tools/                                  @rashidakanchwala
-package/                                @rashidakanchwala
+# Backend
+*.py                 @Huongg @ravi-kumar-pilla
+package/             @Huongg @ravi-kumar-pilla
 
-Makefile                                @rashidakanchwala
-.circleci/                              @rashidakanchwala
-
-*.js                                    @rashidakanchwala @jitu5
-*.json                                  @rashidakanchwala @jitu5
-*.scss                                  @rashidakanchwala @jitu5
-*.py                                    @rashidakanchwala @ravi-kumar-pilla
-*.md                                    @rashidakanchwala
-
-.babelrc                                @rashidakanchwala
-.eslintrc.json                          @rashidakanchwala
-.prettierrc                             @rashidakanchwala
-.gitignore                              @rashidakanchwala
-CODEOWNERS                              @rashidakanchwala
-CONTRIBUTING.md                         @rashidakanchwala
-README.md                               @rashidakanchwala
-RELEASE.md                              @rashidakanchwala
-legal_header.txt                        @rashidakanchwala
-LICENSE.md                              @rashidakanchwala
+# CI / release
+.github/workflows/   @Huongg @jitu5 @ravi-kumar-pilla
+Makefile             @Huongg @jitu5 @ravi-kumar-pilla
+RELEASE.md           @Huongg @jitu5 @ravi-kumar-pilla


### PR DESCRIPTION
## Description

- Tidies up `.github/CODEOWNERS`: removes stale paths (`.babelrc`, `.circleci/`, `.eslintrc.json`, `legal_header.txt`, etc.)
- replaces `@rashidakanchwala` with `@Huongg`
- groups the remaining rules by area (frontend, backend, CI/release).


## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro-viz/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Updated `RELEASE.md` with a description of this change
- [ ] Added tests to cover my changes
