### PR TITLE
Prepare project enrichment through one inspection loader

### DIFF
--- a/.github/actions/install_kedro_and_python_dependencies/action.yml
+++ b/.github/actions/install_kedro_and_python_dependencies/action.yml
@@ -1,5 +1,5 @@
 name: Install Kedro and other Python Dependencies
-description: Installs Kedro from the main branch and other Python dependencies, then prints the Python version and installed packages.
+description: Installs the project requirements, including the supported Kedro requirement, then prints the Python version and installed packages.
 runs:
   using: composite
   steps:
@@ -9,7 +9,6 @@ runs:
       shell: bash
     - name: Install Python dependencies
       run: |-
-        uv pip install --system git+https://github.com/kedro-org/kedro@main
         uv pip install --system -r package/test_requirements.txt -r demo-project/src/docker_requirements.txt -U
       shell: bash
     - name: Echo package versions

--- a/package/kedro_viz/integrations/kedro/data_loader.py
+++ b/package/kedro_viz/integrations/kedro/data_loader.py
@@ -3,7 +3,6 @@ load data from a Kedro project. It takes care of making sure viz can
 load data from projects created in a range of Kedro versions.
 """
 
-import json
 import logging
 import sys
 from pathlib import Path
@@ -17,114 +16,13 @@ from kedro.framework.startup import bootstrap_project
 from kedro.io import DataCatalog
 from kedro.pipeline import Pipeline
 
-from kedro_viz.constants import VIZ_METADATA_ARGS
 from kedro_viz.integrations.kedro.abstract_dataset_lite import AbstractDatasetLite
+from kedro_viz.integrations.kedro.inspection.enrichment import load_enrichment_sources
 from kedro_viz.integrations.kedro.lite_parser import LiteParser
 from kedro_viz.integrations.utils import _VizNullPluginManager
 from kedro_viz.models.metadata import Metadata, NodeExtras
 
 logger = logging.getLogger(__name__)
-
-
-def _read_and_validate_json(
-    file_path: Path, file_type: str, project_path: Path, fallback_message: str
-) -> Dict:
-    """Read and validate a JSON file, returning a dictionary.
-
-    Args:
-        file_path: Path to the JSON file to read
-        file_type: Type of file for logging (e.g., "stats.json", "styles.json")
-        project_path: Project path for logging context
-        fallback_message: Message to log when falling back to empty dict
-
-    Returns:
-        Dictionary containing the JSON data, or empty dict if file cannot be read/parsed
-    """
-    try:
-        with open(file_path, encoding="utf8") as json_file:
-            data = json.load(json_file)
-
-            # Validate that the loaded JSON is a dictionary
-            if not isinstance(data, dict):
-                logger.warning(
-                    "Invalid data format in %s at project path %s. "
-                    "Expected a JSON object (dictionary), got %s. "
-                    "Please ensure %s contains a valid JSON object.",
-                    file_type,
-                    project_path,
-                    type(data).__name__,
-                    file_type,
-                )
-                return {}
-
-            return data
-
-    except json.JSONDecodeError as exc:
-        logger.warning(
-            "Invalid JSON format in %s at project path %s. "
-            "Error at line %s, column %s: %s. "
-            "Please check your %s file for syntax errors.",
-            file_type,
-            project_path,
-            exc.lineno,
-            exc.colno,
-            exc.msg,
-            file_type,
-        )
-        return {}
-    except FileNotFoundError:
-        logger.debug("%s not found at %s", file_type, file_path)
-        return {}
-    except PermissionError as exc:
-        logger.warning(
-            "Permission denied accessing %s at project path %s: %s. "
-            "Please check file permissions.",
-            file_type,
-            project_path,
-            exc,
-        )
-        return {}
-    except Exception as exc:  # noqa: BLE001
-        logger.warning(
-            "Issue in reading %s at project path %s: %s. %s",
-            file_type,
-            project_path,
-            exc,
-            fallback_message,
-        )
-        return {}
-
-
-def _get_dataset_stats(project_path: Path) -> Dict:
-    """Return the stats saved at stats.json as a dictionary if found.
-    If not, return an empty dictionary
-
-    Args:
-        project_path: the path where the Kedro project is located.
-    """
-    stats_file_path = project_path / f"{VIZ_METADATA_ARGS['path']}/stats.json"
-    return _read_and_validate_json(
-        file_path=stats_file_path,
-        file_type="stats.json",
-        project_path=project_path,
-        fallback_message="Kedro-Viz will continue without dataset statistics.",
-    )
-
-
-def _get_node_styles(project_path: Path) -> Dict:
-    """Return the styles saved at styles.json as a dictionary if found.
-    If not, return an empty dictionary
-
-    Args:
-        project_path: the path where the Kedro project is located.
-    """
-    styles_file_path = project_path / f"{VIZ_METADATA_ARGS['path']}/styles.json"
-    return _read_and_validate_json(
-        file_path=styles_file_path,
-        file_type="styles.json",
-        project_path=project_path,
-        fallback_message="Kedro-Viz will continue without node styling.",
-    )
 
 
 def _create_node_extras_mapping(project_path: Path) -> Dict[str, NodeExtras]:
@@ -137,24 +35,7 @@ def _create_node_extras_mapping(project_path: Path) -> Dict[str, NodeExtras]:
         Dictionary mapping node names to NodeExtras objects
     """
 
