### PR TITLE
Fix toolbar `tooltip` not dismissing on mouse leave

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -12,7 +12,7 @@ Please follow the established format:
  - Fix for `autoreload` to ignore notebook file changes. (#2712)
  - Align pandas requirement with Kedro (`pandas>=2.0,<4.0`). (#2694)
  - Update Node.js version from v18 to v24 and bump `canvas` to v3 and `jest`/`jest-environment-jsdom` for compatibility. (#2754)
- - Fix toolbar tooltip not dismissing on mouse leave. (#2770)
+ - Fix toolbar `tooltip` not dismissing on mouse leave. (#2770)
 
 
 # Release 12.4.0

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -12,6 +12,8 @@ Please follow the established format:
  - Fix for `autoreload` to ignore notebook file changes. (#2712)
  - Align pandas requirement with Kedro (`pandas>=2.0,<4.0`). (#2694)
  - Update Node.js version from v18 to v24 and bump `canvas` to v3 and `jest`/`jest-environment-jsdom` for compatibility. (#2754)
+ - Fix toolbar tooltips not dismissing on mouse leave. (#XXXX)
+
 
 # Release 12.4.0
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -12,7 +12,7 @@ Please follow the established format:
  - Fix for `autoreload` to ignore notebook file changes. (#2712)
  - Align pandas requirement with Kedro (`pandas>=2.0,<4.0`). (#2694)
  - Update Node.js version from v18 to v24 and bump `canvas` to v3 and `jest`/`jest-environment-jsdom` for compatibility. (#2754)
- - Fix toolbar tooltips not dismissing on mouse leave. (#XXXX)
+ - Fix toolbar tooltip not dismissing on mouse leave. (#2770)
 
 
 # Release 12.4.0

--- a/src/components/ui/icon-button/icon-button.jsx
+++ b/src/components/ui/icon-button/icon-button.jsx
@@ -49,7 +49,6 @@ const IconButton = ({
       if (!isHovered.current) {
         return;
       }
-      window.localStorage.setItem('kedro-viz-tooltip-show', true);
       setIsTooltipVisible(true);
     }, 333);
   };

--- a/src/components/ui/icon-button/icon-button.jsx
+++ b/src/components/ui/icon-button/icon-button.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import './icon-button.scss';
@@ -25,8 +25,15 @@ const IconButton = ({
   ...rest
 }) => {
   const Icon = icon;
-  let inTimeout;
+  const inTimeout = useRef(null);
+  const isHovered = useRef(false);
   const [isTooltipVisible, setIsTooltipVisible] = useState(false);
+
+  // Clear any pending show-timeout when the button unmounts, so the tooltip
+  // can't be shown after the pointer has already left.
+  useEffect(() => {
+    return () => clearTimeout(inTimeout.current);
+  }, []);
 
   const labelPosition = labelPositionTypes.includes(
     labelTextPosition.toLowerCase()
@@ -35,14 +42,21 @@ const IconButton = ({
     : 'right';
 
   const showTooltip = () => {
-    inTimeout = setTimeout(() => {
+    isHovered.current = true;
+    clearTimeout(inTimeout.current);
+    inTimeout.current = setTimeout(() => {
+      // Bail out if the pointer left while the timeout was pending.
+      if (!isHovered.current) {
+        return;
+      }
       window.localStorage.setItem('kedro-viz-tooltip-show', true);
       setIsTooltipVisible(true);
     }, 333);
   };
 
   const hideTooltip = () => {
-    clearTimeout(inTimeout);
+    isHovered.current = false;
+    clearTimeout(inTimeout.current);
     setIsTooltipVisible(false);
   };
 

--- a/src/components/ui/icon-button/icon-button.test.jsx
+++ b/src/components/ui/icon-button/icon-button.test.jsx
@@ -102,6 +102,39 @@ describe('IconButton', () => {
     );
   });
 
+  it('does not show tooltip if the pointer leaves before the show delay elapses, even across a re-render', () => {
+    jest.useFakeTimers();
+    const { container, rerender } = render(
+      <IconButton labelText="Toggle theme" active={false} visible={true} />
+    );
+
+    const button = container.querySelector('.pipeline-icon-toolbar__button');
+
+    act(() => {
+      fireEvent.mouseEnter(button);
+    });
+
+    // A re-render happens while the show-timeout is still pending (common in
+    // kedro-viz as global store state updates on hover/layout changes).
+    act(() => {
+      rerender(
+        <IconButton labelText="Toggle theme" active={true} visible={true} />
+      );
+    });
+
+    act(() => {
+      // Pointer leaves before the 333ms delay is up.
+      fireEvent.mouseLeave(button);
+      jest.runOnlyPendingTimers();
+    });
+
+    expect(
+      container.querySelector('.pipeline-toolbar__label__visible')
+    ).not.toBeInTheDocument();
+
+    jest.useRealTimers();
+  });
+
   it('hides tooltip on mouse leave', () => {
     const { container } = render(
       <IconButton


### PR DESCRIPTION
## Description

Resolves https://github.com/kedro-org/kedro-viz/issues/2282

## Development notes

**Root cause**

`IconButton` used a plain local variable to hold the tooltip's show-timeout id:

```jsx
let inTimeout; // recreated on every render
```

`showTooltip` (on `mouseEnter`) schedules a `setTimeout(..., 333)` that flips the tooltip visible, and `hideTooltip` (on `mouseLeave`) is supposed to `clearTimeout(inTimeout)`. Because `inTimeout` is re-created on every render, if the component re-renders during that 333 ms window (very common in Kedro-Viz - hover/layout/store updates re-render the connected toolbar), the new render's `hideTooltip` calls `clearTimeout(undefined)` and never cancels the pending timer. That orphaned timer then fires **after** the pointer has already left, and since no further `mouseleave` event is coming, the tooltip stays on screen indefinitely.

**Fix** (`src/components/ui/icon-button/icon-button.jsx`)

- Store the timeout id in a `useRef` so the handle is stable across re-renders and `hideTooltip` always cancels the right timer.
- Add an `isHovered` ref; the delayed callback bails out if the pointer left while it was pending.
- Add a `useEffect` cleanup that clears any pending timer on unmount (covers the "button unmounted / covered by a panel while hovered" variants too).

## QA notes

**Behaviour change:** toolbar tooltips now always disappear when the pointer leaves the icon. A tooltip can no longer appear (or remain) while the cursor is elsewhere.

**Automated tests:** added a regression test in `src/components/ui/icon-button/icon-button.test.jsx` - `does not show tooltip if the pointer leaves before the show delay elapses, even across a re-render` - which reproduces the exact race (mouseEnter -> re-render -> mouseLeave -> run timers) and asserts the tooltip stays hidden.

**Manual steps to reproduce the original bug:**

The bug needs a re-render of the `IconButton` to land inside the 333 ms show-delay while the cursor never leaves the button. Browser zoom fires a `resize` -> Redux `updateChartSize` -> the toolbar re-renders, and it's keyboard-only so the mouse stays parked.

1. To make the timing window comfortable, temporarily widen the delay in `src/components/ui/icon-button/icon-button.jsx` (line ~41): change `333` to `4000`.
2. `make run` (or your usual dev start) and open the app in the browser.
3. Move the mouse onto a left-hand toolbar icon - e.g. **Hide menu**, the theme toggle, or **Expand all pipelines**. Leave it there, don't move it.
4. Within the 4 s window, press **Cmd + `-`** (zoom out) once or twice. The cursor stays on the button.
5. Move the mouse well away - into the flowchart canvas - before the 4 s elapses.
6. Wait for the delay to elapse.

- **On `main`:** the tooltip label appears with the cursor nowhere near it and stays on screen indefinitely (until you hover + unhover that same button again).

<img width="1723" height="887" alt="Screenshot 2026-09-10 at 12 44 01 PM" src="https://github.com/user-attachments/assets/b6cf444b-4264-48e3-9248-6d529e51a7df" />


---

- **With this fix:** the tooltip never appears.

<img width="1708" height="891" alt="image" src="https://github.com/user-attachments/assets/24c4f34d-2683-4382-88a6-158c2368bf57" />



## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [x] Added new entries to the `RELEASE.md` file
- [x] Added tests to cover my changes
