### PR TITLE
Centralize inspection inputs in `VizProjectContext`

### DIFF
--- a/package/kedro_viz/integrations/kedro/inspection/__init__.py
+++ b/package/kedro_viz/integrations/kedro/inspection/__init__.py
@@ -2,16 +2,10 @@
 
 from kedro_viz.integrations.kedro.inspection.context import VizProjectContext
 from kedro_viz.integrations.kedro.inspection.enrichment import EnrichmentSources
-from kedro_viz.integrations.kedro.inspection.graph_builder import GraphBuilder
-from kedro_viz.integrations.kedro.inspection.graph_service import (
-    InspectionGraphService,
-    PipelineNotFoundError,
-)
+from kedro_viz.integrations.kedro.inspection.errors import PipelineNotFoundError
 
 __all__ = [
     "EnrichmentSources",
-    "GraphBuilder",
-    "InspectionGraphService",
     "PipelineNotFoundError",
     "VizProjectContext",
 ]

--- a/package/kedro_viz/integrations/kedro/inspection/context.py
+++ b/package/kedro_viz/integrations/kedro/inspection/context.py
@@ -9,6 +9,10 @@ from kedro_viz.integrations.kedro.inspection.enrichment import EnrichmentSources
 from kedro_viz.integrations.kedro.inspection.graph_service import (
     InspectionGraphService,
 )
+from kedro_viz.integrations.kedro.inspection.snapshot_source import (
+    filter_inspection_inputs,
+    load_inspection_inputs,
+)
 
 
 class VizProjectContext:
@@ -47,14 +51,20 @@ class VizProjectContext:
         Raises:
             PipelineNotFoundError: If ``pipeline_name`` is not registered.
         """
+        inspection_inputs = load_inspection_inputs(
+            project_path,
+            env=env,
+            runtime_params=runtime_params,
+            package_name=package_name,
+            is_lite=is_lite,
+        )
+        if pipeline_name is not None:
+            inspection_inputs = filter_inspection_inputs(
+                inspection_inputs, pipeline_name
+            )
         return cls(
-            graph=InspectionGraphService.from_project(
-                project_path,
-                env=env,
-                pipeline_name=pipeline_name,
-                runtime_params=runtime_params,
-                package_name=package_name,
-                is_lite=is_lite,
+            graph=InspectionGraphService.from_inspection_inputs(
+                inspection_inputs,
                 enrichment=enrichment,
             )
         )

--- a/package/kedro_viz/integrations/kedro/inspection/errors.py
+++ b/package/kedro_viz/integrations/kedro/inspection/errors.py
@@ -1,0 +1,5 @@
+"""Domain errors raised by project-scoped inspection services."""
+
+
+class PipelineNotFoundError(ValueError):
+    """Raised when a requested pipeline is not present in the inspection snapshot."""

--- a/package/kedro_viz/integrations/kedro/inspection/graph_service.py
+++ b/package/kedro_viz/integrations/kedro/inspection/graph_service.py
@@ -2,28 +2,16 @@
 
 from __future__ import annotations
 
-import dataclasses
-from contextlib import nullcontext
-from pathlib import Path
-from typing import TYPE_CHECKING, Any
-
 from kedro_viz.api.rest.responses.pipelines import GraphAPIResponse
 from kedro_viz.integrations.kedro.inspection.enrichment import (
     EnrichmentSources,
     enrich_graph_response,
 )
+from kedro_viz.integrations.kedro.inspection.errors import PipelineNotFoundError
 from kedro_viz.integrations.kedro.inspection.graph_builder import GraphBuilder
 from kedro_viz.integrations.kedro.inspection.snapshot_source import (
-    _InspectionSession,
-    lite_import_stubs,
+    InspectionInputs,
 )
-
-if TYPE_CHECKING:
-    from kedro.inspection.models import ProjectSnapshot
-
-
-class PipelineNotFoundError(ValueError):
-    """Raised when a requested pipeline is not present in the inspection snapshot."""
 
 
 class InspectionGraphService:
@@ -38,52 +26,23 @@ class InspectionGraphService:
         self._enrichment = enrichment if enrichment is not None else EnrichmentSources()
 
     @classmethod
-    def from_project(
+    def from_inspection_inputs(
         cls,
-        project_path: str | Path,
+        inspection_inputs: InspectionInputs,
         *,
-        env: str | None = None,
-        pipeline_name: str | None = None,
-        runtime_params: dict[str, Any] | None = None,
-        package_name: str | None = None,
-        is_lite: bool = False,
         enrichment: EnrichmentSources | None = None,
     ) -> InspectionGraphService:
-        """Read one project snapshot and prepare the graph service.
-
-        Args:
-            project_path: The Kedro project root.
-            env: The Kedro environment, honouring ``--env``.
-            pipeline_name: Restrict the view to one registered pipeline, honouring
-                ``--pipeline``.
-            runtime_params: Typed parameter overrides from ``--params``.
-            package_name: Project package used to identify imports in lite mode.
-            is_lite: Whether missing project dependencies should be temporarily mocked.
-            enrichment: Explicit fields supplied by the transitional live load.
-
-        Raises:
-            PipelineNotFoundError: If ``pipeline_name`` is not registered.
-        """
-        sources = enrichment if enrichment is not None else EnrichmentSources()
-        import_context = (
-            lite_import_stubs(project_path, package_name) if is_lite else nullcontext()
+        """Prepare the graph service from already-loaded inspection inputs."""
+        enrichment_sources = (
+            enrichment if enrichment is not None else EnrichmentSources()
         )
-        with import_context:
-            session = _InspectionSession(
-                project_path, env=env, runtime_params=runtime_params
-            )
-            snapshot = session.snapshot()
-            catalog_config = session.catalog_config()
-            parameters = session.parameters()
-            if pipeline_name is not None:
-                snapshot = cls._filter_to_pipeline(snapshot, pipeline_name)
-            builder = GraphBuilder(
-                snapshot,
-                catalog_config,
-                parameters=parameters,
-                layer_by_dataset=sources.layer_by_dataset,
-            )
-        return cls(builder, sources)
+        builder = GraphBuilder(
+            inspection_inputs.snapshot,
+            dict(inspection_inputs.catalog_config),
+            parameters=dict(inspection_inputs.parameters),
+            layer_by_dataset=enrichment_sources.layer_by_dataset,
+        )
+        return cls(builder, enrichment_sources)
 
     def get_pipeline_response(self, pipeline_id: str | None = None) -> GraphAPIResponse:
         """Return the graph for one registered pipeline.