-    stats_dict = _get_dataset_stats(project_path)
-    styles_dict = _get_node_styles(project_path)
-    node_extras_map = {}
-
-    # Get all unique node names from both stats and styles
-    all_node_names = set(stats_dict.keys()) | set(styles_dict.keys())
-
-    # Create NodeExtras objects for each node
-    for node_name in all_node_names:
-        stats = stats_dict.get(node_name)
-        styles = styles_dict.get(node_name)
-
-        node_extras = NodeExtras.create_node_extras(stats=stats, styles=styles)
-
-        if node_extras:
-            node_extras_map[node_name] = node_extras
-
-    return node_extras_map
+    return dict(load_enrichment_sources(project_path).node_extras_by_name)
 
 
 def _load_data_helper(

--- a/package/kedro_viz/integrations/kedro/inspection/context.py
+++ b/package/kedro_viz/integrations/kedro/inspection/context.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-from kedro_viz.integrations.kedro.inspection.enrichment import EnrichmentSources
+from kedro_viz.integrations.kedro.inspection.enrichment import (
+    EnrichmentSources,
+    load_enrichment_sources,
+)
 from kedro_viz.integrations.kedro.inspection.graph_service import (
     InspectionGraphService,
 )
@@ -62,9 +65,12 @@ class VizProjectContext:
             inspection_inputs = filter_inspection_inputs(
                 inspection_inputs, pipeline_name
             )
+        enrichment_sources = (
+            load_enrichment_sources(project_path) if enrichment is None else enrichment
+        )
         return cls(
             graph=InspectionGraphService.from_inspection_inputs(
                 inspection_inputs,
-                enrichment=enrichment,
+                enrichment=enrichment_sources,
             )
         )

--- a/package/kedro_viz/integrations/kedro/inspection/enrichment.py
+++ b/package/kedro_viz/integrations/kedro/inspection/enrichment.py
@@ -1,8 +1,12 @@
-"""Add live-only fields to graph responses without changing their structure."""
+"""Load file-backed node extras and enrich inspection graph responses."""
 
 from __future__ import annotations
 
+import json
+import logging
 from collections.abc import Iterable, Mapping
+from pathlib import Path
+from typing import Any
 
 from pydantic import BaseModel, Field, field_validator
 
@@ -11,52 +15,37 @@ from kedro_viz.api.rest.responses.pipelines import (
     GraphAPIResponse,
     NodeExtrasAPIResponse,
 )
+from kedro_viz.constants import VIZ_METADATA_ARGS
 from kedro_viz.models.flowchart.nodes import DataNode, GraphNode
 from kedro_viz.models.metadata import NodeExtras
 
+logger = logging.getLogger(__name__)
+
 
 class EnrichmentSources(BaseModel, frozen=True):
-    """Fields copied from the transitional live load, keyed by existing node IDs.
+    """Prepared file-backed and live enrichment for one project.
 
-    The IDs come from the already-built live nodes rather than being recalculated here. This
-    keeps enrichment independent of graph construction while the live backend remains available.
+    File extras retain their names for snapshot metadata. Graph overlays retain the exact
+    live node IDs and values, including any live-node selection of transcoded extras.
+    No live nodes are retained.
     """
 
+    node_extras_by_name: Mapping[str, NodeExtras] = Field(default_factory=dict)
     node_extras_by_node_id: Mapping[str, NodeExtras] = Field(default_factory=dict)
     dataset_type_by_node_id: Mapping[str, str | None] = Field(default_factory=dict)
-    layer_by_dataset: Mapping[str, str] | None = None
+    layer_by_dataset_name: Mapping[str, str] | None = None
 
     @field_validator(
+        "node_extras_by_name",
         "node_extras_by_node_id",
         "dataset_type_by_node_id",
-        "layer_by_dataset",
+        "layer_by_dataset_name",
         mode="before",
     )
     @classmethod
     def _copy_mapping(cls, value: Mapping | None) -> dict | None:
         """Copy caller-owned mappings before storing them on the prepared model."""
         return None if value is None else dict(value)
-
-    @classmethod
-    def from_live_nodes(
-        cls,
-        nodes: Iterable[GraphNode],
-        *,
-        layer_by_dataset: Mapping[str, str] | None = None,
-    ) -> EnrichmentSources:
-        """Copy the fields needed by the inspection graph from already-built live nodes."""
-        node_extras_by_node_id: dict[str, NodeExtras] = {}
-        dataset_type_by_node_id: dict[str, str | None] = {}
-        for node in nodes:
-            if node.node_extras is not None:
-                node_extras_by_node_id[node.id] = node.node_extras
-            if isinstance(node, DataNode):
-                dataset_type_by_node_id[node.id] = node.dataset_type
-        return cls(
-            node_extras_by_node_id=node_extras_by_node_id,
-            dataset_type_by_node_id=dataset_type_by_node_id,
-            layer_by_dataset=layer_by_dataset,
-        )
 
 
 def enrich_graph_response(
@@ -75,3 +64,127 @@ def enrich_graph_response(
             and node.id in sources.dataset_type_by_node_id
         ):
             node.dataset_type = sources.dataset_type_by_node_id[node.id]
+
+
+def _read_and_validate_json(
+    file_path: Path,
+    file_type: str,
+    project_path: Path,
+    fallback_message: str,
+) -> dict[str, Any]:
+    """Read a JSON object, returning an empty mapping when it cannot be used."""
+    try:
+        with open(file_path, encoding="utf8") as json_file:
+            data = json.load(json_file)
+
+            if not isinstance(data, dict):
+                logger.warning(
+                    "Invalid data format in %s at project path %s. "
+                    "Expected a JSON object (dictionary), got %s. "
+                    "Please ensure %s contains a valid JSON object.",
+                    file_type,
+                    project_path,
+                    type(data).__name__,
+                    file_type,
+                )
+                return {}
+
+            return data
+
+    except json.JSONDecodeError as exc:
+        logger.warning(
+            "Invalid JSON format in %s at project path %s. "
+            "Error at line %s, column %s: %s. "
+            "Please check your %s file for syntax errors.",
+            file_type,
+            project_path,
+            exc.lineno,
+            exc.colno,
+            exc.msg,
+            file_type,
+        )
+        return {}
+    except FileNotFoundError:
+        logger.debug("%s not found at %s", file_type, file_path)
+        return {}
+    except PermissionError as exc:
+        logger.warning(
+            "Permission denied accessing %s at project path %s: %s. "
+            "Please check file permissions.",
+            file_type,
+            project_path,
+            exc,
+        )
+        return {}
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "Issue in reading %s at project path %s: %s. %s",
+            file_type,
+            project_path,
+            exc,
+            fallback_message,
+        )
+        return {}
+
+
+def _get_dataset_stats(project_path: Path) -> dict[str, Any]:
+    """Return the contents of ``.viz/stats.json``, or an empty mapping."""
+    stats_file_path = project_path / f"{VIZ_METADATA_ARGS['path']}/stats.json"
+    return _read_and_validate_json(
+        file_path=stats_file_path,
+        file_type="stats.json",
+        project_path=project_path,
+        fallback_message="Kedro-Viz will continue without dataset statistics.",
+    )
+
+
+def _get_node_styles(project_path: Path) -> dict[str, Any]:
+    """Return the contents of ``.viz/styles.json``, or an empty mapping."""
+    styles_file_path = project_path / f"{VIZ_METADATA_ARGS['path']}/styles.json"
+    return _read_and_validate_json(
+        file_path=styles_file_path,
+        file_type="styles.json",
+        project_path=project_path,
+        fallback_message="Kedro-Viz will continue without node styling.",
+    )
+
+
+def load_enrichment_sources(
+    project_path: str | Path,
+    *,
+    nodes: Iterable[GraphNode] = (),
+    node_extras_by_name: Mapping[str, NodeExtras] | None = None,
+    layer_by_dataset_name: Mapping[str, str] | None = None,
+) -> EnrichmentSources:
+    """Prepare enrichment once, reusing file extras when the live load supplied them.
+
+    An explicit empty extras mapping skips file reads. Live graph overlays are copied by
+    their existing IDs; they do not replace the name-keyed file values used by metadata.
+    Layers are supplied by the caller, preserving the distinction between absent and empty.
+    """
+    if node_extras_by_name is None:
+        stats_by_name = _get_dataset_stats(Path(project_path))
+        styles_by_name = _get_node_styles(Path(project_path))
+        file_extras: dict[str, NodeExtras] = {}
+        for node_name in stats_by_name.keys() | styles_by_name.keys():
+            node_extras = NodeExtras.create_node_extras(
+                stats=stats_by_name.get(node_name),
+                styles=styles_by_name.get(node_name),
+            )
+            if node_extras is not None:
+                file_extras[node_name] = node_extras
+        node_extras_by_name = file_extras
+
+    node_extras_by_node_id: dict[str, NodeExtras] = {}
+    dataset_type_by_node_id: dict[str, str | None] = {}
+    for node in nodes:
+        if node.node_extras is not None:
+            node_extras_by_node_id[node.id] = node.node_extras
+        if isinstance(node, DataNode):
+            dataset_type_by_node_id[node.id] = node.dataset_type
+    return EnrichmentSources(
+        node_extras_by_name=node_extras_by_name,
+        node_extras_by_node_id=node_extras_by_node_id,
+        dataset_type_by_node_id=dataset_type_by_node_id,
+        layer_by_dataset_name=layer_by_dataset_name,
+    )

--- a/package/kedro_viz/integrations/kedro/inspection/graph_builder.py
+++ b/package/kedro_viz/integrations/kedro/inspection/graph_builder.py
@@ -110,12 +110,12 @@ class GraphBuilder:
         catalog_config: dict[str, Any] | None = None,
         *,
         parameters: dict[str, Any] | None = None,
-        layer_by_dataset: Mapping[str, str] | None = None,
+        layer_by_dataset_name: Mapping[str, str] | None = None,
     ) -> None:
         self._snapshot = snapshot
-        self._layer_by_dataset = (
-            dict(layer_by_dataset)
-            if layer_by_dataset is not None
+        self._layer_by_dataset_name = (
+            dict(layer_by_dataset_name)
+            if layer_by_dataset_name is not None
             else _extract_layers(
                 catalog_config=catalog_config or {},
                 dataset_names=_dataset_names_from_snapshot(snapshot),
@@ -302,7 +302,9 @@ class GraphBuilder:
             modular_pipelines=(
                 self._modular_pipeline_index.modular_pipelines_for_dataset(base_name)
             ),
-            layer=(None if is_parameter else self._layer_by_dataset.get(base_name)),
+            layer=(
+                None if is_parameter else self._layer_by_dataset_name.get(base_name)
+            ),
             dataset_type=dataset_type,
         )
 
@@ -312,7 +314,7 @@ class GraphBuilder:
         edges: dict[tuple[str, str], GraphEdgeAPIResponse],
     ) -> list[str]:
         """Sort the project-wide layer set using the selected pipeline's edges."""
-        if not self._layer_by_dataset:
+        if not self._layer_by_dataset_name:
             return []
         dependencies: dict[str, set[str]] = defaultdict(set)
         for source, target in edges:
@@ -323,7 +325,7 @@ class GraphBuilder:
         }
         # Include layered datasets used by any pipeline so every view exposes the
         # project-wide layer set; this view's edges determine their order.
