### PR TITLE
Enhance GitHub Actions workflows with concurrency settings and branch filter

### DIFF
--- a/.github/workflows/build-backend.yml
+++ b/.github/workflows/build-backend.yml
@@ -4,6 +4,8 @@ name: Build backend
 
 on:
   push:
+    branches:
+      - main
     paths:
       - 'package/**'
       - '.github/**'
@@ -12,6 +14,10 @@ on:
       - 'package/**'
       - '.github/**'
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/.github/workflows/docs-checks.yml
+++ b/.github/workflows/docs-checks.yml
@@ -5,6 +5,15 @@ on:
     paths:
       - "docs/**"
       - '**.md'
+      - '.github/styles/**'
+      - '.github/workflows/docs-checks.yml'
+      - 'Makefile'
+      - 'mkdocs.yml'
+      - 'package/pyproject.toml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/.github/workflows/docs-linkcheck.yml
+++ b/.github/workflows/docs-linkcheck.yml
@@ -4,10 +4,27 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'docs/**'
+      - '**.md'
+      - 'Makefile'
+      - 'mkdocs.yml'
+      - 'package/pyproject.toml'
+      - '.github/workflows/docs-linkcheck.yml'
   pull_request:
     branches:
       - main
+    paths:
+      - 'docs/**'
+      - '**.md'
+      - 'Makefile'
+      - 'mkdocs.yml'
+      - 'package/pyproject.toml'
+      - '.github/workflows/docs-linkcheck.yml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/.github/workflows/docs-only-checks.yml
+++ b/.github/workflows/docs-only-checks.yml
@@ -7,12 +7,18 @@ on:
     paths:
       - "docs/**"
       - '**.md'
+      - '.github/workflows/docs-only-checks.yml'
   pull_request:
     branches:
       - main
     paths:
       - "docs/**"
       - '**.md'
+      - '.github/workflows/docs-only-checks.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/.github/workflows/javascript-lint-and-tests.yml
+++ b/.github/workflows/javascript-lint-and-tests.yml
@@ -4,13 +4,25 @@ name: Run javascript linters and tests on Kedro-Viz
 
 on:
   push:
+    branches:
+      - main
     paths-ignore:
       - 'package/**'
+      - 'docs/**'
+      - 'openspec/**'
+      - '**.md'
   pull_request:
     paths-ignore:
       - 'package/**'
+      - 'docs/**'
+      - 'openspec/**'
+      - '**.md'
   workflow_dispatch:
   workflow_call:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/.github/workflows/merge-gatekeeper.yml
+++ b/.github/workflows/merge-gatekeeper.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   TIMEOUT: 3600
   INTERVAL: 30


### PR DESCRIPTION
Resolves https://github.com/kedro-org/kedro-viz/issues/2734 

## Description

Reduce unnecessary GitHub Actions runs and prevent outdated PR checks from consuming CI resources.

Previously, backend and JavaScript workflows could run twice for the same commit: once for `push` and once for `pull_request`.

## Development notes

- Restricted backend and JavaScript `push` workflows to `main`.
- Kept pull request checks available for PRs targeting intermediate branches.
- Added concurrency rules to cancel outdated runs for the same PR.
- Added documentation-specific path filters.
- Prevented JavaScript checks from running for Python package, documentation, Markdown, and OpenSpec-only changes.

## QA notes

- Validated the modified workflow files as YAML.
- Verified representative path-filter scenarios.
- Ran `git diff --check`.
- Confirmed that different PRs and workflows use separate concurrency groups.

## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a Draft Pull Request if it is work-in-progress
- [x] Documentation changes are not required
- [x] Release notes are not required
- [x] Workflow configuration changes were validated