@@ -101,24 +60,3 @@ class InspectionGraphService:
         response = self._builder.build(selected_pipeline_id)
         enrich_graph_response(response, self._enrichment)
         return response
-
-    @staticmethod
-    def _filter_to_pipeline(
-        snapshot: ProjectSnapshot, pipeline_name: str
-    ) -> ProjectSnapshot:
-        """Return a copy of the snapshot containing only the requested pipeline.
-
-        Raises:
-            PipelineNotFoundError: If ``pipeline_name`` is not registered.
-        """
-        matching = [
-            pipeline
-            for pipeline in snapshot.pipelines
-            if pipeline.name == pipeline_name
-        ]
-        if not matching:
-            available = sorted(pipeline.name for pipeline in snapshot.pipelines)
-            raise PipelineNotFoundError(
-                f"Pipeline {pipeline_name!r} not found in snapshot; available: {available}"
-            )
-        return dataclasses.replace(snapshot, pipelines=matching)

--- a/package/kedro_viz/integrations/kedro/inspection/snapshot_source.py
+++ b/package/kedro_viz/integrations/kedro/inspection/snapshot_source.py
@@ -2,16 +2,40 @@
 
 from __future__ import annotations
 
+import dataclasses
 import logging
-from collections.abc import Iterator
-from contextlib import contextmanager
+from collections.abc import Iterator, Mapping
+from contextlib import contextmanager, nullcontext
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
+
+from pydantic import BaseModel, Field, field_validator
+
+from kedro_viz.integrations.kedro.inspection.errors import PipelineNotFoundError
 
 if TYPE_CHECKING:
     from kedro.inspection.models import ProjectSnapshot
 
 logger = logging.getLogger(__name__)
+
+
+class InspectionInputs(BaseModel, frozen=True):
+    """Snapshot and resolved config shared by a project's inspection services."""
+
+    # Kedro has already built the snapshot. Keep it opaque to Pydantic so importing
+    # this model does not load Kedro inspection modules before lite-mode stubs.
+    if TYPE_CHECKING:
+        snapshot: ProjectSnapshot
+    else:
+        snapshot: Any
+    catalog_config: Mapping[str, Any] = Field(default_factory=dict)
+    parameters: Mapping[str, Any] = Field(default_factory=dict)
+
+    @field_validator("catalog_config", "parameters", mode="before")
+    @classmethod
+    def _copy_mapping(cls, value: Mapping[str, Any]) -> dict[str, Any]:
+        """Copy caller-owned mappings before storing the prepared inputs."""
+        return dict(value)
 
 
 @contextmanager