-        for dataset_name, layer in self._layer_by_dataset.items():
+        for dataset_name, layer in self._layer_by_dataset_name.items():
             dataset_pipelines = self._index.get_pipelines_for_dataset_name(dataset_name)
             if is_dataset_param(dataset_name) or not dataset_pipelines:
                 continue

--- a/package/kedro_viz/integrations/kedro/inspection/graph_service.py
+++ b/package/kedro_viz/integrations/kedro/inspection/graph_service.py
@@ -40,7 +40,7 @@ class InspectionGraphService:
             inspection_inputs.snapshot,
             dict(inspection_inputs.catalog_config),
             parameters=dict(inspection_inputs.parameters),
-            layer_by_dataset=enrichment_sources.layer_by_dataset,
+            layer_by_dataset_name=enrichment_sources.layer_by_dataset_name,
         )
         return cls(builder, enrichment_sources)
 

--- a/package/kedro_viz/integrations/kedro/inspection/layers.py
+++ b/package/kedro_viz/integrations/kedro/inspection/layers.py
@@ -27,7 +27,7 @@ def _extract_layers(
         ValueError: If transcoded variants of one dataset (``name@a``, ``name@b``) declare
             different layers, matching the legacy backend's validation.
     """
-    layer_by_dataset: dict[str, str] = {}
+    layer_by_dataset_name: dict[str, str] = {}
     resolver_config: dict[str, dict[str, Any]] = {}
     has_patterns = False
     for name, config in catalog_config.items():
@@ -44,7 +44,7 @@ def _extract_layers(
         if CatalogConfigResolver.is_pattern(name):
             has_patterns = True
             continue
-        _set_layer(layer_by_dataset, name, layer)
+        _set_layer(layer_by_dataset_name, name, layer)
 
     if has_patterns:
         resolver = CatalogConfigResolver(
@@ -57,22 +57,22 @@ def _extract_layers(
                 layer = resolved_config["metadata"]["kedro-viz"]["layer"]
             except (KeyError, TypeError):
                 continue
-            _set_layer(layer_by_dataset, name, layer)
+            _set_layer(layer_by_dataset_name, name, layer)
 
-    return layer_by_dataset
+    return layer_by_dataset_name
 
 
-def _set_layer(layer_by_dataset: dict[str, str], name: str, layer: str) -> None:
+def _set_layer(layer_by_dataset_name: dict[str, str], name: str, layer: str) -> None:
     """Store a layer under the dataset's non-transcoded name."""
     stripped = _strip_transcoding(name)
-    existing = layer_by_dataset.get(stripped)
+    existing = layer_by_dataset_name.get(stripped)
     if existing is not None and existing != layer:
         raise ValueError(
             "Transcoded datasets should have the same layer. "
             "Please ensure consistent layering in your Kedro catalog. "
             f"Mismatch found for: {stripped}"
         )
-    layer_by_dataset[stripped] = layer
+    layer_by_dataset_name[stripped] = layer
 
 
 def sort_layers(

--- a/package/kedro_viz/server.py
+++ b/package/kedro_viz/server.py
@@ -13,9 +13,9 @@ from kedro_viz.constants import DEFAULT_HOST, DEFAULT_PORT
 from kedro_viz.data_access import DataAccessManager, data_access_manager
 from kedro_viz.integrations.kedro import data_loader as kedro_data_loader
 from kedro_viz.integrations.kedro.inspection import (
-    EnrichmentSources,
     VizProjectContext,
 )
+from kedro_viz.integrations.kedro.inspection.enrichment import load_enrichment_sources
 from kedro_viz.launchers.utils import _check_viz_up, _wait_for, display_cli_message
 from kedro_viz.models.metadata import NodeExtras
 
@@ -104,12 +104,14 @@ def _create_viz_project_context(
         # A hook can add, change or remove layer metadata, and only the populated catalog
         # reflects that, so with hooks the builder reads layers from there instead of the
         # raw catalog config.
-        layer_by_dataset = (
+        layer_by_dataset_name = (
             dict(live_data.catalog.layers_mapping) if include_hooks else None
         )
-        enrichment = EnrichmentSources.from_live_nodes(
-            live_data.nodes.as_list(),
-            layer_by_dataset=layer_by_dataset,
+        enrichment = load_enrichment_sources(
+            path,
+            nodes=live_data.nodes.as_list(),
+            node_extras_by_name=live_data.node_extras,
+            layer_by_dataset_name=layer_by_dataset_name,
         )
         return VizProjectContext.from_project(
             path,

--- a/package/requirements.txt
+++ b/package/requirements.txt
@@ -3,10 +3,7 @@ click-default-group
 fastapi>=0.100.0,<0.200.0
 fsspec>=2021.4
 ipython>=7.0.0, <9.0
-# [TODO] Switch to a released Kedro version once it includes NodeSnapshot.func_name.
-# Until then, keep this git pin in trufflehog-ignore.txt and expect the Read the Docs build to fail.
-# When switching, remove package/requirements.txt from trufflehog-ignore.txt and run make secret-scan.
-kedro @ git+https://github.com/kedro-org/kedro.git@55bde97bb23ca6ebc7efdc9051a7efb060302af0
+kedro>=1.6.0
 kedro-telemetry>=0.6.0
 networkx>=2.5
 orjson>=3.9, <4.0

--- a/package/tests/test_inspection_adapter/test_context.py
+++ b/package/tests/test_inspection_adapter/test_context.py
@@ -76,7 +76,9 @@ def test_context_filters_shared_inputs_before_building_services(mocker) -> None:
     VizProjectContext.from_project(PROJECT, pipeline_name="data_science")
 
     filter_inputs.assert_called_once_with(inputs, "data_science")
-    from_inspection_inputs.assert_called_once_with(filtered_inputs, enrichment=None)
+    from_inspection_inputs.assert_called_once_with(
+        filtered_inputs, enrichment=EnrichmentSources()
+    )
 
 
 @pytest.mark.parametrize("pipeline_name", ["unknown", ""])

--- a/package/tests/test_inspection_adapter/test_context_creation.py
+++ b/package/tests/test_inspection_adapter/test_context_creation.py
@@ -24,8 +24,8 @@ def test_cli_options_and_explicit_enrichment_are_forwarded_to_the_context(
     live_data.nodes.as_list.return_value = live_nodes
     live_data.catalog.layers_mapping = {}
     enrichment = mock.sentinel.enrichment
-    from_live_nodes = mocker.patch(
-        "kedro_viz.server.EnrichmentSources.from_live_nodes",
+    load_enrichment = mocker.patch(
+        "kedro_viz.server.load_enrichment_sources",
         return_value=enrichment,
     )
     context = mock.sentinel.context
@@ -46,7 +46,12 @@ def test_cli_options_and_explicit_enrichment_are_forwarded_to_the_context(
         include_hooks=True,
     )
 
-    from_live_nodes.assert_called_once_with(live_nodes, layer_by_dataset={})
+    load_enrichment.assert_called_once_with(
+        PROJECT,
+        nodes=live_nodes,
+        node_extras_by_name=live_data.node_extras,
+        layer_by_dataset_name={},
+    )
     from_project.assert_called_once_with(
         PROJECT,
         env="staging",
@@ -86,14 +91,16 @@ def test_hook_modified_factory_layer_is_forwarded_to_the_context(mocker) -> None
     )
     live_data = DataAccessManager()
     live_data.add_catalog(catalog, {"__default__": processing_pipeline})
-    from_live_nodes = mocker.patch("kedro_viz.server.EnrichmentSources.from_live_nodes")
+    load_enrichment = mocker.patch("kedro_viz.server.load_enrichment_sources")
     mocker.patch("kedro_viz.server.VizProjectContext.from_project")
 
     _create_viz_project_context(PROJECT, live_data, include_hooks=True)
 
-    from_live_nodes.assert_called_once_with(
-        live_data.nodes.as_list(),
-        layer_by_dataset={"processing.int_companies": "hooked"},
+    load_enrichment.assert_called_once_with(
+        PROJECT,
+        nodes=live_data.nodes.as_list(),
+        node_extras_by_name=live_data.node_extras,
+        layer_by_dataset_name={"processing.int_companies": "hooked"},
     )
 
 
@@ -120,14 +127,16 @@ def test_unmaterialized_factory_layer_is_absent_from_hook_layers(mocker) -> None
     live_data = DataAccessManager()
     live_data.add_catalog(catalog, {"__default__": processing_pipeline})
     assert "companies_input" not in catalog.keys()
-    from_live_nodes = mocker.patch("kedro_viz.server.EnrichmentSources.from_live_nodes")
+    load_enrichment = mocker.patch("kedro_viz.server.load_enrichment_sources")
     mocker.patch("kedro_viz.server.VizProjectContext.from_project")
 
     _create_viz_project_context(PROJECT, live_data, include_hooks=True)
 
-    from_live_nodes.assert_called_once_with(
-        live_data.nodes.as_list(),
-        layer_by_dataset={},
+    load_enrichment.assert_called_once_with(
+        PROJECT,
+        nodes=live_data.nodes.as_list(),
+        node_extras_by_name=live_data.node_extras,
+        layer_by_dataset_name={},
     )
 
 
@@ -137,14 +146,16 @@ def test_hooks_disabled_keeps_the_raw_catalog_layer_path(mocker) -> None:
     live_nodes = [mock.sentinel.live_node]
     live_data.nodes.as_list.return_value = live_nodes
     live_data.catalog.layers_mapping = {"companies": "hooked"}
-    from_live_nodes = mocker.patch("kedro_viz.server.EnrichmentSources.from_live_nodes")
+    load_enrichment = mocker.patch("kedro_viz.server.load_enrichment_sources")
     mocker.patch("kedro_viz.server.VizProjectContext.from_project")
 
     _create_viz_project_context(PROJECT, live_data)
 
-    from_live_nodes.assert_called_once_with(
-        live_nodes,
-        layer_by_dataset=None,
+    load_enrichment.assert_called_once_with(
+        PROJECT,
+        nodes=live_nodes,
+        node_extras_by_name=live_data.node_extras,
+        layer_by_dataset_name=None,
     )
 
 
@@ -152,7 +163,7 @@ def test_a_context_build_failure_is_logged_and_re_raised(mocker, caplog) -> None
     """A failed context build stops startup instead of serving an incomplete graph."""
     live_data = mocker.MagicMock()
     live_data.nodes.as_list.return_value = []
-    mocker.patch("kedro_viz.server.EnrichmentSources.from_live_nodes")
+    mocker.patch("kedro_viz.server.load_enrichment_sources")
     mocker.patch(
         "kedro_viz.server.VizProjectContext.from_project",
         side_effect=RuntimeError("no snapshot"),

--- a/package/tests/test_inspection_adapter/test_enrichment.py
+++ b/package/tests/test_inspection_adapter/test_enrichment.py
@@ -15,6 +15,7 @@ from kedro_viz.api.rest.responses.pipelines import (
 from kedro_viz.integrations.kedro.inspection.enrichment import (
     EnrichmentSources,
     enrich_graph_response,
+    load_enrichment_sources,
 )
 from kedro_viz.integrations.kedro.node_ids import _create_dataset_node_id
 from kedro_viz.models.flowchart.nodes import GraphNode, TranscodedDataNode
@@ -84,7 +85,9 @@ def test_live_dataset_fields_are_copied_by_existing_node_id() -> None:
         styles={"backgroundColor": "#fff"},
     )
     graph_node = _graph_dataset("companies")
-    sources = EnrichmentSources.from_live_nodes([live_node])
+    sources = load_enrichment_sources(
+        "/unused", nodes=[live_node], node_extras_by_name={}
+    )
 
     enrich_graph_response(_graph_response(graph_node), sources)
 
@@ -98,19 +101,21 @@ def test_live_dataset_fields_are_copied_by_existing_node_id() -> None:
 def test_enrichment_sources_copy_the_layer_mapping() -> None:
     """Later mutations of the caller's mapping cannot change a prepared service."""
     layers = {"companies": "raw"}
-    sources = EnrichmentSources.from_live_nodes([], layer_by_dataset=layers)
+    sources = load_enrichment_sources(
+        "/unused", node_extras_by_name={}, layer_by_dataset_name=layers
+    )
 
     layers["companies"] = "changed"
 
-    assert sources.layer_by_dataset == {"companies": "raw"}
+    assert sources.layer_by_dataset_name == {"companies": "raw"}
 
 
 def test_enrichment_sources_are_frozen() -> None:
     """Prepared enrichment fields cannot be replaced after construction."""
-    sources = EnrichmentSources(layer_by_dataset={"companies": "raw"})
+    sources = EnrichmentSources(layer_by_dataset_name={"companies": "raw"})
 
     with pytest.raises(ValidationError, match="Instance is frozen"):
-        sources.layer_by_dataset = {}  # type: ignore[misc]
+        sources.layer_by_dataset_name = {}  # type: ignore[misc]
 
 
 def test_enrichment_sources_copy_all_constructor_mappings() -> None:
@@ -133,7 +138,9 @@ def test_live_nodes_are_consumed_in_one_pass() -> None:
     """A generator supplies both extras and dataset types, not only the first mapping."""
     live_node = _live_dataset("companies", stats={"rows": 5})
 
-    sources = EnrichmentSources.from_live_nodes(node for node in [live_node])
+    sources = load_enrichment_sources(
+        "/unused", nodes=(node for node in [live_node]), node_extras_by_name={}
+    )
 
     assert live_node.id in sources.node_extras_by_node_id
     assert live_node.id in sources.dataset_type_by_node_id
@@ -158,8 +165,10 @@ def test_enrichment_does_not_change_graph_topology() -> None:
     )
     node_shape = [(node.id, node.type, node.name) for node in response.nodes]
     edge_shape = [(edge.source, edge.target) for edge in response.edges]
-    sources = EnrichmentSources.from_live_nodes(
-        [_live_dataset("source", stats={"rows": 5})]
+    sources = load_enrichment_sources(
+        "/unused",
+        nodes=[_live_dataset("source", stats={"rows": 5})],
+        node_extras_by_name={},
     )
 
     enrich_graph_response(response, sources)
@@ -174,7 +183,9 @@ def test_transcoded_dataset_uses_one_id_without_exposing_a_dataset_type() -> Non
     live_node = _live_dataset("ds@pandas", stats={"rows": 7})
     assert isinstance(live_node, TranscodedDataNode)
     graph_node = _graph_dataset("ds", dataset_type=None)
-    sources = EnrichmentSources.from_live_nodes([live_node])
+    sources = load_enrichment_sources(
+        "/unused", nodes=[live_node], node_extras_by_name={}
+    )
 
     enrich_graph_response(_graph_response(graph_node), sources)
 
@@ -182,3 +193,62 @@ def test_transcoded_dataset_uses_one_id_without_exposing_a_dataset_type() -> Non
     assert graph_node.dataset_type is None
     assert graph_node.node_extras is not None
     assert graph_node.node_extras.stats == {"rows": 7}
+
+
+def test_file_extras_are_available_without_live_nodes(tmp_path, mocker) -> None:
+    """File data does not depend on a populated catalog or live graph."""
+    from kedro_viz.integrations.kedro.inspection import enrichment
+
+    stats = mocker.patch.object(
+        enrichment, "_get_dataset_stats", return_value={"companies": {"rows": 5}}
+    )
+    styles = mocker.patch.object(
+        enrichment, "_get_node_styles", return_value={"companies": {"color": "red"}}
+    )
+
+    sources = load_enrichment_sources(tmp_path)
+
+    stats.assert_called_once_with(tmp_path)
+    styles.assert_called_once_with(tmp_path)
+    assert sources.node_extras_by_name == {
+        "companies": NodeExtras(stats={"rows": 5}, styles={"color": "red"})
+    }
+    assert sources.node_extras_by_node_id == {}
+    assert sources.dataset_type_by_node_id == {}
+    assert sources.layer_by_dataset_name is None
+
+
+@pytest.mark.parametrize("extras", [{}, {"companies": NodeExtras(stats={"rows": 5})}])
+def test_supplied_file_extras_are_copied_without_reading_files(
+    tmp_path, mocker, extras
+) -> None:
+    from kedro_viz.integrations.kedro.inspection import enrichment
+
+    stats = mocker.patch.object(enrichment, "_get_dataset_stats")
+    styles = mocker.patch.object(enrichment, "_get_node_styles")
+    supplied = dict(extras)
+
+    sources = load_enrichment_sources(tmp_path, node_extras_by_name=supplied)
+    supplied.clear()
+
+    stats.assert_not_called()
+    styles.assert_not_called()
+    assert sources.node_extras_by_name == extras
+
+
+def test_file_metadata_and_live_graph_overlays_keep_their_own_values(tmp_path) -> None:
+    """Consolidation must not change live graph precedence or static file metadata."""
+    file_extras = {"companies": NodeExtras(stats={"rows": 5})}
+    live_node = _live_dataset("companies", stats={"rows": 9})
+    live_node.id = "existing-canonical-id"
+
+    sources = load_enrichment_sources(
+        tmp_path,
+        nodes=[live_node],
+        node_extras_by_name=file_extras,
+        layer_by_dataset_name={},
+    )
+
+    assert sources.node_extras_by_name["companies"].stats == {"rows": 5}
+    assert sources.node_extras_by_node_id["existing-canonical-id"].stats == {"rows": 9}
+    assert sources.layer_by_dataset_name == {}

--- a/package/tests/test_inspection_adapter/test_graph_builder_edge_cases.py
+++ b/package/tests/test_inspection_adapter/test_graph_builder_edge_cases.py
@@ -24,13 +24,13 @@ def _builder(
     catalog_config: dict[str, Any] | None = None,
     *,
     parameters: dict[str, Any] | None = None,
-    layer_by_dataset: dict[str, str] | None = None,
+    layer_by_dataset_name: dict[str, str] | None = None,
 ) -> GraphBuilder:
     return GraphBuilder(
         cast("ProjectSnapshot", snapshot),
         catalog_config,
         parameters=parameters,
-        layer_by_dataset=layer_by_dataset,
+        layer_by_dataset_name=layer_by_dataset_name,
     )
 
 
@@ -479,7 +479,7 @@ def test_populated_catalog_layers_override_raw_config() -> None:
     graph = _builder(
         snapshot,
         catalog_config,
-        layer_by_dataset={"x": "hooked"},
+        layer_by_dataset_name={"x": "hooked"},
     ).build("__default__")
     data_nodes = {
         node.name: node
@@ -497,7 +497,9 @@ def test_empty_populated_catalog_layers_remove_raw_config_layers() -> None:
     catalog_config = {
         "x": {"metadata": {"kedro-viz": {"layer": "raw"}}},
     }
-    graph = _builder(snapshot, catalog_config, layer_by_dataset={}).build("__default__")
+    graph = _builder(snapshot, catalog_config, layer_by_dataset_name={}).build(
+        "__default__"
+    )
     data_nodes = [
         node
         for node in graph.nodes

--- a/package/tests/test_inspection_adapter/test_graph_service.py
+++ b/package/tests/test_inspection_adapter/test_graph_service.py
@@ -93,7 +93,7 @@ def test_inputs_reaches_the_builder(mocker) -> None:
         mocker.sentinel.snapshot,
         {"companies": {}},
         parameters={"split": 0.2},
-        layer_by_dataset=None,
+        layer_by_dataset_name=None,
     )
 
 
@@ -102,7 +102,7 @@ def test_populated_catalog_layers_reach_the_builder(mocker) -> None:
     graph_builder = mocker.patch(
         "kedro_viz.integrations.kedro.inspection.graph_service.GraphBuilder"
     )
-    enrichment = EnrichmentSources(layer_by_dataset={"companies": "hooked"})
+    enrichment = EnrichmentSources(layer_by_dataset_name={"companies": "hooked"})
     inputs = mocker.Mock(
         spec=InspectionInputs,
         snapshot=mocker.sentinel.snapshot,
@@ -116,7 +116,7 @@ def test_populated_catalog_layers_reach_the_builder(mocker) -> None:
         mocker.sentinel.snapshot,
         {},
         parameters={},
-        layer_by_dataset={"companies": "hooked"},
+        layer_by_dataset_name={"companies": "hooked"},
     )
 
 

--- a/package/tests/test_inspection_adapter/test_inspection_adapter_parity.py
+++ b/package/tests/test_inspection_adapter/test_inspection_adapter_parity.py
@@ -75,7 +75,15 @@ def live_enriched_graph_service(_restore_kedro_project_state):
     manager = DataAccessManager()
     catalog, pipelines, node_extras = data_loader.load_data(DEMO_PROJECT)
     populate_data(manager, catalog, pipelines, node_extras)
-    enrichment = EnrichmentSources.from_live_nodes(manager.nodes.as_list())
+    from kedro_viz.integrations.kedro.inspection.enrichment import (
+        load_enrichment_sources,
+    )
+
+    enrichment = load_enrichment_sources(
+        DEMO_PROJECT,
+        nodes=manager.nodes.as_list(),
+        node_extras_by_name=manager.node_extras,
+    )
     return InspectionGraphService.from_inspection_inputs(
         load_inspection_inputs(DEMO_PROJECT),
         enrichment=enrichment,

--- a/package/tests/test_integrations/test_kedro_data_loader.py
+++ b/package/tests/test_integrations/test_kedro_data_loader.py
@@ -1,4 +1,4 @@
-"""Tests for kedro data loader functions."""
+"""Tests for Kedro data loading and file-backed node extras."""
 
 import json
 import logging
@@ -9,6 +9,8 @@ import pytest
 from kedro_viz.constants import VIZ_METADATA_ARGS
 from kedro_viz.integrations.kedro.data_loader import (
     _create_node_extras_mapping,
+)
+from kedro_viz.integrations.kedro.inspection.enrichment import (
     _get_dataset_stats,
     _get_node_styles,
 )

--- a/trufflehog-ignore.txt
+++ b/trufflehog-ignore.txt
@@ -1,6 +1,5 @@
 package.json
 package-lock.json
-package/requirements.txt
 tools/test-lib/react-app/package.json
 tools/test-lib/react-app/package-lock.json
 RELEASE.md


### PR DESCRIPTION
Part 2 of 6 for #2660. 

Review order: [1: #2763](https://github.com/kedro-org/kedro-viz/pull/2763) → [2: #2764](https://github.com/kedro-org/kedro-viz/pull/2764) → [3: #2765](https://github.com/kedro-org/kedro-viz/pull/2765) → [4: #2766](https://github.com/kedro-org/kedro-viz/pull/2766) → [5: #2767](https://github.com/kedro-org/kedro-viz/pull/2767) → [6: #2768](https://github.com/kedro-org/kedro-viz/pull/2768).

## Description

Prepare project enrichment through one entry point in `inspection/enrichment.py`, returning one `EnrichmentSources` object to the context. Use the released Kedro dependency range `kedro>=1.6.0`.

## Development notes

- Rename `layer_by_dataset` to `layer_by_dataset_name` consistently across preparation, graph consumers and tests, making the mapping key explicit without changing behavior.
- Replace the separate `load_node_extras()` and `EnrichmentSources.from_live_nodes()` preparation paths with `load_enrichment_sources()`.
- Gather file-backed stats/styles, copied live graph fields and supplied layer overrides into the prepared model. Keep the small JSON-reading helpers.
- Retain file extras by name for static metadata and exact live-ID overlays for graph responses. These views can differ; preserving both avoids changing live/transcoded selection or precedence.
- Reuse supplied file extras, including an explicit empty mapping, without rereading files. File-only preparation does not require a catalog or live nodes.
- Keep the legacy data-loader entry point as a delegating wrapper. The context loads enrichment only when no prepared object was supplied.
- Require `kedro>=1.6.0` exactly as agreed: no upper bound. CI uses the project requirement instead of installing Kedro main first; `requirements.txt` remains covered by secret scanning.

## QA notes

Local verification at `889219644`: **699 backend tests passed with 100% statement coverage**, using Python 3.13 and Kedro 1.6.0. Ruff, formatting and both MyPy targets passed. 

Tests cover stats/styles loading, file-only preparation, copied mappings, no rereads for supplied or empty extras, live-ID preservation, and differing file/live values. Existing graph parity expectations are unchanged.

At the final stack tip, 103 parity/enrichment/route tests passed in a clean checkout. Targeted Bandit checks and secret scanning passed again. Wheel building and strict docs passed on the preceding revision; this naming-only update changes neither packaging nor docs.

These are local results, not a claim that current-head GitHub checks are green. The previously diagnosed lite-mode E2E defect—whole-`sys.modules` restoration causing NumPy reinitialization—is inherited from V2 and deliberately unchanged. In the preceding CI runs, both full-mode scenarios passed and both lite-related scenarios errored. This revision does not claim to fix that defect; check the new runs below.

## Scope and checklist

- [x] Tests and local verification for this layer
- [x] One commit on `feat/backend_v2`, following merged #2763
- [x] Release note included in #2768
- [ ] Current-head GitHub checks complete

This stack covers context-owned metadata and run-status HTTP. Context-backed export/deployment and the parameter-behavior rewrite remain separate work; #2660 stays open.



