### PR TITLE
Cache the lite-mode project import scan

### DIFF
--- a/package/kedro_viz/integrations/kedro/data_loader.py
+++ b/package/kedro_viz/integrations/kedro/data_loader.py
@@ -19,7 +19,7 @@ from kedro.pipeline import Pipeline
 
 from kedro_viz.constants import VIZ_METADATA_ARGS
 from kedro_viz.integrations.kedro.abstract_dataset_lite import AbstractDatasetLite
-from kedro_viz.integrations.kedro.lite_parser import LiteParser
+from kedro_viz.integrations.kedro.lite_parser import LiteParser, unresolved_modules
 from kedro_viz.integrations.utils import _VizNullPluginManager
 from kedro_viz.models.metadata import Metadata, NodeExtras
 
@@ -243,20 +243,18 @@ def load_data(
         bootstrap_project(project_path)
 
     if is_lite:
-        lite_parser = LiteParser(package_name)
-        unresolved_imports = lite_parser.parse(project_path)
+        modules_to_mock: Set[str] = set(
+            unresolved_modules(str(project_path), package_name)
+        )
         sys_modules_patch = sys.modules.copy()
 
-        if unresolved_imports and len(unresolved_imports) > 0:
-            modules_to_mock: Set[str] = set()
-
+        if modules_to_mock:
             # for the viz lite banner
             Metadata.set_has_missing_dependencies(True)
 
-            for unresolved_module_set in unresolved_imports.values():
-                modules_to_mock = modules_to_mock.union(unresolved_module_set)
-
-            mocked_modules = lite_parser.create_mock_modules(modules_to_mock)
+            mocked_modules = LiteParser(package_name).create_mock_modules(
+                modules_to_mock
+            )
             sys_modules_patch.update(mocked_modules)
 
             logger.warning(

--- a/package/kedro_viz/integrations/kedro/data_loader.py
+++ b/package/kedro_viz/integrations/kedro/data_loader.py
@@ -19,7 +19,7 @@ from kedro.pipeline import Pipeline
 
 from kedro_viz.constants import VIZ_METADATA_ARGS
 from kedro_viz.integrations.kedro.abstract_dataset_lite import AbstractDatasetLite
-from kedro_viz.integrations.kedro.lite_parser import LiteParser, unresolved_modules
+from kedro_viz.integrations.kedro.lite_parser import LiteParser, get_unresolved_modules
 from kedro_viz.integrations.utils import _VizNullPluginManager
 from kedro_viz.models.metadata import Metadata, NodeExtras
 
@@ -244,7 +244,7 @@ def load_data(
 
     if is_lite:
         modules_to_mock: Set[str] = set(
-            unresolved_modules(str(project_path), package_name)
+            get_unresolved_modules(project_path, package_name)
         )
         sys_modules_patch = sys.modules.copy()
 

--- a/package/kedro_viz/integrations/kedro/inspection/snapshot_source.py
+++ b/package/kedro_viz/integrations/kedro/inspection/snapshot_source.py
@@ -37,6 +37,7 @@ def lite_import_stubs(
         sys_modules_patch.update(
             LiteParser(package_name).create_mock_modules(modules_to_mock)
         )
+        # TODO(#2724): Restore this warning when the live loader is removed.
         # The live loader already warned the user about these modules.
         logger.debug(
             "Building the snapshot with %d project dependency module(s) mocked:\n%s",

--- a/package/kedro_viz/integrations/kedro/inspection/snapshot_source.py
+++ b/package/kedro_viz/integrations/kedro/inspection/snapshot_source.py
@@ -22,23 +22,24 @@ def lite_import_stubs(
     import sys
     from unittest.mock import patch
 
-    from kedro_viz.integrations.kedro.lite_parser import LiteParser
+    from kedro_viz.integrations.kedro.lite_parser import (
+        LiteParser,
+        unresolved_modules,
+    )
     from kedro_viz.models.metadata import Metadata
 
-    lite_parser = LiteParser(package_name)
-    unresolved = lite_parser.parse(Path(project_path)) or {}
-    modules_to_mock: set[str] = set()
-    for module_set in unresolved.values():
-        modules_to_mock |= module_set
+    modules_to_mock = set(unresolved_modules(str(project_path), package_name))
 
     sys_modules_patch = sys.modules.copy()
     if modules_to_mock:
         # Same banner the live --lite loader sets, so the UI flags limited functionality.
         Metadata.set_has_missing_dependencies(True)
-        sys_modules_patch.update(lite_parser.create_mock_modules(modules_to_mock))
-        logger.warning(
-            "Kedro-Viz --lite: building the snapshot with %d project dependency module(s) "
-            "mocked. Install them for full functionality:\n%s",
+        sys_modules_patch.update(
+            LiteParser(package_name).create_mock_modules(modules_to_mock)
+        )
+        # The live loader already warned the user about these modules.
+        logger.debug(
+            "Building the snapshot with %d project dependency module(s) mocked:\n%s",
             len(modules_to_mock),
             sorted(modules_to_mock),
         )

--- a/package/kedro_viz/integrations/kedro/inspection/snapshot_source.py
+++ b/package/kedro_viz/integrations/kedro/inspection/snapshot_source.py
@@ -24,11 +24,11 @@ def lite_import_stubs(
 
     from kedro_viz.integrations.kedro.lite_parser import (
         LiteParser,
-        unresolved_modules,
+        get_unresolved_modules,
     )
     from kedro_viz.models.metadata import Metadata
 
-    modules_to_mock = set(unresolved_modules(str(project_path), package_name))
+    modules_to_mock = set(get_unresolved_modules(project_path, package_name))
 
     sys_modules_patch = sys.modules.copy()
     if modules_to_mock:
@@ -37,7 +37,7 @@ def lite_import_stubs(
         sys_modules_patch.update(
             LiteParser(package_name).create_mock_modules(modules_to_mock)
         )
-        # TODO(#2724): Restore this warning when the live loader is removed.
+        # TODO(#2661): Restore this warning when --lite startup skips the live loader.
         # The live loader already warned the user about these modules.
         logger.debug(
             "Building the snapshot with %d project dependency module(s) mocked:\n%s",

--- a/package/kedro_viz/integrations/kedro/lite_parser.py
+++ b/package/kedro_viz/integrations/kedro/lite_parser.py
@@ -3,13 +3,35 @@
 import ast
 import importlib.util
 import logging
+from functools import lru_cache
 from pathlib import Path
-from typing import Dict, List, Set, Union
+from typing import Dict, FrozenSet, List, Set, Union
 from unittest.mock import MagicMock
 
 from kedro_viz.utils import Spinner, is_file_ignored, load_gitignore_patterns
 
 logger = logging.getLogger(__name__)
+
+
+@lru_cache(maxsize=None)
+def unresolved_modules(
+    project_path: str, package_name: Union[str, None] = None
+) -> FrozenSet[str]:
+    """Return unresolved project imports, walking each project and package once.
+
+    The live loader and inspection snapshot both need this result in lite mode. Kedro-Viz
+    restarts in a new process when project files change, so the process-local cache cannot
+    serve results from an earlier reload.
+
+    Args:
+        project_path: The project directory to parse.
+        package_name: The project package to inspect, when known.
+
+    Returns:
+        The module names that need to be mocked.
+    """
+    unresolved_imports = LiteParser(package_name).parse(Path(project_path)) or {}
+    return frozenset().union(*unresolved_imports.values())
 
 
 class LiteParser:

--- a/package/kedro_viz/integrations/kedro/lite_parser.py
+++ b/package/kedro_viz/integrations/kedro/lite_parser.py
@@ -13,9 +13,8 @@ from kedro_viz.utils import Spinner, is_file_ignored, load_gitignore_patterns
 logger = logging.getLogger(__name__)
 
 
-@lru_cache(maxsize=None)
-def unresolved_modules(
-    project_path: str, package_name: Union[str, None] = None
+def get_unresolved_modules(
+    project_path: Union[str, Path], package_name: Union[str, None] = None
 ) -> FrozenSet[str]:
     """Return unresolved project imports, walking each project and package once.
 
@@ -30,6 +29,17 @@ def unresolved_modules(
     Returns:
         The module names that need to be mocked.
     """
+    resolved_project_path = str(Path(project_path).resolve())
+    return _get_unresolved_modules(resolved_project_path, package_name)
+
+
+# TODO(#2661): Remove this cache once --lite startup skips the live loader.
+# The inspection snapshot will then be the only caller during startup.
+@lru_cache(maxsize=None)
+def _get_unresolved_modules(
+    project_path: str, package_name: Union[str, None]
+) -> FrozenSet[str]:
+    """Parse and flatten unresolved imports for a resolved project path."""
     unresolved_imports = LiteParser(package_name).parse(Path(project_path)) or {}
     return frozenset().union(*unresolved_imports.values())
 

--- a/package/tests/test_inspection_adapter/test_snapshot_source.py
+++ b/package/tests/test_inspection_adapter/test_snapshot_source.py
@@ -13,6 +13,7 @@ import pytest
 
 from kedro_viz.integrations.kedro.inspection import snapshot_source
 from kedro_viz.integrations.kedro.inspection.snapshot_source import _InspectionSession
+from kedro_viz.integrations.kedro.lite_parser import _get_unresolved_modules
 
 DEMO_PROJECT = Path(__file__).resolve().parents[3] / "demo-project"
 
@@ -21,12 +22,14 @@ _MISSING_MODULE = "totally_missing_pkg_for_lite_stub_test"
 
 
 @pytest.fixture(autouse=True)
-def _restore_missing_deps_flag():
-    """Restore the global ``Metadata.has_missing_dependencies`` banner after each test."""
+def _restore_lite_mode_state():
+    """Restore process-level lite-mode state after each test."""
     from kedro_viz.models.metadata import Metadata
 
     original = Metadata.has_missing_dependencies
+    _get_unresolved_modules.cache_clear()
     yield
+    _get_unresolved_modules.cache_clear()
     Metadata.set_has_missing_dependencies(original)
 
 

--- a/package/tests/test_integrations/test_lite_parser.py
+++ b/package/tests/test_integrations/test_lite_parser.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from kedro_viz.integrations.kedro.lite_parser import LiteParser
+from kedro_viz.integrations.kedro.lite_parser import LiteParser, unresolved_modules
 
 
 @pytest.fixture
@@ -248,3 +248,29 @@ class TestLiteParser:
         # ignore files in other packages if
         # LiteParser is instantiated with a package_name
         assert len(unresolvable_imports) == 0
+
+
+class TestUnresolvedModules:
+    def test_returns_the_flattened_module_names(
+        self, sample_project_path, mock_spinner
+    ):
+        unresolved_modules.cache_clear()
+        assert unresolved_modules(
+            str(sample_project_path / "mock_spaceflights"), None
+        ) == frozenset({"nonexistentmodule"})
+
+    def test_the_project_is_walked_once_per_project_and_package(
+        self, sample_project_path, mock_spinner
+    ):
+        """The two lite-mode callers should share one project walk."""
+        unresolved_modules.cache_clear()
+        target = str(sample_project_path / "mock_spaceflights")
+
+        with patch.object(
+            LiteParser, "parse", autospec=True, return_value={}
+        ) as mock_parse:
+            unresolved_modules(target, None)
+            unresolved_modules(target, None)
+            unresolved_modules(target, "mock_spaceflights")
+
+        assert mock_parse.call_count == 2

--- a/package/tests/test_integrations/test_lite_parser.py
+++ b/package/tests/test_integrations/test_lite_parser.py
@@ -3,7 +3,18 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from kedro_viz.integrations.kedro.lite_parser import LiteParser, unresolved_modules
+from kedro_viz.integrations.kedro.lite_parser import (
+    LiteParser,
+    _get_unresolved_modules,
+    get_unresolved_modules,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_unresolved_modules_cache():
+    _get_unresolved_modules.cache_clear()
+    yield
+    _get_unresolved_modules.cache_clear()
 
 
 @pytest.fixture
@@ -250,27 +261,40 @@ class TestLiteParser:
         assert len(unresolvable_imports) == 0
 
 
-class TestUnresolvedModules:
+class TestGetUnresolvedModules:
     def test_returns_the_flattened_module_names(
         self, sample_project_path, mock_spinner
     ):
-        unresolved_modules.cache_clear()
-        assert unresolved_modules(
-            str(sample_project_path / "mock_spaceflights"), None
+        assert get_unresolved_modules(
+            sample_project_path / "mock_spaceflights", None
         ) == frozenset({"nonexistentmodule"})
 
     def test_the_project_is_walked_once_per_project_and_package(
         self, sample_project_path, mock_spinner
     ):
         """The two lite-mode callers should share one project walk."""
-        unresolved_modules.cache_clear()
-        target = str(sample_project_path / "mock_spaceflights")
+        target = sample_project_path / "mock_spaceflights"
 
         with patch.object(
             LiteParser, "parse", autospec=True, return_value={}
         ) as mock_parse:
-            unresolved_modules(target, None)
-            unresolved_modules(target, None)
-            unresolved_modules(target, "mock_spaceflights")
+            get_unresolved_modules(target, None)
+            get_unresolved_modules(target, None)
+            get_unresolved_modules(target, "mock_spaceflights")
 
         assert mock_parse.call_count == 2
+
+    def test_normalizes_the_project_path_before_cache_lookup(
+        self, sample_project_path, mock_spinner, monkeypatch
+    ):
+        """Relative and absolute paths to one project should share a cache entry."""
+        absolute_target = sample_project_path / "mock_spaceflights"
+        monkeypatch.chdir(sample_project_path)
+
+        with patch.object(
+            LiteParser, "parse", autospec=True, return_value={}
+        ) as mock_parse:
+            get_unresolved_modules(Path("mock_spaceflights"), None)
+            get_unresolved_modules(absolute_target, None)
+
+        mock_parse.assert_called_once()


### PR DESCRIPTION
## Description

Both the live lite loader and the inspection snapshot stubs need the same unresolved-project-import list. Cache that scan by project path and package so starting Kedro-Viz in lite mode does not walk the project twice.

This is an independent optimisation extracted from #2750. It does not change the graph or endpoint behaviour.

- Add a cached `unresolved_modules()` helper.
- Reuse it from the live loader and snapshot import stubs.
- Keep the existing missing-dependency mocking and user-facing lite warning.
- Add focused coverage for flattened results and cache keys.

## Verification

- `pytest package/tests/test_integrations/test_lite_parser.py`: 25 passed
- `pytest package/tests/test_inspection_adapter/test_snapshot_source.py -k lite_import_stubs`: 2 passed
- `pytest package/tests/test_integrations/test_kedro_data_loader.py`: 23 passed
- `ruff check`: clean
- `ruff format --check`: clean