### PR TITLE
Serve `/api/main` and `/api/pipelines/{id}` from the inspection snapshot

### DIFF
--- a/package/kedro_viz/api/apps.py
+++ b/package/kedro_viz/api/apps.py
@@ -18,7 +18,9 @@ from werkzeug.utils import secure_filename
 from kedro_viz import __version__
 from kedro_viz.api.rest.responses.utils import EnhancedORJSONResponse
 from kedro_viz.integrations.kedro import telemetry as kedro_telemetry
+from kedro_viz.integrations.kedro.inspection import VizProjectContext
 
+from .rest.router import create_graph_router
 from .rest.router import router as rest_router
 
 _HTML_DIR = Path(__file__).parent.parent.absolute() / "html"
@@ -50,18 +52,24 @@ def _create_base_api_app() -> FastAPI:
 
 
 def create_api_app_from_project(
-    project_path: Path, autoreload: bool = False
+    context: VizProjectContext,
+    project_path: Path,
+    autoreload: bool = False,
 ) -> FastAPI:
     """Create an API from a real Kedro project by adding the router to the FastAPI app.
 
     Args:
-        project_path: Path to the Kedro project
+        context: Project-scoped services built from the inspection snapshot and enrichment
+            sources.
+        project_path: Path to the Kedro project.
         autoreload: Whether the app should autoreload based on content change
-            in the Kedro project
+            in the Kedro project.
+
     Returns:
-        The FastAPI app
+        The FastAPI app.
     """
     app = _create_base_api_app()
+    app.include_router(create_graph_router(context))
     app.include_router(rest_router)
 
     # Check for html directory existence.

--- a/package/kedro_viz/api/rest/router.py
+++ b/package/kedro_viz/api/rest/router.py
@@ -1,6 +1,9 @@
 """`kedro_viz.api.rest.router` defines REST routes and handling logic."""
 
+from __future__ import annotations
+
 import logging
+from typing import TYPE_CHECKING
 
 from fastapi import APIRouter
 from fastapi.responses import JSONResponse
@@ -15,10 +18,7 @@ from kedro_viz.api.rest.responses.nodes import (
     NodeMetadataAPIResponse,
     get_node_metadata_response,
 )