@@ -48,11 +72,10 @@ def lite_import_stubs(
 
 
 class _InspectionSession:
-    """Read a project's snapshot and config, bootstrapping and building the loader once.
+    """Read a project's snapshot and config with one cached config loader.
 
-    Create one session per adapter build. The project is bootstrapped and the Kedro config loader
-    is built lazily on first use and then cached, so the catalog config and parameters reuse a
-    single loader instead of rebuilding it.
+    The catalog config and parameters share the loader built lazily here. Kedro's snapshot API
+    performs its own internal project bootstrap and config loading.
     """
 
     def __init__(
@@ -113,3 +136,60 @@ class _InspectionSession:
             return self.config_loader["parameters"]
         except (KeyError, MissingConfigException):
             return {}
+
+
+def load_inspection_inputs(
+    project_path: str | Path,
+    *,
+    env: str | None = None,
+    runtime_params: dict[str, Any] | None = None,
+    package_name: str | None = None,
+    is_lite: bool = False,
+) -> InspectionInputs:
+    """Read the snapshot and resolved config for one context build.
+
+    Lite-mode import stubs remain active until all three inputs have been read. A single
+    ``_InspectionSession`` coordinates the reads; Kedro's snapshot API may perform its own
+    internal bootstrap independently of the cached config loader used by the other two reads.
+    """
+    import_context = (
+        lite_import_stubs(project_path, package_name) if is_lite else nullcontext()
+    )
+    with import_context:
+        session = _InspectionSession(
+            project_path,
+            env=env,
+            runtime_params=runtime_params,
+        )
+        return InspectionInputs(
+            snapshot=session.snapshot(),
+            catalog_config=session.catalog_config(),
+            parameters=session.parameters(),
+        )
+
+
+def filter_inspection_inputs(
+    inputs: InspectionInputs,
+    pipeline_name: str,
+) -> InspectionInputs:
+    """Return inspection inputs whose snapshot contains only ``pipeline_name``.
+
+    Raises:
+        PipelineNotFoundError: If ``pipeline_name`` is not registered.
+    """
+    matching = [
+        pipeline
+        for pipeline in inputs.snapshot.pipelines
+        if pipeline.name == pipeline_name
+    ]
+    if not matching:
+        available = sorted(pipeline.name for pipeline in inputs.snapshot.pipelines)
+        raise PipelineNotFoundError(
+            f"Pipeline {pipeline_name!r} not found in snapshot; available: {available}"
+        )
+
+    return InspectionInputs(
+        snapshot=dataclasses.replace(inputs.snapshot, pipelines=matching),
+        catalog_config=inputs.catalog_config,
+        parameters=inputs.parameters,
+    )

--- a/package/tests/conftest.py
+++ b/package/tests/conftest.py
@@ -20,9 +20,9 @@ from kedro_viz.data_access.repositories.modular_pipelines import (
 )
 from kedro_viz.integrations.kedro.hooks import DatasetStatsHook
 from kedro_viz.integrations.kedro.inspection import (
-    InspectionGraphService,
     VizProjectContext,
 )
+from kedro_viz.integrations.kedro.inspection.graph_service import InspectionGraphService
 from kedro_viz.models.flowchart.node_metadata import DataNodeMetadata
 from kedro_viz.models.flowchart.nodes import GraphNode
 from kedro_viz.models.metadata import NodeExtras

--- a/package/tests/test_inspection_adapter/test_context.py
+++ b/package/tests/test_inspection_adapter/test_context.py
@@ -1,0 +1,136 @@
+"""Tests for constructing project-scoped inspection services from shared inputs."""
+
+from pathlib import Path
+
+import pytest
+
+from kedro_viz.api.rest.responses.pipelines import TaskNodeAPIResponse
+from kedro_viz.integrations.kedro.inspection import (
+    EnrichmentSources,
+    PipelineNotFoundError,
+    VizProjectContext,
+)
+from kedro_viz.integrations.kedro.inspection import context as context_module
+from kedro_viz.integrations.kedro.inspection.graph_service import InspectionGraphService
+
+PROJECT = Path("/some/project")
+DEMO_PROJECT = Path(__file__).resolve().parents[3] / "demo-project"
+
+
+def test_context_builds_graph_from_the_loaded_inputs(mocker) -> None:
+    """The context, rather than an individual service, owns the project read."""
+    inputs = mocker.sentinel.inputs
+    load_inputs = mocker.patch(
+        "kedro_viz.integrations.kedro.inspection.context.load_inspection_inputs",
+        return_value=inputs,
+    )
+    graph = mocker.sentinel.graph
+    from_inspection_inputs = mocker.patch.object(
+        InspectionGraphService,
+        "from_inspection_inputs",
+        return_value=graph,
+    )
+    enrichment = EnrichmentSources()
+    runtime_params = {"split": 0.3}
+
+    context = VizProjectContext.from_project(
+        PROJECT,
+        env="staging",
+        runtime_params=runtime_params,
+        package_name="spaceflights",
+        is_lite=True,
+        enrichment=enrichment,
+    )
+
+    load_inputs.assert_called_once_with(
+        PROJECT,
+        env="staging",
+        runtime_params=runtime_params,
+        package_name="spaceflights",
+        is_lite=True,
+    )
+    from_inspection_inputs.assert_called_once_with(
+        inputs,
+        enrichment=enrichment,
+    )
+    assert context.graph is graph
+
+
+def test_context_filters_shared_inputs_before_building_services(mocker) -> None:
+    """A pipeline restriction is applied once at the context boundary."""
+    inputs = mocker.sentinel.inputs
+    filtered_inputs = mocker.sentinel.filtered_inputs
+    mocker.patch(
+        "kedro_viz.integrations.kedro.inspection.context.load_inspection_inputs",
+        return_value=inputs,
+    )
+    filter_inputs = mocker.patch(
+        "kedro_viz.integrations.kedro.inspection.context.filter_inspection_inputs",
+        return_value=filtered_inputs,
+    )
+    from_inspection_inputs = mocker.patch.object(
+        InspectionGraphService,
+        "from_inspection_inputs",
+    )
+
+    VizProjectContext.from_project(PROJECT, pipeline_name="data_science")
+
+    filter_inputs.assert_called_once_with(inputs, "data_science")
+    from_inspection_inputs.assert_called_once_with(filtered_inputs, enrichment=None)
+
+
+@pytest.mark.parametrize("pipeline_name", ["unknown", ""])
+def test_unknown_pipeline_is_rejected_before_service_construction(
+    mocker, _restore_kedro_project_state, pipeline_name
+) -> None:
+    prepare = mocker.patch.object(InspectionGraphService, "from_inspection_inputs")
+
+    with pytest.raises(PipelineNotFoundError, match="not found in snapshot"):
+        VizProjectContext.from_project(DEMO_PROJECT, pipeline_name=pipeline_name)
+
+    prepare.assert_not_called()
+
+
+def test_context_reuses_loaded_inputs_across_requests(
+    mocker, _restore_kedro_project_state
+) -> None:
+    load = mocker.spy(context_module, "load_inspection_inputs")
+    filter_inputs = mocker.spy(context_module, "filter_inspection_inputs")
+    prepare = mocker.spy(InspectionGraphService, "from_inspection_inputs")
+
+    context = VizProjectContext.from_project(
+        DEMO_PROJECT, pipeline_name="data_ingestion"
+    )
+    first = context.graph.get_pipeline_response()
+    second = context.graph.get_pipeline_response("data_ingestion")
+
+    load.assert_called_once()
+    filter_inputs.assert_called_once()
+    prepare.assert_called_once()
+    assert first == second
+    assert first is not second
+
+
+def test_context_preserves_unvalidated_parameter_values(
+    mocker, _restore_kedro_project_state
+) -> None:
+    """Inspection must not add pipeline-annotation validation during context loading."""
+    validate = mocker.patch(
+        "kedro.validation.parameter_validator.ParameterValidator.validate_raw_params",
+        side_effect=AssertionError("Inspection must not validate parameters"),
+    )
+    context = VizProjectContext.from_project(
+        DEMO_PROJECT,
+        runtime_params={"split_options": {"test_size": "not-a-number"}},
+    )
+
+    response = context.graph.get_pipeline_response()
+
+    validate.assert_not_called()
+    split_nodes = [
+        node
+        for node in response.nodes
+        if isinstance(node, TaskNodeAPIResponse) and node.name.startswith("split_data")
+    ]
+    assert split_nodes
+    assert split_nodes[0].parameters["split_options"]["test_size"] == "not-a-number"

--- a/package/tests/test_inspection_adapter/test_graph_routes.py
+++ b/package/tests/test_inspection_adapter/test_graph_routes.py
@@ -14,10 +14,10 @@ from fastapi.testclient import TestClient
 from kedro_viz.api import apps
 from kedro_viz.api.rest.responses.pipelines import GraphAPIResponse
 from kedro_viz.integrations.kedro.inspection import (
-    InspectionGraphService,
     VizProjectContext,
 )
 from kedro_viz.integrations.kedro.inspection.graph_service import (
+    InspectionGraphService,
     PipelineNotFoundError,
 )
 

--- a/package/tests/test_inspection_adapter/test_graph_service.py
+++ b/package/tests/test_inspection_adapter/test_graph_service.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from contextlib import contextmanager
 from pathlib import Path
 
 import pytest
@@ -10,8 +9,13 @@ import pytest
 from kedro_viz.api.rest.responses.pipelines import GraphAPIResponse
 from kedro_viz.integrations.kedro.inspection import (
     EnrichmentSources,
-    InspectionGraphService,
     PipelineNotFoundError,
+)
+from kedro_viz.integrations.kedro.inspection.graph_service import InspectionGraphService
+from kedro_viz.integrations.kedro.inspection.snapshot_source import (
+    InspectionInputs,
+    filter_inspection_inputs,
+    load_inspection_inputs,
 )
 
 DEMO_PROJECT = Path(__file__).resolve().parents[3] / "demo-project"
@@ -20,7 +24,9 @@ DEMO_PROJECT = Path(__file__).resolve().parents[3] / "demo-project"
 @pytest.fixture(scope="module")
 def graph_service(_restore_kedro_project_state) -> InspectionGraphService:
     """Build the demo snapshot once for the service response tests."""
-    return InspectionGraphService.from_project(DEMO_PROJECT)
+    return InspectionGraphService.from_inspection_inputs(
+        load_inspection_inputs(DEMO_PROJECT)
+    )
 
 
 def test_default_pipeline_is_served_when_none_is_requested(graph_service) -> None:
@@ -57,9 +63,11 @@ def test_pipeline_filter_hides_every_other_pipeline(
     _restore_kedro_project_state,
 ) -> None:
     """``--pipeline`` narrows the snapshot to that pipeline alone."""
-    service = InspectionGraphService.from_project(
-        DEMO_PROJECT, pipeline_name="data_ingestion"
+    inputs = filter_inspection_inputs(
+        load_inspection_inputs(DEMO_PROJECT),
+        "data_ingestion",
     )
+    service = InspectionGraphService.from_inspection_inputs(inputs)
 
     response = service.get_pipeline_response()
     assert [pipeline.id for pipeline in response.pipelines] == ["data_ingestion"]
@@ -67,115 +75,49 @@ def test_pipeline_filter_hides_every_other_pipeline(
         service.get_pipeline_response("reporting_stage")
 
 
-def test_unknown_pipeline_filter_is_rejected_at_startup(
-    _restore_kedro_project_state,
-) -> None:
-    """A bad ``--pipeline`` fails during construction, not on the first request."""
-    with pytest.raises(PipelineNotFoundError, match="not found in snapshot"):
-        InspectionGraphService.from_project(
-            DEMO_PROJECT, pipeline_name="no_such_pipeline"
-        )
-
-
-def test_project_options_and_parameters_reach_the_builder(mocker) -> None:
-    """Snapshot configuration and resolved parameters come from the same session."""
-    runtime_params = {"split_options": {"test_size": 0.3}}
-    session_class = mocker.patch(
-        "kedro_viz.integrations.kedro.inspection.graph_service._InspectionSession"
+def test_inputs_reaches_the_builder(mocker) -> None:
+    """Graph construction consumes the already-loaded snapshot and config."""
+    inputs = mocker.Mock(
+        spec=InspectionInputs,
+        snapshot=mocker.sentinel.snapshot,
+        catalog_config={"companies": {}},
+        parameters={"split": 0.2},
     )
-    session = session_class.return_value
     graph_builder = mocker.patch(
         "kedro_viz.integrations.kedro.inspection.graph_service.GraphBuilder"
     )
 
-    InspectionGraphService.from_project(
-        DEMO_PROJECT,
-        env="staging",
-        runtime_params=runtime_params,
-    )
+    InspectionGraphService.from_inspection_inputs(inputs)
 
-    session_class.assert_called_once_with(
-        DEMO_PROJECT,
-        env="staging",
-        runtime_params=runtime_params,
-    )
     graph_builder.assert_called_once_with(
-        session.snapshot.return_value,
-        session.catalog_config.return_value,
-        parameters=session.parameters.return_value,
+        mocker.sentinel.snapshot,
+        {"companies": {}},
+        parameters={"split": 0.2},
         layer_by_dataset=None,
     )
 
 
 def test_populated_catalog_layers_reach_the_builder(mocker) -> None:
     """The post-hook catalog mapping is authoritative for rendered layers."""
-    session = mocker.patch(
-        "kedro_viz.integrations.kedro.inspection.graph_service._InspectionSession"
-    ).return_value
     graph_builder = mocker.patch(
         "kedro_viz.integrations.kedro.inspection.graph_service.GraphBuilder"
     )
     enrichment = EnrichmentSources(layer_by_dataset={"companies": "hooked"})
+    inputs = mocker.Mock(
+        spec=InspectionInputs,
+        snapshot=mocker.sentinel.snapshot,
+        catalog_config={},
+        parameters={},
+    )
 
-    InspectionGraphService.from_project(DEMO_PROJECT, enrichment=enrichment)
+    InspectionGraphService.from_inspection_inputs(inputs, enrichment=enrichment)
 
     graph_builder.assert_called_once_with(
-        session.snapshot.return_value,
-        session.catalog_config.return_value,
-        parameters=session.parameters.return_value,
+        mocker.sentinel.snapshot,
+        {},
+        parameters={},
         layer_by_dataset={"companies": "hooked"},
     )
-
-
-def test_lite_service_reads_project_data_inside_import_stubs(mocker) -> None:
-    """Project imports stay mocked until snapshot, catalog and parameters are read."""
-    events: list[object] = []
-
-    @contextmanager
-    def import_stubs(project_path, package_name):
-        events.append(("enter", project_path, package_name))
-        yield
-        events.append(("exit", project_path, package_name))
-
-    session = mocker.patch(
-        "kedro_viz.integrations.kedro.inspection.graph_service._InspectionSession"
-    ).return_value
-
-    def read_snapshot():
-        events.append("snapshot")
-        return object()
-
-    def read_catalog():
-        events.append("catalog")
-        return {}
-
-    def read_parameters():
-        events.append("parameters")
-        return {}
-
-    session.snapshot.side_effect = read_snapshot
-    session.catalog_config.side_effect = read_catalog
-    session.parameters.side_effect = read_parameters
-    mocker.patch("kedro_viz.integrations.kedro.inspection.graph_service.GraphBuilder")
-    stubs = mocker.patch(
-        "kedro_viz.integrations.kedro.inspection.graph_service.lite_import_stubs",
-        side_effect=import_stubs,
-    )
-
-    InspectionGraphService.from_project(
-        DEMO_PROJECT,
-        package_name="spaceflights",
-        is_lite=True,
-    )
-
-    stubs.assert_called_once_with(DEMO_PROJECT, "spaceflights")
-    assert events == [
-        ("enter", DEMO_PROJECT, "spaceflights"),
-        "snapshot",
-        "catalog",
-        "parameters",
-        ("exit", DEMO_PROJECT, "spaceflights"),
-    ]
 
 
 def test_service_enriches_the_built_response(mocker) -> None:

--- a/package/tests/test_inspection_adapter/test_inspection_adapter_parity.py
+++ b/package/tests/test_inspection_adapter/test_inspection_adapter_parity.py
@@ -19,7 +19,10 @@ from kedro_viz.constants import ROOT_MODULAR_PIPELINE_ID
 from kedro_viz.data_access import DataAccessManager
 from kedro_viz.integrations.kedro.inspection import (
     EnrichmentSources,
-    InspectionGraphService,
+)
+from kedro_viz.integrations.kedro.inspection.graph_service import InspectionGraphService
+from kedro_viz.integrations.kedro.inspection.snapshot_source import (
+    load_inspection_inputs,
 )
 
 from .capture_baseline import normalize_graph
@@ -73,7 +76,10 @@ def live_enriched_graph_service(_restore_kedro_project_state):
     catalog, pipelines, node_extras = data_loader.load_data(DEMO_PROJECT)
     populate_data(manager, catalog, pipelines, node_extras)
     enrichment = EnrichmentSources.from_live_nodes(manager.nodes.as_list())
-    return InspectionGraphService.from_project(DEMO_PROJECT, enrichment=enrichment)
+    return InspectionGraphService.from_inspection_inputs(
+        load_inspection_inputs(DEMO_PROJECT),
+        enrichment=enrichment,
+    )
 
 
 @pytest.mark.parametrize("pipeline_id", PIPELINE_IDS)

--- a/package/tests/test_inspection_adapter/test_snapshot_source.py
+++ b/package/tests/test_inspection_adapter/test_snapshot_source.py
@@ -5,19 +5,46 @@ the bundled ``demo-project``.
 """
 
 import importlib
+import importlib.util
 import sys
+from contextlib import contextmanager
 from pathlib import Path
 from unittest.mock import PropertyMock
 
 import pytest
+from kedro.inspection.models import (
+    PipelineSnapshot,
+    ProjectMetadataSnapshot,
+    ProjectSnapshot,
+)
+from pydantic import ValidationError
 
 from kedro_viz.integrations.kedro.inspection import snapshot_source
-from kedro_viz.integrations.kedro.inspection.snapshot_source import _InspectionSession
+from kedro_viz.integrations.kedro.inspection.errors import PipelineNotFoundError
+from kedro_viz.integrations.kedro.inspection.snapshot_source import (
+    InspectionInputs,
+    _InspectionSession,
+    filter_inspection_inputs,
+    load_inspection_inputs,
+)
 
 DEMO_PROJECT = Path(__file__).resolve().parents[3] / "demo-project"
 
 # A module name that does not exist, so LiteParser must flag it as unresolved.
 _MISSING_MODULE = "totally_missing_pkg_for_lite_stub_test"
+
+
+def _snapshot(*pipeline_names: str) -> ProjectSnapshot:
+    return ProjectSnapshot(
+        metadata=ProjectMetadataSnapshot(
+            project_name="project",
+            package_name="project",
+            kedro_version="1.0.0",
+        ),
+        pipelines=[PipelineSnapshot(name=name, nodes=[]) for name in pipeline_names],
+        datasets={},
+        parameters=[],
+    )
 
 
 @pytest.fixture(autouse=True)
@@ -130,3 +157,147 @@ def test_session_returns_empty_when_section_missing(mocker, section) -> None:
         return_value={},
     )
     assert getattr(_InspectionSession(DEMO_PROJECT), section)() == {}