-from kedro_viz.api.rest.responses.pipelines import (
-    GraphAPIResponse,
-    get_pipeline_response,
-)
+from kedro_viz.api.rest.responses.pipelines import GraphAPIResponse
 from kedro_viz.api.rest.responses.run_events import (
     RunStatusAPIResponse,
     get_run_status_response,
@@ -27,6 +27,10 @@ from kedro_viz.api.rest.responses.version import (
     VersionAPIResponse,
     get_version_response,
 )
+from kedro_viz.integrations.kedro.inspection import PipelineNotFoundError
+
+if TYPE_CHECKING:
+    from kedro_viz.integrations.kedro.inspection import VizProjectContext
 
 logger = logging.getLogger(__name__)
 
@@ -36,9 +40,32 @@ router = APIRouter(
 )
 
 
-@router.get("/main", response_model=GraphAPIResponse)
-async def main():
-    return get_pipeline_response()
+def create_graph_router(context: VizProjectContext) -> APIRouter:
+    """Bind the graph routes to one project context."""
+    graph_router = APIRouter(
+        prefix="/api",
+        responses={404: {"model": APINotFoundResponse}},
+    )
+
+    @graph_router.get("/main", response_model=GraphAPIResponse)
+    async def main():
+        # With no caller-supplied ID, the service selects from its own registered pipelines,
+        # so PipelineNotFoundError cannot occur here.
+        return context.graph.get_pipeline_response()
+
+    @graph_router.get(
+        "/pipelines/{registered_pipeline_id}",
+        response_model=GraphAPIResponse,
+    )
+    async def get_single_pipeline_data(registered_pipeline_id: str):
+        try:
+            return context.graph.get_pipeline_response(registered_pipeline_id)
+        except PipelineNotFoundError:
+            return JSONResponse(
+                status_code=404, content={"message": "Invalid pipeline ID"}
+            )
+
+    return graph_router
 
 
 @router.get(
@@ -48,14 +75,6 @@ async def main():
 )
 async def get_single_node_metadata(node_id: str):
     return get_node_metadata_response(node_id)
-
-
-@router.get(
-    "/pipelines/{registered_pipeline_id}",
-    response_model=GraphAPIResponse,
-)
-async def get_single_pipeline_data(registered_pipeline_id: str):
-    return get_pipeline_response(registered_pipeline_id)
 
 
 @router.get(

--- a/package/kedro_viz/integrations/kedro/inspection/__init__.py
+++ b/package/kedro_viz/integrations/kedro/inspection/__init__.py
@@ -1,8 +1,17 @@
-"""Kedro inspection snapshot adapter for Kedro-Viz.
+"""Build project-scoped Kedro-Viz services from inspection snapshots."""
 
-Converts a Kedro project inspection snapshot into a graph response.
-"""
-
+from kedro_viz.integrations.kedro.inspection.context import VizProjectContext
+from kedro_viz.integrations.kedro.inspection.enrichment import EnrichmentSources
 from kedro_viz.integrations.kedro.inspection.graph_builder import GraphBuilder
+from kedro_viz.integrations.kedro.inspection.graph_service import (
+    InspectionGraphService,
+    PipelineNotFoundError,
+)
 
-__all__ = ["GraphBuilder"]
+__all__ = [
+    "EnrichmentSources",
+    "GraphBuilder",
+    "InspectionGraphService",
+    "PipelineNotFoundError",
+    "VizProjectContext",
+]

--- a/package/kedro_viz/integrations/kedro/inspection/context.py
+++ b/package/kedro_viz/integrations/kedro/inspection/context.py
@@ -1,0 +1,60 @@
+"""Project-scoped services passed explicitly to Kedro-Viz consumers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from kedro_viz.integrations.kedro.inspection.enrichment import EnrichmentSources
+from kedro_viz.integrations.kedro.inspection.graph_service import (
+    InspectionGraphService,
+)
+
+
+class VizProjectContext:
+    """Services prepared for one Kedro project load."""
+
+    def __init__(self, graph: InspectionGraphService) -> None:
+        self.graph = graph
+
+    @classmethod
+    def from_project(
+        cls,
+        project_path: str | Path,
+        *,
+        env: str | None = None,
+        pipeline_name: str | None = None,
+        runtime_params: dict[str, Any] | None = None,
+        package_name: str | None = None,
+        is_lite: bool = False,
+        enrichment: EnrichmentSources | None = None,
+    ) -> VizProjectContext:
+        """Build project-scoped services from one inspection snapshot.
+
+        Args:
+            project_path: The Kedro project root.
+            env: The Kedro environment, honouring ``--env``.
+            pipeline_name: Restrict the context to one registered pipeline, honouring
+                ``--pipeline``.
+            runtime_params: Typed parameter overrides from ``--params``.
+            package_name: Project package used to identify imports in lite mode.
+            is_lite: Whether missing project dependencies should be temporarily mocked.
+            enrichment: Explicit fields supplied by the transitional live load.
+
+        Returns:
+            A project context containing the prepared inspection graph service.
+
+        Raises:
+            PipelineNotFoundError: If ``pipeline_name`` is not registered.
+        """
+        return cls(
+            graph=InspectionGraphService.from_project(
+                project_path,
+                env=env,
+                pipeline_name=pipeline_name,
+                runtime_params=runtime_params,
+                package_name=package_name,
+                is_lite=is_lite,
+                enrichment=enrichment,
+            )
+        )

--- a/package/kedro_viz/integrations/kedro/inspection/enrichment.py
+++ b/package/kedro_viz/integrations/kedro/inspection/enrichment.py
@@ -1,0 +1,77 @@
+"""Add live-only fields to graph responses without changing their structure."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+
+from pydantic import BaseModel, Field, field_validator
+
+from kedro_viz.api.rest.responses.pipelines import (
+    DataNodeAPIResponse,
+    GraphAPIResponse,
+    NodeExtrasAPIResponse,
+)
+from kedro_viz.models.flowchart.nodes import DataNode, GraphNode
+from kedro_viz.models.metadata import NodeExtras
+
+
+class EnrichmentSources(BaseModel, frozen=True):
+    """Fields copied from the transitional live load, keyed by existing node IDs.
+
+    The IDs come from the already-built live nodes rather than being recalculated here. This
+    keeps enrichment independent of graph construction while the live backend remains available.
+    """
+
+    node_extras_by_node_id: Mapping[str, NodeExtras] = Field(default_factory=dict)
+    dataset_type_by_node_id: Mapping[str, str | None] = Field(default_factory=dict)
+    layer_by_dataset: Mapping[str, str] | None = None
+
+    @field_validator(
+        "node_extras_by_node_id",
+        "dataset_type_by_node_id",
+        "layer_by_dataset",
+        mode="before",
+    )
+    @classmethod
+    def _copy_mapping(cls, value: Mapping | None) -> dict | None:
+        """Copy caller-owned mappings before storing them on the prepared model."""
+        return None if value is None else dict(value)
+
+    @classmethod
+    def from_live_nodes(
+        cls,
+        nodes: Iterable[GraphNode],
+        *,
+        layer_by_dataset: Mapping[str, str] | None = None,
+    ) -> EnrichmentSources:
+        """Copy the fields needed by the inspection graph from already-built live nodes."""
+        node_extras_by_node_id: dict[str, NodeExtras] = {}
+        dataset_type_by_node_id: dict[str, str | None] = {}
+        for node in nodes:
+            if node.node_extras is not None:
+                node_extras_by_node_id[node.id] = node.node_extras
+            if isinstance(node, DataNode):
+                dataset_type_by_node_id[node.id] = node.dataset_type
+        return cls(
+            node_extras_by_node_id=node_extras_by_node_id,
+            dataset_type_by_node_id=dataset_type_by_node_id,
+            layer_by_dataset=layer_by_dataset,
+        )
+
+
+def enrich_graph_response(
+    response: GraphAPIResponse, sources: EnrichmentSources
+) -> None:
+    """Mutate live-only response fields without adding, removing or renaming nodes."""
+    for node in response.nodes:
+        node_extras = sources.node_extras_by_node_id.get(node.id)
+        if node_extras is not None:
+            node.node_extras = NodeExtrasAPIResponse(
+                stats=node_extras.stats,
+                styles=node_extras.styles,
+            )
+        if (
+            isinstance(node, DataNodeAPIResponse)
+            and node.id in sources.dataset_type_by_node_id
+        ):
+            node.dataset_type = sources.dataset_type_by_node_id[node.id]

--- a/package/kedro_viz/integrations/kedro/inspection/graph_builder.py
+++ b/package/kedro_viz/integrations/kedro/inspection/graph_builder.py
@@ -11,6 +11,7 @@ use raw catalog type strings from the snapshot.
 from __future__ import annotations
 
 from collections import defaultdict
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any
 
 from kedro_viz.api.rest.responses.pipelines import (
@@ -99,18 +100,26 @@ class GraphBuilder:
 
     Renders nodes and edges for one selected pipeline. Tags and registered
     pipelines on each node are collected across every pipeline in the project.
+    An explicit layer mapping replaces the raw catalog config, because it is read from the
+    populated catalog and so reflects any layer a project hook added, changed or removed.
     """
 
     def __init__(
         self,
         snapshot: ProjectSnapshot,
         catalog_config: dict[str, Any] | None = None,
+        *,
         parameters: dict[str, Any] | None = None,
+        layer_by_dataset: Mapping[str, str] | None = None,
     ) -> None:
         self._snapshot = snapshot
-        self._layer_by_dataset = _extract_layers(
-            catalog_config=catalog_config or {},
-            dataset_names=_dataset_names_from_snapshot(snapshot),
+        self._layer_by_dataset = (
+            dict(layer_by_dataset)
+            if layer_by_dataset is not None
+            else _extract_layers(
+                catalog_config=catalog_config or {},
+                dataset_names=_dataset_names_from_snapshot(snapshot),
+            )
         )
         # Resolved parameter values (``--params`` already applied), used to fill task-node
         # ``parameters`` in the format the detail panel expects. Empty when values aren't loaded.

--- a/package/kedro_viz/integrations/kedro/inspection/graph_service.py
+++ b/package/kedro_viz/integrations/kedro/inspection/graph_service.py
@@ -1,0 +1,124 @@
+"""Serve graph responses from one Kedro inspection snapshot."""
+
+from __future__ import annotations
+
+import dataclasses
+from contextlib import nullcontext
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from kedro_viz.api.rest.responses.pipelines import GraphAPIResponse
+from kedro_viz.integrations.kedro.inspection.enrichment import (
+    EnrichmentSources,
+    enrich_graph_response,
+)
+from kedro_viz.integrations.kedro.inspection.graph_builder import GraphBuilder
+from kedro_viz.integrations.kedro.inspection.snapshot_source import (
+    _InspectionSession,
+    lite_import_stubs,
+)
+
+if TYPE_CHECKING:
+    from kedro.inspection.models import ProjectSnapshot
+
+
+class PipelineNotFoundError(ValueError):
+    """Raised when a requested pipeline is not present in the inspection snapshot."""
+
+
+class InspectionGraphService:
+    """Build graph responses from one prepared inspection snapshot."""
+
+    def __init__(
+        self,
+        builder: GraphBuilder,
+        enrichment: EnrichmentSources | None = None,
+    ) -> None:
+        self._builder = builder
+        self._enrichment = enrichment if enrichment is not None else EnrichmentSources()
+
+    @classmethod
+    def from_project(
+        cls,
+        project_path: str | Path,
+        *,
+        env: str | None = None,
+        pipeline_name: str | None = None,
+        runtime_params: dict[str, Any] | None = None,
+        package_name: str | None = None,
+        is_lite: bool = False,
+        enrichment: EnrichmentSources | None = None,
+    ) -> InspectionGraphService:
+        """Read one project snapshot and prepare the graph service.
+
+        Args:
+            project_path: The Kedro project root.
+            env: The Kedro environment, honouring ``--env``.
+            pipeline_name: Restrict the view to one registered pipeline, honouring
+                ``--pipeline``.
+            runtime_params: Typed parameter overrides from ``--params``.
+            package_name: Project package used to identify imports in lite mode.
+            is_lite: Whether missing project dependencies should be temporarily mocked.
+            enrichment: Explicit fields supplied by the transitional live load.
+
+        Raises:
+            PipelineNotFoundError: If ``pipeline_name`` is not registered.
+        """
+        sources = enrichment if enrichment is not None else EnrichmentSources()
+        import_context = (
+            lite_import_stubs(project_path, package_name) if is_lite else nullcontext()
+        )
+        with import_context:
+            session = _InspectionSession(
+                project_path, env=env, runtime_params=runtime_params
+            )
+            snapshot = session.snapshot()
+            catalog_config = session.catalog_config()
+            parameters = session.parameters()
+            if pipeline_name is not None:
+                snapshot = cls._filter_to_pipeline(snapshot, pipeline_name)
+            builder = GraphBuilder(
+                snapshot,
+                catalog_config,
+                parameters=parameters,
+                layer_by_dataset=sources.layer_by_dataset,
+            )
+        return cls(builder, sources)
+
+    def get_pipeline_response(self, pipeline_id: str | None = None) -> GraphAPIResponse:
+        """Return the graph for one registered pipeline.
+
+        Raises:
+            PipelineNotFoundError: If ``pipeline_id`` is not registered.
+        """
+        selected_pipeline_id = (
+            self._builder.default_pipeline_id() if pipeline_id is None else pipeline_id
+        )
+        if not self._builder.has_pipeline(selected_pipeline_id):
+            raise PipelineNotFoundError(
+                f"Invalid pipeline ID: {selected_pipeline_id!r}"
+            )
+        response = self._builder.build(selected_pipeline_id)
+        enrich_graph_response(response, self._enrichment)
+        return response
+
+    @staticmethod
+    def _filter_to_pipeline(
+        snapshot: ProjectSnapshot, pipeline_name: str
+    ) -> ProjectSnapshot:
+        """Return a copy of the snapshot containing only the requested pipeline.
+
+        Raises:
+            PipelineNotFoundError: If ``pipeline_name`` is not registered.
+        """
+        matching = [
+            pipeline
+            for pipeline in snapshot.pipelines
+            if pipeline.name == pipeline_name
+        ]
+        if not matching:
+            available = sorted(pipeline.name for pipeline in snapshot.pipelines)
+            raise PipelineNotFoundError(
+                f"Pipeline {pipeline_name!r} not found in snapshot; available: {available}"
+            )
+        return dataclasses.replace(snapshot, pipelines=matching)

--- a/package/kedro_viz/integrations/kedro/inspection/modular_pipelines/boundaries.py
+++ b/package/kedro_viz/integrations/kedro/inspection/modular_pipelines/boundaries.py
@@ -9,8 +9,9 @@ See ``kedro.pipeline.pipeline`` for the source of truth.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 from typing import TYPE_CHECKING
+
+from pydantic import BaseModel
 
 from kedro_viz.constants import ROOT_MODULAR_PIPELINE_ID
 from kedro_viz.utils import _strip_transcoding
@@ -111,8 +112,7 @@ def _free_io(nodes: list[NodeSnapshot], mp_id: str) -> _BoundaryIO:
     return free_inputs, free_outputs
 
 
-@dataclass(frozen=True)
-class _NamespaceBoundaries:
+class _NamespaceBoundaries(BaseModel, frozen=True):
     """Namespace IDs, dataset assignments and boundary I/O for one node list.
 
     Dataset assignments use transcoding-stripped names; boundary I/O keeps original names.

--- a/package/kedro_viz/integrations/kedro/inspection/modular_pipelines/tree.py
+++ b/package/kedro_viz/integrations/kedro/inspection/modular_pipelines/tree.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
+
+from pydantic import BaseModel, Field
 
 from kedro_viz.api.rest.responses.pipelines import (
     ModularPipelineChildAPIResponse,
@@ -24,8 +25,7 @@ if TYPE_CHECKING:
     from kedro.inspection.models import NodeSnapshot
 
 
-@dataclass
-class _ModularPipelineTreeEntry:
+class _ModularPipelineTreeEntry(BaseModel):
     """One node in the modular-pipeline tree.
 
     ``name`` and the modular-pipeline IDs are namespace strings; dataset and task IDs in
@@ -33,9 +33,9 @@ class _ModularPipelineTreeEntry:
     """
 
     name: str
-    inputs: set[str] = field(default_factory=set)
-    outputs: set[str] = field(default_factory=set)
-    children: set[tuple[str, str]] = field(default_factory=set)  # (node_id, node_type)
+    inputs: set[str] = Field(default_factory=set)
+    outputs: set[str] = Field(default_factory=set)
+    children: set[tuple[str, str]] = Field(default_factory=set)  # (node_id, node_type)
 
 
 class _ModularPipelineTreeBuilder:
@@ -61,7 +61,7 @@ class _ModularPipelineTreeBuilder:
         Parameter references are tracked separately so they remain parameter children under
         ``__root__`` instead of being added as data children inside modular pipelines.
         """
-        root = _ModularPipelineTreeEntry(ROOT_MODULAR_PIPELINE_ID)
+        root = _ModularPipelineTreeEntry(name=ROOT_MODULAR_PIPELINE_ID)
         tree = {ROOT_MODULAR_PIPELINE_ID: root}
         params: set[str] = set()
 
@@ -78,7 +78,8 @@ class _ModularPipelineTreeBuilder:
         params: set[str],
     ) -> None:
         """Populate one entry, record its boundary parameters and link it to its parent."""
-        entry = tree.setdefault(mp_id, _ModularPipelineTreeEntry(mp_id))
+        entry = _ModularPipelineTreeEntry(name=mp_id)
+        tree[mp_id] = entry
         free_inputs, free_outputs = self._boundary_io_by_modular_pipeline[mp_id]
         entry.inputs = {_create_dataset_node_id(d) for d in free_inputs}
         entry.outputs = {_create_dataset_node_id(d) for d in free_outputs}
@@ -138,7 +139,7 @@ class _ModularPipelineTreeBuilder:
         parent_id = (
             mp_id.rsplit(".", 1)[0] if "." in mp_id else ROOT_MODULAR_PIPELINE_ID
         )
-        parent = tree.setdefault(parent_id, _ModularPipelineTreeEntry(parent_id))
+        parent = tree[parent_id]
         parent.children.add((mp_id, GraphNodeType.MODULAR_PIPELINE.value))
         for dataset_id in boundary:
             if (

--- a/package/kedro_viz/integrations/kedro/inspection/snapshot_source.py
+++ b/package/kedro_viz/integrations/kedro/inspection/snapshot_source.py
@@ -50,9 +50,9 @@ def lite_import_stubs(
 class _InspectionSession:
     """Read a project's snapshot and config, bootstrapping and building the loader once.
 
-    Create one session per request. The project is bootstrapped and the Kedro config loader is built
-    lazily on first use and then cached, so the catalog config and parameters reuse a single loader
-    instead of rebuilding it.
+    Create one session per adapter build. The project is bootstrapped and the Kedro config loader
+    is built lazily on first use and then cached, so the catalog config and parameters reuse a
+    single loader instead of rebuilding it.
     """
 
     def __init__(

--- a/package/kedro_viz/server.py
+++ b/package/kedro_viz/server.py
@@ -43,7 +43,7 @@ def populate_data(
     data_access_manager.add_pipelines(pipelines)
 
 
-def _load_and_populate_project_data(
+def load_and_populate_data(
     path: Path,
     env: Optional[str] = None,
     include_hooks: bool = False,
@@ -52,7 +52,11 @@ def _load_and_populate_project_data(
     extra_params: Optional[Dict[str, Any]] = None,
     is_lite: bool = False,
 ) -> DataAccessManager:
-    """Load one project and populate the transitional live repositories."""
+    """Load a project and return the populated legacy repositories.
+
+    VSCode and deployment call this entry point and ignore its return value. The HTTP
+    server uses the returned repositories to build its project-scoped inspection context.
+    """
 
     # Loads data from underlying Kedro Project
     catalog, pipelines, node_extras_dict = kedro_data_loader.load_data(
@@ -68,31 +72,6 @@ def _load_and_populate_project_data(
     # Creates data repositories which are used by Kedro Viz Backend APIs
     populate_data(data_access_manager, catalog, pipelines, node_extras_dict)
     return data_access_manager
-
-
-def load_and_populate_data(
-    path: Path,
-    env: Optional[str] = None,
-    include_hooks: bool = False,
-    package_name: Optional[str] = None,
-    pipeline_name: Optional[str] = None,
-    extra_params: Optional[Dict[str, Any]] = None,
-    is_lite: bool = False,
-) -> None:
-    """Load a project and populate the legacy repositories.
-
-    VSCode and deployment call this compatibility entry point directly. Project-scoped
-    inspection services are created only by their own entry points.
-    """
-    _load_and_populate_project_data(
-        path,
-        env,
-        include_hooks,
-        package_name,
-        pipeline_name,
-        extra_params,
-        is_lite,
-    )
 
 
 def _create_viz_project_context(
@@ -198,7 +177,7 @@ def run_server(
     path = Path(project_path) if project_path else Path.cwd()
 
     if load_file is None:
-        live_data = _load_and_populate_project_data(
+        live_data = load_and_populate_data(
             path, env, include_hooks, package_name, pipeline_name, extra_params, is_lite
         )
         # Copy enrichment from the transitional live repositories into the project-scoped

--- a/package/kedro_viz/server.py
+++ b/package/kedro_viz/server.py
@@ -1,6 +1,7 @@
 """`kedro_viz.server` provides utilities to launch a webserver
 for Kedro pipeline visualisation."""
 
+import logging
 from pathlib import Path
 from typing import Any, Dict, Optional
 
@@ -11,8 +12,14 @@ from kedro_viz.autoreload_file_filter import AutoreloadFileFilter
 from kedro_viz.constants import DEFAULT_HOST, DEFAULT_PORT
 from kedro_viz.data_access import DataAccessManager, data_access_manager
 from kedro_viz.integrations.kedro import data_loader as kedro_data_loader
+from kedro_viz.integrations.kedro.inspection import (
+    EnrichmentSources,
+    VizProjectContext,
+)
 from kedro_viz.launchers.utils import _check_viz_up, _wait_for, display_cli_message
 from kedro_viz.models.metadata import NodeExtras
+
+logger = logging.getLogger(__name__)
 
 DEV_PORT = 4142
 
@@ -36,7 +43,7 @@ def populate_data(
     data_access_manager.add_pipelines(pipelines)
 
 
-def load_and_populate_data(
+def _load_and_populate_project_data(
     path: Path,
     env: Optional[str] = None,
     include_hooks: bool = False,
@@ -44,8 +51,8 @@ def load_and_populate_data(
     pipeline_name: Optional[str] = None,
     extra_params: Optional[Dict[str, Any]] = None,
     is_lite: bool = False,
-):
-    """Loads underlying Kedro project data and populates Kedro Viz Repositories"""
+) -> DataAccessManager:
+    """Load one project and populate the transitional live repositories."""
 
     # Loads data from underlying Kedro Project
     catalog, pipelines, node_extras_dict = kedro_data_loader.load_data(
@@ -60,6 +67,87 @@ def load_and_populate_data(
 
     # Creates data repositories which are used by Kedro Viz Backend APIs
     populate_data(data_access_manager, catalog, pipelines, node_extras_dict)
+    return data_access_manager
+
+
+def load_and_populate_data(
+    path: Path,
+    env: Optional[str] = None,
+    include_hooks: bool = False,
+    package_name: Optional[str] = None,
+    pipeline_name: Optional[str] = None,
+    extra_params: Optional[Dict[str, Any]] = None,
+    is_lite: bool = False,
+) -> None:
+    """Load a project and populate the legacy repositories.
+
+    VSCode and deployment call this compatibility entry point directly. Project-scoped
+    inspection services are created only by their own entry points.
+    """
+    _load_and_populate_project_data(
+        path,
+        env,
+        include_hooks,
+        package_name,
+        pipeline_name,
+        extra_params,
+        is_lite,
+    )
+
+
+def _create_viz_project_context(
+    path: Path,
+    live_data: DataAccessManager,
+    *,
+    env: Optional[str] = None,
+    pipeline_name: Optional[str] = None,
+    extra_params: Optional[Dict[str, Any]] = None,
+    package_name: Optional[str] = None,
+    is_lite: bool = False,
+    include_hooks: bool = False,
+) -> VizProjectContext:
+    """Create the explicit context used by the HTTP graph routes.
+
+    Args:
+        path: The Kedro project root.
+        live_data: Repositories populated by the transitional live load.
+        env: The Kedro environment, honouring ``--env``.
+        pipeline_name: Restrict the view to one registered pipeline, honouring ``--pipeline``.
+        extra_params: Typed parameter overrides from ``--params``.
+        package_name: The Kedro project package, used to identify project imports in lite mode.
+        is_lite: Whether to mock missing project dependencies while building the snapshot.
+        include_hooks: Whether hook-modified layers should replace raw catalog layers.
+
+    Raises:
+        Exception: If the inspection context cannot be constructed.
+    """
+    try:
+        # A hook can add, change or remove layer metadata, and only the populated catalog
+        # reflects that, so with hooks the builder reads layers from there instead of the
+        # raw catalog config.
+        layer_by_dataset = (
+            dict(live_data.catalog.layers_mapping) if include_hooks else None
+        )
+        enrichment = EnrichmentSources.from_live_nodes(
+            live_data.nodes.as_list(),
+            layer_by_dataset=layer_by_dataset,
+        )
+        return VizProjectContext.from_project(
+            path,
+            env=env,
+            pipeline_name=pipeline_name,
+            runtime_params=extra_params,
+            package_name=package_name,
+            is_lite=is_lite,
+            enrichment=enrichment,
+        )
+    # Context construction is an all-or-nothing startup requirement. Log and propagate every
+    # failure rather than serving an app whose graph routes cannot work.
+    except Exception:
+        logger.exception(
+            "Could not build the Kedro inspection context, so the graph cannot be served."
+        )
+        raise
 
 
 def run_server(
@@ -110,11 +198,26 @@ def run_server(
     path = Path(project_path) if project_path else Path.cwd()
 
     if load_file is None:
-        load_and_populate_data(
+        live_data = _load_and_populate_project_data(
             path, env, include_hooks, package_name, pipeline_name, extra_params, is_lite
         )
+        # Copy enrichment from the transitional live repositories into the project-scoped
+        # context. The graph service keeps no reference to the global repositories.
+        context = _create_viz_project_context(
+            path,
+            live_data,
+            env=env,
+            pipeline_name=pipeline_name,
+            extra_params=extra_params,
+            package_name=package_name,
+            is_lite=is_lite,
+            include_hooks=include_hooks,
+        )
+
         # [TODO: As we can do this with `kedro viz build`,
         # we need to shift this feature outside of kedro viz run]
+        # TODO(#2660): make ``--save-file`` and ``kedro viz build`` use the project
+        # context so static exports match the HTTP graph responses.
         if save_file:
             from kedro_viz.api.rest.responses.save_responses import (
                 save_api_responses_to_fs,
@@ -122,7 +225,7 @@ def run_server(
 
             save_api_responses_to_fs(save_file, fsspec.filesystem("file"), True)
 
-        app = apps.create_api_app_from_project(path, autoreload)
+        app = apps.create_api_app_from_project(context, path, autoreload)
     else:
         app = apps.create_api_app_from_file(f"{path}/{load_file}/api")
 

--- a/package/tests/conftest.py
+++ b/package/tests/conftest.py
@@ -1,6 +1,6 @@
 import json
 from pathlib import Path
-from typing import Dict
+from typing import Dict, cast
 from unittest import mock
 
 import pandas as pd
@@ -13,11 +13,16 @@ from kedro_datasets.pandas import CSVDataset
 from pydantic import BaseModel
 
 from kedro_viz.api import apps
+from kedro_viz.api.rest.responses.pipelines import get_pipeline_response
 from kedro_viz.data_access import DataAccessManager
 from kedro_viz.data_access.repositories.modular_pipelines import (
     ModularPipelinesRepository,
 )
 from kedro_viz.integrations.kedro.hooks import DatasetStatsHook
+from kedro_viz.integrations.kedro.inspection import (
+    InspectionGraphService,
+    VizProjectContext,
+)
 from kedro_viz.models.flowchart.node_metadata import DataNodeMetadata
 from kedro_viz.models.flowchart.nodes import GraphNode
 from kedro_viz.models.metadata import NodeExtras
@@ -497,14 +502,36 @@ def example_transcoded_catalog():
 
 
 @pytest.fixture
+def repository_project_context() -> VizProjectContext:
+    """Provide graph services backed by the repositories these tests build.
+
+    These tests populate ``data_access_manager`` with synthetic pipelines rather than a Kedro
+    project, so the inspection graph service cannot be built for them. This context keeps them
+    exercising routing and response shape; the adapter itself is covered in
+    ``test_inspection_adapter``.
+
+    Transitional: it goes away with the live backend (#2724).
+    """
+
+    class _RepositoryBackedGraphService:
+        def get_pipeline_response(self, pipeline_id=None):
+            return get_pipeline_response(pipeline_id)
+
+    return VizProjectContext(
+        graph=cast(InspectionGraphService, _RepositoryBackedGraphService())
+    )
+
+
+@pytest.fixture
 def example_api(
     data_access_manager: DataAccessManager,
     example_pipelines: Dict[str, Pipeline],
     example_catalog: DataCatalog,
     example_node_extras_dict: Dict[str, NodeExtras],
+    repository_project_context: VizProjectContext,
     mocker,
 ):
-    api = apps.create_api_app_from_project(mock.MagicMock())
+    api = apps.create_api_app_from_project(repository_project_context, mock.MagicMock())
     populate_data(
         data_access_manager,
         example_catalog,
@@ -527,10 +554,11 @@ def example_api_no_default_pipeline(
     data_access_manager: DataAccessManager,
     example_pipelines: Dict[str, Pipeline],
     example_catalog: DataCatalog,
+    repository_project_context: VizProjectContext,
     mocker,
 ):
     del example_pipelines["__default__"]
-    api = apps.create_api_app_from_project(mock.MagicMock())
+    api = apps.create_api_app_from_project(repository_project_context, mock.MagicMock())
     populate_data(data_access_manager, example_catalog, example_pipelines, {})
     mocker.patch(
         "kedro_viz.api.rest.responses.pipelines.data_access_manager",
@@ -548,9 +576,10 @@ def example_api_for_edge_case_pipelines(
     data_access_manager: DataAccessManager,
     edge_case_example_pipelines: Dict[str, Pipeline],
     example_catalog: DataCatalog,
+    repository_project_context: VizProjectContext,
     mocker,
 ):
-    api = apps.create_api_app_from_project(mock.MagicMock())
+    api = apps.create_api_app_from_project(repository_project_context, mock.MagicMock())
 
     # For readability we are not hashing the node id
     mocker.patch("kedro_viz.utils._hash", side_effect=lambda value: value)
@@ -581,9 +610,10 @@ def example_api_for_pipelines_with_additional_tags(
     data_access_manager: DataAccessManager,
     example_pipelines_with_additional_tags: Dict[str, Pipeline],
     example_catalog: DataCatalog,
+    repository_project_context: VizProjectContext,
     mocker,
 ):
-    api = apps.create_api_app_from_project(mock.MagicMock())
+    api = apps.create_api_app_from_project(repository_project_context, mock.MagicMock())
 
     # For readability we are not hashing the node id
     mocker.patch("kedro_viz.utils._hash", side_effect=lambda value: value)
@@ -614,9 +644,10 @@ def example_transcoded_api(
     data_access_manager: DataAccessManager,
     example_transcoded_pipelines: Dict[str, Pipeline],
     example_transcoded_catalog: DataCatalog,
+    repository_project_context: VizProjectContext,
     mocker,
 ):
-    api = apps.create_api_app_from_project(mock.MagicMock())
+    api = apps.create_api_app_from_project(repository_project_context, mock.MagicMock())
     populate_data(
         data_access_manager,
         example_transcoded_catalog,

--- a/package/tests/test_api/test_apps.py
+++ b/package/tests/test_api/test_apps.py
@@ -4,6 +4,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from kedro_viz.api import apps
+from kedro_viz.integrations.kedro.inspection import VizProjectContext
 
 
 class TestIndexEndpoint:
@@ -29,8 +30,10 @@ class TestIndexEndpoint:
 
 
 @pytest.fixture
-def example_autoreload_api():
-    yield apps.create_api_app_from_project(mock.MagicMock(), autoreload=True)
+def example_autoreload_api(repository_project_context: VizProjectContext):
+    yield apps.create_api_app_from_project(
+        repository_project_context, mock.MagicMock(), autoreload=True
+    )
 
 
 class TestReloadEndpoint:
@@ -49,10 +52,14 @@ class TestReloadEndpoint:
 
     @mock.patch("kedro_viz.api.apps._create_etag")
     def test_reload_endpoint_return_304_when_content_has_not_changed(
-        self, patched_create_etag
+        self,
+        patched_create_etag,
+        repository_project_context: VizProjectContext,
     ):
         patched_create_etag.return_value = "old etag"
-        api = apps.create_api_app_from_project(mock.MagicMock(), autoreload=True)
+        api = apps.create_api_app_from_project(
+            repository_project_context, mock.MagicMock(), autoreload=True
+        )
 
         client = TestClient(api)
 

--- a/package/tests/test_inspection_adapter/test_context_creation.py
+++ b/package/tests/test_inspection_adapter/test_context_creation.py
@@ -1,0 +1,164 @@
+"""Tests for creating the project-scoped inspection context at server startup."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest import mock
+
+import pytest
+from kedro.io import DataCatalog, MemoryDataset
+from kedro.pipeline import node, pipeline
+
+from kedro_viz.data_access.managers import DataAccessManager
+from kedro_viz.server import _create_viz_project_context
+
+PROJECT = Path("/some/project")
+
+
+def test_cli_options_and_explicit_enrichment_are_forwarded_to_the_context(
+    mocker,
+) -> None:
+    """Startup builds one context from the supplied live data and CLI options."""
+    live_data = mocker.MagicMock()
+    live_nodes = [mock.sentinel.live_node]
+    live_data.nodes.as_list.return_value = live_nodes
+    live_data.catalog.layers_mapping = {}
+    enrichment = mock.sentinel.enrichment
+    from_live_nodes = mocker.patch(
+        "kedro_viz.server.EnrichmentSources.from_live_nodes",
+        return_value=enrichment,
+    )
+    context = mock.sentinel.context
+    from_project = mocker.patch(
+        "kedro_viz.server.VizProjectContext.from_project",
+        return_value=context,
+    )
+    runtime_params = {"split": {"test_size": 0.3}}
+
+    result = _create_viz_project_context(
+        PROJECT,
+        live_data,
+        env="staging",
+        pipeline_name="data_ingestion",
+        extra_params=runtime_params,
+        package_name="spaceflights",
+        is_lite=True,
+        include_hooks=True,
+    )
+
+    from_live_nodes.assert_called_once_with(live_nodes, layer_by_dataset={})
+    from_project.assert_called_once_with(
+        PROJECT,
+        env="staging",
+        pipeline_name="data_ingestion",
+        runtime_params=runtime_params,
+        package_name="spaceflights",
+        is_lite=True,
+        enrichment=enrichment,
+    )
+    assert result is context
+
+
+def test_hook_modified_factory_layer_is_forwarded_to_the_context(mocker) -> None:
+    """The hooks path retains metadata on a materialised dataset factory entry."""
+    catalog = DataCatalog.from_config(
+        {
+            "{namespace}.int_{name}": {
+                "type": "kedro.io.MemoryDataset",
+                "metadata": {"kedro-viz": {"layer": "factory"}},
+            }
+        }
+    )
+    concrete_dataset = catalog.get("processing.int_companies")
+    assert isinstance(concrete_dataset, MemoryDataset)
+    assert concrete_dataset.metadata is not None
+    concrete_dataset.metadata["kedro-viz"]["layer"] = "hooked"
+    processing_pipeline = pipeline(
+        [
+            node(
+                lambda value: value,
+                inputs="int_companies",
+                outputs="result",
+                name="process",
+            )
+        ],
+        namespace="processing",
+    )
+    live_data = DataAccessManager()
+    live_data.add_catalog(catalog, {"__default__": processing_pipeline})
+    from_live_nodes = mocker.patch("kedro_viz.server.EnrichmentSources.from_live_nodes")
+    mocker.patch("kedro_viz.server.VizProjectContext.from_project")
+
+    _create_viz_project_context(PROJECT, live_data, include_hooks=True)
+
+    from_live_nodes.assert_called_once_with(
+        live_data.nodes.as_list(),
+        layer_by_dataset={"processing.int_companies": "hooked"},
+    )
+
+
+def test_unmaterialized_factory_layer_is_absent_from_hook_layers(mocker) -> None:
+    """An unresolved factory stays absent, matching the populated live catalog."""
+    catalog = DataCatalog.from_config(
+        {
+            "{name}_input": {
+                "type": "missing_package.MissingDataset",
+                "metadata": {"kedro-viz": {"layer": "raw"}},
+            }
+        }
+    )
+    processing_pipeline = pipeline(
+        [
+            node(
+                lambda value: value,
+                inputs="companies_input",
+                outputs="result",
+                name="process",
+            )
+        ]
+    )
+    live_data = DataAccessManager()
+    live_data.add_catalog(catalog, {"__default__": processing_pipeline})
+    assert "companies_input" not in catalog.keys()
+    from_live_nodes = mocker.patch("kedro_viz.server.EnrichmentSources.from_live_nodes")
+    mocker.patch("kedro_viz.server.VizProjectContext.from_project")
+
+    _create_viz_project_context(PROJECT, live_data, include_hooks=True)
+
+    from_live_nodes.assert_called_once_with(
+        live_data.nodes.as_list(),
+        layer_by_dataset={},
+    )
+
+
+def test_hooks_disabled_keeps_the_raw_catalog_layer_path(mocker) -> None:
+    """Without hooks, the builder reads layers from raw config."""
+    live_data = mocker.MagicMock()
+    live_nodes = [mock.sentinel.live_node]
+    live_data.nodes.as_list.return_value = live_nodes
+    live_data.catalog.layers_mapping = {"companies": "hooked"}
+    from_live_nodes = mocker.patch("kedro_viz.server.EnrichmentSources.from_live_nodes")
+    mocker.patch("kedro_viz.server.VizProjectContext.from_project")
+
+    _create_viz_project_context(PROJECT, live_data)
+
+    from_live_nodes.assert_called_once_with(
+        live_nodes,
+        layer_by_dataset=None,
+    )
+
+
+def test_a_context_build_failure_is_logged_and_re_raised(mocker, caplog) -> None:
+    """A failed context build stops startup instead of serving an incomplete graph."""
+    live_data = mocker.MagicMock()
+    live_data.nodes.as_list.return_value = []
+    mocker.patch("kedro_viz.server.EnrichmentSources.from_live_nodes")
+    mocker.patch(
+        "kedro_viz.server.VizProjectContext.from_project",
+        side_effect=RuntimeError("no snapshot"),
+    )
+
+    with caplog.at_level("ERROR"), pytest.raises(RuntimeError, match="no snapshot"):
+        _create_viz_project_context(PROJECT, live_data)
+
+    assert "Could not build the Kedro inspection context" in caplog.text

--- a/package/tests/test_inspection_adapter/test_enrichment.py
+++ b/package/tests/test_inspection_adapter/test_enrichment.py
@@ -1,0 +1,184 @@
+"""Tests for explicit live-field enrichment of inspection graph responses."""
+
+from __future__ import annotations
+
+import pytest
+from kedro_datasets.pandas import CSVDataset
+from pydantic import ValidationError
+
+from kedro_viz.api.rest.responses.pipelines import (
+    DataNodeAPIResponse,
+    GraphAPIResponse,
+    GraphEdgeAPIResponse,
+    NodeExtrasAPIResponse,
+)
+from kedro_viz.integrations.kedro.inspection.enrichment import (
+    EnrichmentSources,
+    enrich_graph_response,
+)
+from kedro_viz.integrations.kedro.node_ids import _create_dataset_node_id
+from kedro_viz.models.flowchart.nodes import GraphNode, TranscodedDataNode
+from kedro_viz.models.metadata import NodeExtras
+from kedro_viz.utils import _hash_input_output
+
+
+def _live_dataset(
+    name: str,
+    *,
+    stats: dict | None = None,
+    styles: dict | None = None,
+) -> GraphNode:
+    extras = (
+        NodeExtras(stats=stats, styles=styles)
+        if stats is not None or styles is not None
+        else None
+    )
+    return GraphNode.create_data_node(
+        dataset_id=_hash_input_output(name),
+        dataset_name=name,
+        layer=None,
+        tags=set(),
+        dataset=CSVDataset(filepath="data.csv"),
+        modular_pipelines=None,
+        node_extras=extras,
+    )
+
+
+def _graph_dataset(
+    name: str,
+    *,
+    dataset_type: str | None = "pandas.CSVDataset",
+) -> DataNodeAPIResponse:
+    return DataNodeAPIResponse(
+        id=_create_dataset_node_id(name),
+        name=name,
+        tags=[],
+        pipelines=["__default__"],
+        type="data",
+        modular_pipelines=None,
+        layer=None,
+        dataset_type=dataset_type,
+    )
+
+
+def _graph_response(
+    *nodes: DataNodeAPIResponse,
+    edges: list[GraphEdgeAPIResponse] | None = None,
+) -> GraphAPIResponse:
+    return GraphAPIResponse(
+        nodes=list(nodes),
+        edges=edges or [],
+        layers=[],
+        tags=[],
+        pipelines=[],
+        modular_pipelines={},
+        selected_pipeline="__default__",
+    )
+
+
+def test_live_dataset_fields_are_copied_by_existing_node_id() -> None:
+    """Copy icon type, stats and styles without recalculating the live node ID."""
+    live_node = _live_dataset(
+        "companies",
+        stats={"rows": 5},
+        styles={"backgroundColor": "#fff"},
+    )
+    graph_node = _graph_dataset("companies")
+    sources = EnrichmentSources.from_live_nodes([live_node])
+
+    enrich_graph_response(_graph_response(graph_node), sources)
+
+    assert live_node.id == graph_node.id
+    assert graph_node.dataset_type == "pandas.csv_dataset.CSVDataset"
+    assert isinstance(graph_node.node_extras, NodeExtrasAPIResponse)
+    assert graph_node.node_extras.stats == {"rows": 5}
+    assert graph_node.node_extras.styles == {"backgroundColor": "#fff"}
+
+
+def test_enrichment_sources_copy_the_layer_mapping() -> None:
+    """Later mutations of the caller's mapping cannot change a prepared service."""
+    layers = {"companies": "raw"}
+    sources = EnrichmentSources.from_live_nodes([], layer_by_dataset=layers)
+
+    layers["companies"] = "changed"
+
+    assert sources.layer_by_dataset == {"companies": "raw"}
+
+
+def test_enrichment_sources_are_frozen() -> None:
+    """Prepared enrichment fields cannot be replaced after construction."""
+    sources = EnrichmentSources(layer_by_dataset={"companies": "raw"})
+
+    with pytest.raises(ValidationError, match="Instance is frozen"):
+        sources.layer_by_dataset = {}  # type: ignore[misc]
+
+
+def test_enrichment_sources_copy_all_constructor_mappings() -> None:
+    """The direct constructor defensively copies mappings just like the factory."""
+    extras = {"node": NodeExtras(stats={"rows": 1})}
+    dataset_types = {"node": "pandas.csv_dataset.CSVDataset"}
+    sources = EnrichmentSources(
+        node_extras_by_node_id=extras,
+        dataset_type_by_node_id=dataset_types,
+    )
+
+    extras.clear()
+    dataset_types.clear()
+
+    assert list(sources.node_extras_by_node_id) == ["node"]
+    assert list(sources.dataset_type_by_node_id) == ["node"]
+
+
+def test_live_nodes_are_consumed_in_one_pass() -> None:
+    """A generator supplies both extras and dataset types, not only the first mapping."""
+    live_node = _live_dataset("companies", stats={"rows": 5})
+
+    sources = EnrichmentSources.from_live_nodes(node for node in [live_node])
+
+    assert live_node.id in sources.node_extras_by_node_id
+    assert live_node.id in sources.dataset_type_by_node_id
+
+
+def test_missing_live_node_leaves_builder_fields_untouched() -> None:
+    graph_node = _graph_dataset("only_in_snapshot")
+
+    enrich_graph_response(_graph_response(graph_node), EnrichmentSources())
+
+    assert graph_node.dataset_type == "pandas.CSVDataset"
+    assert graph_node.node_extras is None
+
+
+def test_enrichment_does_not_change_graph_topology() -> None:
+    source = _graph_dataset("source")
+    target = _graph_dataset("target")
+    response = _graph_response(
+        source,
+        target,
+        edges=[GraphEdgeAPIResponse(source=source.id, target=target.id)],
+    )
+    node_shape = [(node.id, node.type, node.name) for node in response.nodes]
+    edge_shape = [(edge.source, edge.target) for edge in response.edges]
+    sources = EnrichmentSources.from_live_nodes(
+        [_live_dataset("source", stats={"rows": 5})]
+    )
+
+    enrich_graph_response(response, sources)
+
+    assert [(node.id, node.type, node.name) for node in response.nodes] == node_shape
+    assert [(edge.source, edge.target) for edge in response.edges] == edge_shape
+    assert source.node_extras is not None
+
+
+def test_transcoded_dataset_uses_one_id_without_exposing_a_dataset_type() -> None:
+    """A transcoded live node enriches the base graph node but keeps its type hidden."""
+    live_node = _live_dataset("ds@pandas", stats={"rows": 7})
+    assert isinstance(live_node, TranscodedDataNode)
+    graph_node = _graph_dataset("ds", dataset_type=None)
+    sources = EnrichmentSources.from_live_nodes([live_node])
+
+    enrich_graph_response(_graph_response(graph_node), sources)
+
+    assert live_node.id == graph_node.id
+    assert graph_node.dataset_type is None
+    assert graph_node.node_extras is not None
+    assert graph_node.node_extras.stats == {"rows": 7}

--- a/package/tests/test_inspection_adapter/test_graph_builder_edge_cases.py
+++ b/package/tests/test_inspection_adapter/test_graph_builder_edge_cases.py
@@ -22,10 +22,15 @@ if TYPE_CHECKING:
 def _builder(
     snapshot: SimpleNamespace,
     catalog_config: dict[str, Any] | None = None,
+    *,
     parameters: dict[str, Any] | None = None,
+    layer_by_dataset: dict[str, str] | None = None,
 ) -> GraphBuilder:
     return GraphBuilder(
-        cast("ProjectSnapshot", snapshot), catalog_config, parameters=parameters
+        cast("ProjectSnapshot", snapshot),
+        catalog_config,
+        parameters=parameters,
+        layer_by_dataset=layer_by_dataset,
     )
 
 
@@ -463,6 +468,44 @@ def test_layers_from_catalog_config_are_sorted_topologically() -> None:
     }
     assert layer_by_name == {"x": "raw", "y": "model"}
     assert graph.layers == ["raw", "model"]
+
+
+def test_populated_catalog_layers_override_raw_config() -> None:
+    """Layer metadata changed by hooks must override the original catalog config."""
+    snapshot = _snapshot([_pipeline("__default__", [_node("t", ["x"], ["y"])])])
+    catalog_config = {
+        "x": {"metadata": {"kedro-viz": {"layer": "raw"}}},
+    }
+    graph = _builder(
+        snapshot,
+        catalog_config,
+        layer_by_dataset={"x": "hooked"},
+    ).build("__default__")
+    data_nodes = {
+        node.name: node
+        for node in graph.nodes
+        if isinstance(node, DataNodeAPIResponse) and node.type == "data"
+    }
+
+    assert data_nodes["x"].layer == "hooked"
+    assert graph.layers == ["hooked"]
+
+
+def test_empty_populated_catalog_layers_remove_raw_config_layers() -> None:
+    """A hook that removed every layer is reflected, rather than the raw config winning."""
+    snapshot = _snapshot([_pipeline("__default__", [_node("t", ["x"], ["y"])])])
+    catalog_config = {
+        "x": {"metadata": {"kedro-viz": {"layer": "raw"}}},
+    }
+    graph = _builder(snapshot, catalog_config, layer_by_dataset={}).build("__default__")
+    data_nodes = [
+        node
+        for node in graph.nodes
+        if isinstance(node, DataNodeAPIResponse) and node.type == "data"
+    ]
+
+    assert all(node.layer is None for node in data_nodes)
+    assert graph.layers == []
 
 
 def test_factory_layer_is_resolved_for_concrete_dataset() -> None:

--- a/package/tests/test_inspection_adapter/test_graph_routes.py
+++ b/package/tests/test_inspection_adapter/test_graph_routes.py
@@ -1,0 +1,131 @@
+"""Tests that graph routes use the context bound when the API app is created.
+
+Everything here goes over HTTP via ``TestClient``. A spy service records what the routes ask
+for, so these fail if ``/api/main`` or ``/api/pipelines/{id}`` bypasses the explicit context.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from kedro_viz.api import apps
+from kedro_viz.api.rest.responses.pipelines import GraphAPIResponse
+from kedro_viz.integrations.kedro.inspection import (
+    InspectionGraphService,
+    VizProjectContext,
+)
+from kedro_viz.integrations.kedro.inspection.graph_service import (
+    PipelineNotFoundError,
+)
+
+DEMO_PROJECT = Path(__file__).resolve().parents[3] / "demo-project"
+
+
+class _SpyGraphService(InspectionGraphService):
+    """Record the pipeline IDs requested by routes."""
+
+    def __init__(self) -> None:
+        self.requested: list[str | None] = []
+
+    def get_pipeline_response(self, pipeline_id: str | None = None) -> GraphAPIResponse:
+        self.requested.append(pipeline_id)
+        if pipeline_id == "unknown":
+            raise PipelineNotFoundError("Invalid pipeline ID: 'unknown'")
+        return GraphAPIResponse(
+            nodes=[],
+            edges=[],
+            layers=[],
+            tags=[],
+            pipelines=[],
+            modular_pipelines={},
+            selected_pipeline=pipeline_id or "__default__",
+        )
+
+
+@pytest.fixture
+def spy_service() -> _SpyGraphService:
+    return _SpyGraphService()
+
+
+@pytest.fixture
+def client(spy_service: _SpyGraphService) -> TestClient:
+    context = VizProjectContext(graph=spy_service)
+    return TestClient(apps.create_api_app_from_project(context, Path.cwd()))
+
+
+def test_main_route_asks_the_service_for_the_default_pipeline(
+    client: TestClient, spy_service: _SpyGraphService
+) -> None:
+    """``/api/main`` delegates with no ID, leaving default selection to the service."""
+    response = client.get("/api/main")
+    assert response.status_code == 200
+    assert spy_service.requested == [None]
+
+
+def test_pipeline_route_passes_the_requested_id_through(
+    client: TestClient, spy_service: _SpyGraphService
+) -> None:
+    """The pipeline ID in the URL reaches the bound service unchanged."""
+    response = client.get("/api/pipelines/data_ingestion")
+    assert response.status_code == 200
+    assert spy_service.requested == ["data_ingestion"]
+    assert response.json()["selected_pipeline"] == "data_ingestion"
+
+
+def test_unknown_pipeline_is_translated_to_http_404(
+    client: TestClient, spy_service: _SpyGraphService
+) -> None:
+    """The HTTP layer translates the service's domain error into the established response."""
+    response = client.get("/api/pipelines/unknown")
+    assert response.status_code == 404
+    assert response.json() == {"message": "Invalid pipeline ID"}
+    assert spy_service.requested == ["unknown"]
+
+
+def test_each_app_uses_the_context_bound_when_it_was_created() -> None:
+    """Two apps in one process do not share or overwrite graph state."""
+    first_service = _SpyGraphService()
+    second_service = _SpyGraphService()
+    first_client = TestClient(
+        apps.create_api_app_from_project(
+            VizProjectContext(graph=first_service), Path.cwd()
+        )
+    )
+    second_client = TestClient(
+        apps.create_api_app_from_project(
+            VizProjectContext(graph=second_service), Path.cwd()
+        )
+    )
+
+    assert first_client.get("/api/pipelines/first").status_code == 200
+    assert second_client.get("/api/pipelines/second").status_code == 200
+    assert first_client.get("/api/main").status_code == 200
+
+    assert first_service.requested == ["first", None]
+    assert second_service.requested == ["second"]
+
+
+def test_routes_serve_the_real_inspection_service(
+    _restore_kedro_project_state,
+) -> None:
+    """End to end: a real project context returns the demo project's graph over HTTP.
+
+    Live-only enrichment is covered separately; this proves that the app-bound inspection
+    service is the implementation serving both graph routes.
+    """
+    context = VizProjectContext.from_project(DEMO_PROJECT)
+    client = TestClient(apps.create_api_app_from_project(context, DEMO_PROJECT))
+
+    main = client.get("/api/main")
+    scoped = client.get("/api/pipelines/data_ingestion")
+    missing = client.get("/api/pipelines/no_such_pipeline")
+
+    assert main.status_code == 200
+    assert main.json()["selected_pipeline"] == "__default__"
+    assert main.json()["nodes"], "the demo project should render nodes"
+    assert scoped.status_code == 200
+    assert scoped.json()["selected_pipeline"] == "data_ingestion"
+    assert missing.status_code == 404

--- a/package/tests/test_inspection_adapter/test_graph_service.py
+++ b/package/tests/test_inspection_adapter/test_graph_service.py
@@ -1,0 +1,204 @@
+"""Tests for the project-scoped inspection graph service."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from pathlib import Path
+
+import pytest
+
+from kedro_viz.api.rest.responses.pipelines import GraphAPIResponse
+from kedro_viz.integrations.kedro.inspection import (
+    EnrichmentSources,
+    InspectionGraphService,
+    PipelineNotFoundError,
+)
+
+DEMO_PROJECT = Path(__file__).resolve().parents[3] / "demo-project"
+
+
+@pytest.fixture(scope="module")
+def graph_service(_restore_kedro_project_state) -> InspectionGraphService:
+    """Build the demo snapshot once for the service response tests."""
+    return InspectionGraphService.from_project(DEMO_PROJECT)
+
+
+def test_default_pipeline_is_served_when_none_is_requested(graph_service) -> None:
+    response = graph_service.get_pipeline_response()
+    assert response.selected_pipeline == "__default__"
+
+
+def test_named_pipeline_is_served(graph_service) -> None:
+    response = graph_service.get_pipeline_response("data_ingestion")
+    assert response.selected_pipeline == "data_ingestion"
+
+
+@pytest.mark.parametrize("pipeline_id", ["does_not_exist", ""])
+def test_unknown_pipeline_is_rejected(graph_service, pipeline_id: str) -> None:
+    """The HTTP route translates the service's domain error into a 404."""
+    with pytest.raises(PipelineNotFoundError, match="Invalid pipeline ID"):
+        graph_service.get_pipeline_response(pipeline_id)
+
+
+def test_pipeline_list_preserves_declaration_order(graph_service) -> None:
+    """Declaration order drives the pipeline dropdown, so the whole list must match."""
+    response = graph_service.get_pipeline_response()
+    assert [pipeline.id for pipeline in response.pipelines] == [
+        "__default__",
+        "data_ingestion",
+        "modelling_stage",
+        "feature_engineering",
+        "reporting_stage",
+        "pre_modelling",
+    ]
+
+
+def test_pipeline_filter_hides_every_other_pipeline(
+    _restore_kedro_project_state,
+) -> None:
+    """``--pipeline`` narrows the snapshot to that pipeline alone."""
+    service = InspectionGraphService.from_project(
+        DEMO_PROJECT, pipeline_name="data_ingestion"
+    )
+
+    response = service.get_pipeline_response()
+    assert [pipeline.id for pipeline in response.pipelines] == ["data_ingestion"]
+    with pytest.raises(PipelineNotFoundError, match="Invalid pipeline ID"):
+        service.get_pipeline_response("reporting_stage")
+
+
+def test_unknown_pipeline_filter_is_rejected_at_startup(
+    _restore_kedro_project_state,
+) -> None:
+    """A bad ``--pipeline`` fails during construction, not on the first request."""
+    with pytest.raises(PipelineNotFoundError, match="not found in snapshot"):
+        InspectionGraphService.from_project(
+            DEMO_PROJECT, pipeline_name="no_such_pipeline"
+        )
+
+
+def test_project_options_and_parameters_reach_the_builder(mocker) -> None:
+    """Snapshot configuration and resolved parameters come from the same session."""
+    runtime_params = {"split_options": {"test_size": 0.3}}
+    session_class = mocker.patch(
+        "kedro_viz.integrations.kedro.inspection.graph_service._InspectionSession"
+    )
+    session = session_class.return_value
+    graph_builder = mocker.patch(
+        "kedro_viz.integrations.kedro.inspection.graph_service.GraphBuilder"
+    )
+
+    InspectionGraphService.from_project(
+        DEMO_PROJECT,
+        env="staging",
+        runtime_params=runtime_params,
+    )
+
+    session_class.assert_called_once_with(
+        DEMO_PROJECT,
+        env="staging",
+        runtime_params=runtime_params,
+    )
+    graph_builder.assert_called_once_with(
+        session.snapshot.return_value,
+        session.catalog_config.return_value,
+        parameters=session.parameters.return_value,
+        layer_by_dataset=None,
+    )
+
+
+def test_populated_catalog_layers_reach_the_builder(mocker) -> None:
+    """The post-hook catalog mapping is authoritative for rendered layers."""
+    session = mocker.patch(
+        "kedro_viz.integrations.kedro.inspection.graph_service._InspectionSession"
+    ).return_value
+    graph_builder = mocker.patch(
+        "kedro_viz.integrations.kedro.inspection.graph_service.GraphBuilder"
+    )
+    enrichment = EnrichmentSources(layer_by_dataset={"companies": "hooked"})
+
+    InspectionGraphService.from_project(DEMO_PROJECT, enrichment=enrichment)
+
+    graph_builder.assert_called_once_with(
+        session.snapshot.return_value,
+        session.catalog_config.return_value,
+        parameters=session.parameters.return_value,
+        layer_by_dataset={"companies": "hooked"},
+    )
+
+
+def test_lite_service_reads_project_data_inside_import_stubs(mocker) -> None:
+    """Project imports stay mocked until snapshot, catalog and parameters are read."""
+    events: list[object] = []
+
+    @contextmanager
+    def import_stubs(project_path, package_name):
+        events.append(("enter", project_path, package_name))
+        yield
+        events.append(("exit", project_path, package_name))
+
+    session = mocker.patch(
+        "kedro_viz.integrations.kedro.inspection.graph_service._InspectionSession"
+    ).return_value
+
+    def read_snapshot():
+        events.append("snapshot")
+        return object()
+
+    def read_catalog():
+        events.append("catalog")
+        return {}
+
+    def read_parameters():
+        events.append("parameters")
+        return {}
+
+    session.snapshot.side_effect = read_snapshot
+    session.catalog_config.side_effect = read_catalog
+    session.parameters.side_effect = read_parameters
+    mocker.patch("kedro_viz.integrations.kedro.inspection.graph_service.GraphBuilder")
+    stubs = mocker.patch(
+        "kedro_viz.integrations.kedro.inspection.graph_service.lite_import_stubs",
+        side_effect=import_stubs,
+    )
+
+    InspectionGraphService.from_project(
+        DEMO_PROJECT,
+        package_name="spaceflights",
+        is_lite=True,
+    )
+
+    stubs.assert_called_once_with(DEMO_PROJECT, "spaceflights")
+    assert events == [
+        ("enter", DEMO_PROJECT, "spaceflights"),
+        "snapshot",
+        "catalog",
+        "parameters",
+        ("exit", DEMO_PROJECT, "spaceflights"),
+    ]
+
+
+def test_service_enriches_the_built_response(mocker) -> None:
+    """The service applies its prepared enrichment after building each graph."""
+    builder = mocker.Mock()
+    builder.default_pipeline_id.return_value = "__default__"
+    builder.has_pipeline.return_value = True
+    response = GraphAPIResponse(
+        nodes=[],
+        edges=[],
+        layers=[],
+        tags=[],
+        pipelines=[],
+        modular_pipelines={},
+        selected_pipeline="__default__",
+    )
+    builder.build.return_value = response
+    enrichment = EnrichmentSources()
+    enrich_graph_response = mocker.patch(
+        "kedro_viz.integrations.kedro.inspection.graph_service.enrich_graph_response"
+    )
+    service = InspectionGraphService(builder, enrichment)
+
+    assert service.get_pipeline_response() is response
+    builder.build.assert_called_once_with("__default__")
+    enrich_graph_response.assert_called_once_with(response, enrichment)

--- a/package/tests/test_inspection_adapter/test_inspection_adapter_parity.py
+++ b/package/tests/test_inspection_adapter/test_inspection_adapter_parity.py
@@ -1,0 +1,99 @@
+"""Parity between the served graph and the captured legacy response.
+
+The baseline under ``baseline/`` was captured from the live backend, so these compare the whole
+served response against it, field for field, for every registered pipeline. The service receives
+explicit enrichment from a local live load, so no process-wide repository is involved.
+This suite covers the normal live-load response; CLI variants are covered by focused context,
+service and ``GraphBuilder`` tests.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from kedro_viz.api.rest.responses.pipelines import GraphAPIResponse
+from kedro_viz.constants import ROOT_MODULAR_PIPELINE_ID
+from kedro_viz.data_access import DataAccessManager
+from kedro_viz.integrations.kedro.inspection import (
+    EnrichmentSources,
+    InspectionGraphService,
+)
+
+from .capture_baseline import normalize_graph
+
+DEMO_PROJECT = Path(__file__).resolve().parents[3] / "demo-project"
+BASELINE_DIR = Path(__file__).parent / "baseline"
+PIPELINE_IDS = [
+    "__default__",
+    "data_ingestion",
+    "feature_engineering",
+    "modelling_stage",
+    "pre_modelling",
+    "reporting_stage",
+]
+
+# The captured demo response lists ``params:split_options`` twice under ``__root__``:
+# once as data and once as parameters. The adapter correctly emits one parameter child, so
+# normalize only the expected baseline rather than excusing the served response.
+_KNOWN_DUPLICATE_ROOT_CHILD = {"id": "22eec376", "type": "data"}
+_KNOWN_PARAMETER_ROOT_CHILD = {"id": "22eec376", "type": "parameters"}
+
+
+def _baseline(pipeline_id: str) -> dict:
+    name = "main" if pipeline_id == "__default__" else pipeline_id
+    path = BASELINE_DIR / ("main.json" if name == "main" else f"pipelines/{name}.json")
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _normalize_expected_graph(graph: dict) -> dict:
+    """Normalize the baseline and remove its one documented duplicate root child."""
+    normalized = normalize_graph(graph)
+    root_children = normalized["modular_pipelines"][ROOT_MODULAR_PIPELINE_ID][
+        "children"
+    ]
+    if _KNOWN_DUPLICATE_ROOT_CHILD in root_children:
+        assert _KNOWN_PARAMETER_ROOT_CHILD in root_children
+        root_children.remove(_KNOWN_DUPLICATE_ROOT_CHILD)
+    return normalized
+
+
+@pytest.fixture(scope="module")
+def live_enriched_graph_service(_restore_kedro_project_state):
+    """A graph service enriched from an isolated live load of the demo project.
+
+    Module-scoped: loading the demo project and reading the snapshot is expensive.
+    """
+    from kedro_viz.integrations.kedro import data_loader
+    from kedro_viz.server import populate_data
+
+    manager = DataAccessManager()
+    catalog, pipelines, node_extras = data_loader.load_data(DEMO_PROJECT)
+    populate_data(manager, catalog, pipelines, node_extras)
+    enrichment = EnrichmentSources.from_live_nodes(manager.nodes.as_list())
+    return InspectionGraphService.from_project(DEMO_PROJECT, enrichment=enrichment)
+
+
+@pytest.mark.parametrize("pipeline_id", PIPELINE_IDS)
+def test_served_graph_matches_the_baseline_after_live_enrichment(
+    live_enriched_graph_service, pipeline_id: str
+) -> None:
+    """The complete snapshot graph plus live-only fields matches the captured response.
+
+    A wrong ID, dataset type, task parameter, node extra or structural field fails here.
+    """
+    response = live_enriched_graph_service.get_pipeline_response(pipeline_id)
+    assert isinstance(response, GraphAPIResponse)
+    expected = _normalize_expected_graph(_baseline(pipeline_id))
+    served = normalize_graph(response.model_dump(mode="json"))
+
+    if pipeline_id == "__default__":
+        assert any(
+            node.get("parameters")
+            for node in expected["nodes"]
+            if node["type"] == "task"
+        ), "the baseline should exercise parameters"
+
+    assert served == expected, pipeline_id

--- a/package/tests/test_server.py
+++ b/package/tests/test_server.py
@@ -1,9 +1,10 @@
 import json
+from pathlib import Path
 
 import pytest
 from pydantic import BaseModel
 
-from kedro_viz.server import run_server
+from kedro_viz.server import load_and_populate_data, run_server
 
 
 class ExampleAPIResponse(BaseModel):
@@ -31,6 +32,12 @@ def patched_create_api_app_from_file(mocker):
 
 
 @pytest.fixture(autouse=True)
+def patched_create_viz_project_context(mocker):
+    """These tests drive startup against a mock path, which has no snapshot to read."""
+    yield mocker.patch("kedro_viz.server._create_viz_project_context")
+
+
+@pytest.fixture(autouse=True)
 def patched_load_data(
     mocker, example_catalog, example_pipelines, example_node_extras_dict
 ):
@@ -49,20 +56,43 @@ class TestServer:
         self,
         patched_create_api_app_from_project,
         patched_data_access_manager,
+        patched_create_viz_project_context,
         patched_uvicorn_run,
         example_catalog,
         example_pipelines,
     ):
+        events = []
+        patched_data_access_manager.add_pipelines.side_effect = lambda _: events.append(
+            "populated"
+        )
+        context = patched_create_viz_project_context.return_value
+        patched_create_viz_project_context.side_effect = lambda *args, **kwargs: (
+            events.append("context") or context
+        )
+
         run_server()
+
         patched_data_access_manager.add_catalog.assert_called_once_with(
             example_catalog, example_pipelines
         )
         patched_data_access_manager.add_pipelines.assert_called_once_with(
             example_pipelines
         )
+        patched_create_viz_project_context.assert_called_once_with(
+            Path.cwd(),
+            patched_data_access_manager,
+            env=None,
+            pipeline_name=None,
+            extra_params=None,
+            package_name=None,
+            is_lite=False,
+            include_hooks=False,
+        )
+        assert events == ["populated", "context"]
 
-        # correct api app is created
-        patched_create_api_app_from_project.assert_called_once()
+        patched_create_api_app_from_project.assert_called_once_with(
+            context, Path.cwd(), False
+        )
 
         # an uvicorn server is launched
         patched_uvicorn_run.assert_called_once()
@@ -79,7 +109,47 @@ class TestServer:
             {"data_science": example_pipelines["data_science"]}
         )
 
-    def test_load_file(self, patched_create_api_app_from_file, tmp_path):
+    def test_runtime_options_are_forwarded_to_context_creation(
+        self,
+        patched_create_viz_project_context,
+        patched_data_access_manager,
+        tmp_path,
+    ):
+        runtime_params = {"split": {"test_size": 0.3}}
+
+        run_server(
+            project_path=str(tmp_path),
+            env="staging",
+            pipeline_name="data_science",
+            extra_params=runtime_params,
+            package_name="spaceflights",
+            is_lite=True,
+            include_hooks=True,
+        )
+
+        patched_create_viz_project_context.assert_called_once_with(
+            tmp_path,
+            patched_data_access_manager,
+            env="staging",
+            pipeline_name="data_science",
+            extra_params=runtime_params,
+            package_name="spaceflights",
+            is_lite=True,
+            include_hooks=True,
+        )
+
+    def test_load_and_populate_data_does_not_create_a_project_context(
+        self, patched_create_viz_project_context
+    ):
+        load_and_populate_data(Path.cwd())
+        patched_create_viz_project_context.assert_not_called()
+
+    def test_load_file(
+        self,
+        patched_create_api_app_from_file,
+        patched_create_viz_project_context,
+        tmp_path,
+    ):
         file_path = "test.json"
         json_file_path = tmp_path / file_path
 
@@ -88,6 +158,7 @@ class TestServer:
 
         run_server(load_file=json_file_path)
         patched_create_api_app_from_file.assert_called_once()
+        patched_create_viz_project_context.assert_not_called()
 
     def test_save_file(self, tmp_path, mocker):
         mock_filesystem = mocker.patch("fsspec.filesystem")

--- a/package/tests/test_server.py
+++ b/package/tests/test_server.py
@@ -138,10 +138,12 @@ class TestServer:
             include_hooks=True,
         )
 
-    def test_load_and_populate_data_does_not_create_a_project_context(
-        self, patched_create_viz_project_context
+    def test_load_and_populate_data_returns_repositories_without_creating_a_context(
+        self, patched_create_viz_project_context, patched_data_access_manager
     ):
-        load_and_populate_data(Path.cwd())
+        result = load_and_populate_data(Path.cwd())
+
+        assert result is patched_data_access_manager
         patched_create_viz_project_context.assert_not_called()
 
     def test_load_file(


### PR DESCRIPTION
**Sub-task:** #2659  
**Parent:** #2265

## Description

Moves `/api/main` and `/api/pipelines/{id}` off the live graph engine and onto the inspection snapshot. No other endpoint implementation changes.

The routes are bound to a project-scoped `VizProjectContext` when the FastAPI app is created. `InspectionGraphService` owns the prepared snapshot, and the router receives the context explicitly—there is no process-wide provider slot or fallback to another engine. If the context cannot be built, startup fails loudly.

The context provides the extension point for #2660, while #2724 can later remove the legacy graph engine without changing these two routes again.

## Implementation

- `integrations/kedro/inspection/enrichment.py` (new): captures live-only fields as explicit, defensively copied inputs. The graph service does not retain or access the global live repositories.
- `integrations/kedro/inspection/graph_service.py` (new): reads the snapshot once at startup and serves both graph routes. `--pipeline` narrows the snapshot, and `--lite` reads it inside the existing import stubs.
- `api/rest/router.py` and `api/apps.py`: bind the graph routes to the context supplied when each FastAPI app is created. Separate apps cannot overwrite each other’s graph state.
- `server.py`: creates the context after the transitional live load and passes it into the app. The shared loader, `build` and `deploy` remain on the existing path. Context-construction failures are logged and re-raised.

Two things worth a closer look:

- **Fields supplied from the transitional live project.** The snapshot does not provide `.viz` stats or styles, or the abbreviated dataset type used by frontend icons. Startup copies those fields into explicit `EnrichmentSources`, keyed by the existing live-node IDs, and the service applies them without reading the global repositories or changing graph topology. Task parameters are not a live overlay: the merged #2736 owns parameter resolution and its tests, while this PR passes `session.parameters()` into `GraphBuilder`.
- **With `--include-hooks`, layers come from the populated catalog instead of the raw catalog config.** A hook can add, change or remove layer metadata, and only the populated catalog reflects that. Without hooks the raw config is used, as before.

## QA notes

- Full-response comparison against the captured baseline, field for field, for all six demo pipelines after a real live load. The baseline holds the existing graph responses, so this compares against real output rather than the adapter against itself.
- Route tests run over HTTP with a graph-service spy bound to the app context. They prove exact pipeline-ID delegation, 404 handling and isolation between two apps in one process. One test runs end to end through the real inspection service.
- Context-creation and server tests cover CLI-option forwarding, creation after live population, hook-modified layers, shared-loader and file-startup isolation, and failure propagation.
- Focused unit tests cover the frozen enrichment model, defensive input copying, graph-shape preservation, pipeline narrowing, lite-mode construction and graph-service behavior.
- The transitional fixture in `conftest.py` supplies a repository-backed `VizProjectContext` for older synthetic endpoint tests. It goes away with the live backend in #2724.
- Manual: run `kedro viz run` on `demo-project` and compare `/api/main` before and after, then verify `--pipeline`, `--params`, `--lite` and `--include-hooks`. `build` and `deploy` are unchanged.

## Deferred and related work

- `/api/nodes/{id}`, `/api/run-status`, static export and `--save-file` still use the live path: #2660. A saved file can therefore differ from what the endpoints serve; there is a TODO at the call site.
- Deleting the live graph engine: #2724.
- #2736 has merged into `feat/backend_v2`. It owns parameter resolution and its tests; this PR only supplies `session.parameters()` to `GraphBuilder`.
- `get_project_snapshot` takes no `runtime_params`, so a no-default `${runtime_params:x}` in the catalog or `parameters.yml` makes the snapshot raise and startup fail. This is an upstream Kedro gap and is not addressed here.
- Six modular-pipeline IDs now return 404 on `/api/nodes/{id}` where they returned `200 {}` before, because the live path registered those group nodes as a side effect of the old `/api/main`. No UI consumer requests them; this resolves with #2660.
- The lite-mode project-walk cache was extracted into the independent #2755 and is not part of this PR.
- `RELEASE.md` will be updated when the complete `backend_v2` work targets `main`.

## Verification

- Backend unit tests pass on Python 3.10 through 3.14.
- Full statement and branch coverage for the project context, graph service, explicit enrichment, route binding, graph-builder inputs and server context creation.
- `ruff check`, `ruff format --check` and both `mypy` runs are clean.
- DCO passes.
- The remaining end-to-end, documentation and secret-scan failures come from the temporary direct Kedro git dependency on `feat/backend_v2`, not from this PR.

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a Draft Pull Request if it is work in progress (not applicable: ready for review)
- [ ] Updated the documentation (not applicable: no user-facing behaviour change)
- [ ] Added a `RELEASE.md` entry (deferred until the complete backend work targets `main`)
- [x] Added tests to cover the changes