+
+
+# -- prepared inspection inputs -- #
+
+
+def test_inputs_copies_mappings_and_is_frozen() -> None:
+    catalog_config = {"companies": {"type": "pandas.CSVDataset"}}
+    parameters = {"split": 0.2}
+    snapshot = _snapshot("__default__")
+
+    inputs = InspectionInputs(
+        snapshot=snapshot,
+        catalog_config=catalog_config,
+        parameters=parameters,
+    )
+    catalog_config["new"] = {}
+    parameters["new"] = True
+
+    assert inputs.catalog_config == {"companies": {"type": "pandas.CSVDataset"}}
+    assert inputs.parameters == {"split": 0.2}
+    assert inputs.snapshot is snapshot
+    assert set(InspectionInputs.model_fields) == {
+        "snapshot",
+        "catalog_config",
+        "parameters",
+    }
+    with pytest.raises(ValidationError, match="frozen_instance"):
+        inputs.parameters = {}  # type: ignore[misc]
+
+
+def test_inputs_module_does_not_import_kedro_inspection_or_validation(monkeypatch):
+    """The inputs model can load before lite-mode project imports are stubbed."""
+    import builtins
+
+    original_import = builtins.__import__
+
+    def guarded_import(name, *args, **kwargs):
+        if name.startswith(("kedro.inspection", "kedro.validation")):
+            raise AssertionError(f"Eager Kedro import: {name}")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", guarded_import)
+    spec = importlib.util.spec_from_file_location(
+        "_inspection_inputs_import_test", snapshot_source.__file__
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, spec.name, module)
+    spec.loader.exec_module(module)
+
+    snapshot = _snapshot("__default__")
+    inputs = module.InspectionInputs(snapshot=snapshot)
+    assert inputs.snapshot is snapshot
+    assert inputs.parameters == {}
+
+
+def test_load_inputs_reads_every_input_inside_lite_stubs(mocker) -> None:
+    events: list[object] = []
+
+    @contextmanager
+    def import_stubs(project_path, package_name):
+        events.append(("enter", project_path, package_name))
+        yield
+        events.append(("exit", project_path, package_name))
+
+    session_class = mocker.patch.object(snapshot_source, "_InspectionSession")
+    session = session_class.return_value
+    snapshot = _snapshot("__default__")
+
+    def read_snapshot():
+        events.append("snapshot")
+        return snapshot
+
+    def read_catalog():
+        events.append("catalog")
+        return {"companies": {}}
+
+    def read_parameters():
+        events.append("parameters")
+        return {"split": 0.2}
+
+    session.snapshot.side_effect = read_snapshot
+    session.catalog_config.side_effect = read_catalog
+    session.parameters.side_effect = read_parameters
+    stubs = mocker.patch.object(
+        snapshot_source,
+        "lite_import_stubs",
+        side_effect=import_stubs,
+    )
+
+    result = load_inspection_inputs(
+        DEMO_PROJECT,
+        env="staging",
+        runtime_params={"split": 0.3},
+        package_name="spaceflights",
+        is_lite=True,
+    )
+
+    session_class.assert_called_once_with(
+        DEMO_PROJECT,
+        env="staging",
+        runtime_params={"split": 0.3},
+    )
+    stubs.assert_called_once_with(DEMO_PROJECT, "spaceflights")
+    assert result.snapshot == snapshot
+    assert result.catalog_config == {"companies": {}}
+    assert result.parameters == {"split": 0.2}
+    assert events == [
+        ("enter", DEMO_PROJECT, "spaceflights"),
+        "snapshot",
+        "catalog",
+        "parameters",
+        ("exit", DEMO_PROJECT, "spaceflights"),
+    ]
+
+
+def test_filter_inputs_preserves_config_and_selects_pipeline() -> None:
+    inputs = InspectionInputs(
+        snapshot=_snapshot("__default__", "data_science"),
+        catalog_config={"companies": {}},
+        parameters={"split": 0.2},
+    )
+
+    filtered = filter_inspection_inputs(inputs, "data_science")
+
+    assert [pipeline.name for pipeline in filtered.snapshot.pipelines] == [
+        "data_science"
+    ]
+    assert filtered.catalog_config == inputs.catalog_config
+    assert filtered.parameters == inputs.parameters
+    assert [pipeline.name for pipeline in inputs.snapshot.pipelines] == [
+        "__default__",
+        "data_science",
+    ]
+
+
+def test_filter_inputs_rejects_unknown_pipeline() -> None:
+    inputs = InspectionInputs(snapshot=_snapshot("__default__"))
+
+    with pytest.raises(
+        PipelineNotFoundError,
+        match=r"Pipeline 'unknown' not found in snapshot; available: \['__default__'\]",
+    ):
+        filter_inspection_inputs(inputs, "unknown")


### PR DESCRIPTION
Part 1 of 6 for #2660. Existing native GitHub stack #2769.

Review order: [1: #2763](https://github.com/kedro-org/kedro-viz/pull/2763) → [2: #2764](https://github.com/kedro-org/kedro-viz/pull/2764) → [3: #2765](https://github.com/kedro-org/kedro-viz/pull/2765) → [4: #2766](https://github.com/kedro-org/kedro-viz/pull/2766) → [5: #2767](https://github.com/kedro-org/kedro-viz/pull/2767) → [6: #2768](https://github.com/kedro-org/kedro-viz/pull/2768).

Please start review here. The other five PRs remain drafts and are available for context or early feedback.

## Description

Move inspection loading to the project context so services can share the same prepared inputs. This follows Ravi’s clarified composition-root design.

## Development notes

- Add the frozen Pydantic `InspectionInputs` model with only `snapshot`, `catalog_config` and `parameters`.
- Use module-level `load_inspection_inputs()` and `filter_inspection_inputs()` helpers. The context coordinates loading and selection; the graph service consumes prepared inputs.
- Preserve existing parameter behavior and `GraphBuilder(parameters=...)`. No annotation validation, flattened feed or typed-field expansion is introduced.
- Keep Kedro inspection imports lazy for lite mode.
- Use explicit `inspection_inputs` and `enrichment_sources` names. Export only `EnrichmentSources`, `PipelineNotFoundError` and `VizProjectContext`; tests import internal classes from their defining modules.

## QA notes

Tests cover shared inputs, filtering and errors, runtime parameters, mapping copies, lazy imports, and projects with parameter values that do not match pipeline annotations. The six existing graph baselines are unchanged.

Local verification at `9ee1bcf84`: **695 tests passed with 100% statement coverage** on both the repository-pinned Kedro revision and released Kedro 1.6.0, using Python 3.13. Ruff, formatting and both MyPy targets passed.

These are local results, not a claim that GitHub CI has passed on the rewritten head. Earlier revisions had an E2E packaging setup failure involving Hatch and direct dependency references; dependency/packaging configuration is unchanged here. Read the Docs also previously failed and has not been diagnosed as part of this correction. Check the current-head runs below for CI status.

## Scope and checklist

- [x] Tests and local verification for this layer
- [x] One corrected commit on the previous stack layer
- [x] Release note included in #2768
- [ ] Current-head GitHub checks complete

This stack covers context-owned metadata and run-status HTTP. Context-backed export/deployment and the parameter-behavior rewrite remain separate work; #2660 stays open.

